### PR TITLE
Fix order summary for solicitor submit event

### DIFF
--- a/api/src/functionalTest/resources/responses/ccd-callback-submit-petition.json
+++ b/api/src/functionalTest/resources/responses/ccd-callback-submit-petition.json
@@ -4,7 +4,7 @@
     "D8PetitionerFirstName": "John",
     "D8PetitionerLastName": "Smith",
     "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
-    "solApplicationFeeOrderSummary": {
+    "SolApplicationFeeOrderSummary": {
       "PaymentTotal": "55000",
       "Fees": [
         {

--- a/api/src/integrationTest/resources/wiremock/responses/issue-fees-response.json
+++ b/api/src/integrationTest/resources/wiremock/responses/issue-fees-response.json
@@ -4,7 +4,7 @@
     "D8PetitionerFirstName": "test_first_name",
     "D8PetitionerLastName": "test_last_name",
     "D8PetitionerEmail": "test@test.com",
-    "solApplicationFeeOrderSummary": {
+    "SolApplicationFeeOrderSummary": {
       "PaymentTotal": "1000",
       "Fees": [
         {

--- a/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/controllers/SolicitorSubmitPetitionController.java
+++ b/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/controllers/SolicitorSubmitPetitionController.java
@@ -45,7 +45,7 @@ public class SolicitorSubmitPetitionController {
 
         OrderSummary orderSummary = solicitorSubmitPetitionService.getOrderSummary();
         CaseData caseData = callbackRequest.getCaseDetails().getCaseData();
-        caseData.setOrderSummary(orderSummary);
+        caseData.setSolApplicationFeeOrderSummary(orderSummary);
 
         return CcdCallbackResponse
             .builder()

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -16,7 +16,9 @@ spring:
     name: NFDIV Case API
   config:
     import: "optional:configtree:/mnt/secrets/nfdiv/"
-
+  jackson:
+    mapper:
+      accept_case_insensitive_enums: true
 azure:
   application-insights:
     instrumentation-key: ${APP_INSIGHTS_KEY:00000000-0000-0000-0000-000000000000}

--- a/api/src/test/java/uk/gov/hmcts/reform/divorce/caseapi/controllers/SolicitorSubmitPetitionControllerTest.java
+++ b/api/src/test/java/uk/gov/hmcts/reform/divorce/caseapi/controllers/SolicitorSubmitPetitionControllerTest.java
@@ -67,7 +67,7 @@ public class SolicitorSubmitPetitionControllerTest {
         OrderSummary orderSummary = getDefaultOrderSummary();
 
         CaseData updatedCaseDate = caseData();
-        updatedCaseDate.setOrderSummary(orderSummary);
+        updatedCaseDate.setSolApplicationFeeOrderSummary(orderSummary);
 
         when(solicitorSubmitPetitionService.getOrderSummary())
             .thenReturn(orderSummary);

--- a/ccd-definitions/src/main/java/uk/gov/hmcts/reform/divorce/ccd/model/CaseData.java
+++ b/ccd-definitions/src/main/java/uk/gov/hmcts/reform/divorce/ccd/model/CaseData.java
@@ -344,10 +344,6 @@ public class CaseData {
     )
     private String d8MarriageRespondentName;
 
-    @JsonProperty("solApplicationFeeOrderSummary")
-    @CCD(label = "Here are your order details")
-    private OrderSummary orderSummary;
-
     @JsonProperty("SolUrgentCase")
     @CCD(
         label = "Is this an urgent jurisdiction case?"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-542

### Change description ###

- Removed duplicate order summary from Case data.
- Added config to accept case sensitive enum as this is required when binding CCD callback request. 
- Tested on local docker and works fine.

<img width="1455" alt="image" src="https://user-images.githubusercontent.com/13840402/112302199-b7b2e300-8c92-11eb-9944-da5aaf17b5ff.png">

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
