### PR TITLE
Add petitioner solicitor roles

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -38,6 +38,8 @@ def secrets = [
                 secret('ccd-importer-username', 'CCD_DEFINITION_IMPORTER_USERNAME'),
                 secret('ccd-importer-password', 'CCD_DEFINITION_IMPORTER_PASSWORD'),
                 secret('idam-secret', 'OAUTH2_CLIENT_SECRET'),
+                secret('idam-solicitor-username', 'IDAM_SOLICITOR_USERNAME'),
+                secret('idam-solicitor-password', 'IDAM_SOLICITOR_PASSWORD'),
         ]
 ]
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -145,6 +145,8 @@ repositories {
 def versions = [
     assertJ           : '3.19.0',
     ccdConfigGenerator: '0.15.6',
+    ccdStoreClient    : '4.7.6',
+    idamClient        : '2.0.0',
     junit             : '5.7.1',
     junitPlatform     : '1.7.1',
     lombok            : '1.18.12',
@@ -196,6 +198,9 @@ dependencies {
     implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformsJavaLogging
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformsJavaLogging
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-spring', version: versions.reformsJavaLogging
+
+    implementation group: 'uk.gov.hmcts.reform', name: 'idam-client', version: versions.idamClient
+    implementation (group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: versions.ccdStoreClient)
 
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.14.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.14.1'

--- a/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/FunctionalTestSuite.java
+++ b/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/FunctionalTestSuite.java
@@ -40,7 +40,7 @@ abstract class FunctionalTestSuite {
     @Value("${idam.solicitor.username}")
     protected String solicitorUsername;
 
-    @Value("${idam.solicitor.password")
+    @Value("${idam.solicitor.password}")
     protected String solicitorPassword;
 
     @Autowired
@@ -72,6 +72,7 @@ abstract class FunctionalTestSuite {
     }
 
     protected String generateIdamTokenForSolicitor() {
+        System.out.println("solicitorPassword"+solicitorPassword);
         return idamClient.getAccessToken(solicitorUsername,solicitorPassword);
     }
 }

--- a/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/FunctionalTestSuite.java
+++ b/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/FunctionalTestSuite.java
@@ -6,6 +6,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.ccd.client.model.Event;
+import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.divorce.ccd.model.CaseData;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 
@@ -16,6 +21,9 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.divorce.caseapi.enums.NotificationConstants.SAVE_AND_CLOSE;
 import static uk.gov.hmcts.reform.divorce.caseapi.enums.NotificationConstants.SUBMITTED_WEBHOOK;
+import static uk.gov.hmcts.reform.divorce.ccd.ccdcase.NoFaultDivorce.CASE_TYPE;
+import static uk.gov.hmcts.reform.divorce.ccd.ccdcase.NoFaultDivorce.JURISDICTION;
+import static uk.gov.hmcts.reform.divorce.ccd.event.solicitor.SolicitorCreate.SOLICITOR_CREATE;
 import static uk.gov.hmcts.reform.divorce.ccd.model.enums.DivorceOrDissolution.DIVORCE;
 
 @TestPropertySource("classpath:application.yaml")
@@ -46,6 +54,9 @@ abstract class FunctionalTestSuite {
     @Autowired
     private IdamClient idamClient;
 
+    @Autowired
+    private CoreCaseDataApi coreCaseDataApi;
+
     protected CaseData caseData() {
         CaseData caseData = new CaseData();
         caseData.setD8PetitionerFirstName(TEST_FIRST_NAME);
@@ -73,5 +84,62 @@ abstract class FunctionalTestSuite {
 
     protected String generateIdamTokenForSolicitor() {
         return idamClient.getAccessToken(solicitorUsername, solicitorPassword);
+    }
+
+
+    protected CaseDetails createCaseInCcd() {
+        String solicitorToken = generateIdamTokenForSolicitor();
+        //Temporarily using cms s2s till ccd whitelists case api
+        String s2sTokenForCms = generateServiceAuthTokenFor("nfdiv_cms");
+        String solicitorUserId = idamClient.getUserDetails(solicitorToken).getId();
+        StartEventResponse startEventResponse = startEventForCreateCase(solicitorToken, s2sTokenForCms, solicitorUserId);
+
+        CaseDataContent caseDataContent = CaseDataContent.builder()
+            .eventToken(startEventResponse.getToken())
+            .event(Event.builder()
+                .id(SOLICITOR_CREATE)
+                .summary("Create draft case")
+                .description("Create draft case for functional tests")
+                .build())
+            .data(Map.of(
+                "PetitionerSolicitorName", "functional test"
+            ))
+            .build();
+
+        return submitNewCase(caseDataContent, solicitorToken, s2sTokenForCms, solicitorUserId);
+    }
+
+    private StartEventResponse startEventForCreateCase(
+        String solicitorToken,
+        String s2sToken,
+        String solicitorUserId
+    ) {
+        // not including in try catch to fail fast the method
+        return coreCaseDataApi.startForCaseworker(
+            solicitorToken,
+            s2sToken,
+            solicitorUserId,
+            JURISDICTION,
+            CASE_TYPE,
+            SOLICITOR_CREATE
+        );
+    }
+
+    private CaseDetails submitNewCase(
+        CaseDataContent caseDataContent,
+        String solicitorToken,
+        String s2sToken,
+        String solicitorUserId
+    ) {
+        // not including in try catch to fast fail the method
+        return coreCaseDataApi.submitForCaseworker(
+            solicitorToken,
+            s2sToken,
+            solicitorUserId,
+            JURISDICTION,
+            CASE_TYPE,
+            true,
+            caseDataContent
+        );
     }
 }

--- a/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/FunctionalTestSuite.java
+++ b/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/FunctionalTestSuite.java
@@ -72,7 +72,6 @@ abstract class FunctionalTestSuite {
     }
 
     protected String generateIdamTokenForSolicitor() {
-        System.out.println("solicitorPassword"+solicitorPassword);
-        return idamClient.getAccessToken(solicitorUsername,solicitorPassword);
+        return idamClient.getAccessToken(solicitorUsername, solicitorPassword);
     }
 }

--- a/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/FunctionalTestSuite.java
+++ b/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/FunctionalTestSuite.java
@@ -3,9 +3,11 @@ package uk.gov.hmcts.reform.divorce.caseapi;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.TestPropertySource;
 import uk.gov.hmcts.reform.divorce.ccd.model.CaseData;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
 
 import java.util.Map;
 
@@ -35,6 +37,15 @@ abstract class FunctionalTestSuite {
     @Value("${s2s.name}")
     protected String s2sName;
 
+    @Value("${idam.solicitor.username}")
+    protected String solicitorUsername;
+
+    @Value("${idam.solicitor.password")
+    protected String solicitorPassword;
+
+    @Autowired
+    private IdamClient idamClient;
+
     protected CaseData caseData() {
         CaseData caseData = new CaseData();
         caseData.setD8PetitionerFirstName(TEST_FIRST_NAME);
@@ -58,5 +69,9 @@ abstract class FunctionalTestSuite {
         assertThat(response.getStatusCode()).isEqualTo(200);
 
         return "Bearer " + response.getBody().print();
+    }
+
+    protected String generateIdamTokenForSolicitor() {
+        return idamClient.getAccessToken(solicitorUsername,solicitorPassword);
     }
 }

--- a/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/SolicitorSubmitPetitionTest.java
+++ b/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/SolicitorSubmitPetitionTest.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.util.ResourceUtils;
 import uk.gov.hmcts.reform.divorce.caseapi.model.CaseDetails;
 import uk.gov.hmcts.reform.divorce.caseapi.model.CcdCallbackRequest;
@@ -37,6 +38,7 @@ public class SolicitorSubmitPetitionTest extends FunctionalTestSuite {
             .baseUri(testUrl)
             .header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
             .header(SERVICE_AUTHORIZATION, generateServiceAuthTokenFor(s2sName))
+            .header(HttpHeaders.AUTHORIZATION,generateIdamTokenForSolicitor())
             .body(
                 CcdCallbackRequest
                     .builder()

--- a/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/SolicitorSubmitPetitionTest.java
+++ b/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/SolicitorSubmitPetitionTest.java
@@ -31,20 +31,22 @@ public class SolicitorSubmitPetitionTest extends FunctionalTestSuite {
     );
 
     @Test
-    public void shouldUpdateCaseDataWithOrderSummaryWhenIssueFeeIsSuccessfullyRetrieved() throws Exception {
+    public void shouldUpdateCaseDataWithOrderSummaryAndAddSolCaseRolesWhenIssueFeeIsSuccessfullyRetrieved()
+        throws Exception {
         Response response = RestAssured
             .given()
             .relaxedHTTPSValidation()
             .baseUri(testUrl)
             .header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
             .header(SERVICE_AUTHORIZATION, generateServiceAuthTokenFor(s2sName))
-            .header(HttpHeaders.AUTHORIZATION,generateIdamTokenForSolicitor())
+            .header(HttpHeaders.AUTHORIZATION, generateIdamTokenForSolicitor())
             .body(
                 CcdCallbackRequest
                     .builder()
                     .caseDetails(
                         CaseDetails
                             .builder()
+                            .caseId("1616591401473378")
                             .caseData(caseData())
                             .build()
                     )

--- a/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/SolicitorSubmitPetitionTest.java
+++ b/api/src/functionalTest/java/uk/gov/hmcts/reform/divorce/caseapi/SolicitorSubmitPetitionTest.java
@@ -46,7 +46,7 @@ public class SolicitorSubmitPetitionTest extends FunctionalTestSuite {
                     .caseDetails(
                         CaseDetails
                             .builder()
-                            .caseId("1616591401473378")
+                            .caseId(String.valueOf(createCaseInCcd().getId()))
                             .caseData(caseData())
                             .build()
                     )

--- a/api/src/functionalTest/resources/application.yaml
+++ b/api/src/functionalTest/resources/application.yaml
@@ -21,6 +21,9 @@ s2s:
 idam:
   s2s-auth:
     url: ${TEST_S2S_URL:http://rpe-service-auth-provider-aat.service.core-compute-aat.internal}
+  solicitor:
+    username: ${IDAM_SOLICITOR_USERNAME}
+    password: ${IDAM_SOLICITOR_PASSWORD}
 
 s2s-authorised:
   services: ccd_data

--- a/api/src/functionalTest/resources/application.yaml
+++ b/api/src/functionalTest/resources/application.yaml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: NFDIV Case API Functional Tests
+
+  main:
+    allow-bean-definition-overriding: true
 # because functional tests load up SpringBootTest
 azure:
   application-insights:
@@ -19,11 +22,22 @@ s2s:
  name: ccd_data
 
 idam:
+  api:
+    url: ${IDAM_API_BASEURL:https://idam-api.aat.platform.hmcts.net}
   s2s-auth:
     url: ${TEST_S2S_URL:http://rpe-service-auth-provider-aat.service.core-compute-aat.internal}
+    secret: dummy
+    microservice: divorce
   solicitor:
-    username: ${IDAM_SOLICITOR_USERNAME}
-    password: ${IDAM_SOLICITOR_PASSWORD}
+    username: ${IDAM_SOLICITOR_USERNAME:dummysolicitor@test.com}
+    password: ${IDAM_SOLICITOR_PASSWORD:dummy}
+  caseworker:
+    username: dummy@test.com
+    password: dummy
+  client:
+    id: 'divorce'
+    secret: ${OAUTH2_CLIENT_SECRET:dummy}
+    redirect_uri: ${IDAM_API_REDIRECT_URL:http://localhost:3001/oauth2/callback}
 
 s2s-authorised:
   services: ccd_data
@@ -31,3 +45,7 @@ s2s-authorised:
 fee:
   api:
     baseUrl: ${FEE_API_URL:http://fees-register-api-aat.service.core-compute-aat.internal}
+
+core_case_data:
+  api:
+    url: ${CASE_DATA_STORE_BASEURL:http://ccd-data-store-api-aat.service.core-compute-aat.internal}

--- a/api/src/integrationTest/java/uk/gov/hmcts/reform/divorce/caseapi/controllers/SolicitorSubmitPetitionControllerTest.java
+++ b/api/src/integrationTest/java/uk/gov/hmcts/reform/divorce/caseapi/controllers/SolicitorSubmitPetitionControllerTest.java
@@ -1,52 +1,82 @@
 package uk.gov.hmcts.reform.divorce.caseapi.controllers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import feign.FeignException;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.util.ResourceUtils;
-import uk.gov.hmcts.reform.divorce.caseapi.clients.FeesAndPaymentsClient;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.divorce.caseapi.TestConstants;
 import uk.gov.hmcts.reform.divorce.caseapi.config.WebMvcConfig;
 import uk.gov.hmcts.reform.divorce.caseapi.config.interceptors.RequestInterceptor;
+import uk.gov.hmcts.reform.divorce.caseapi.service.CcdAccessService;
 import uk.gov.hmcts.reform.divorce.caseapi.service.SolicitorSubmitPetitionService;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.net.URLEncoder.encode;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.AUTH_HEADER_VALUE;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.CASEWORKER_USER_ID;
 import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.SERVICE_AUTHORIZATION;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.SOLICITOR_USER_ID;
 import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.SUBMIT_PETITION_API_URL;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_AUTHORIZATION_TOKEN;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_USER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.caseapi.caseapi.util.TestDataHelper.callbackRequest;
 import static uk.gov.hmcts.reform.divorce.caseapi.caseapi.util.TestDataHelper.getFeeResponse;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureWireMock(port = 0)
 @AutoConfigureMockMvc
+@ContextConfiguration(initializers = {SolicitorSubmitPetitionControllerTest.PropertiesInitializer.class})
 public class SolicitorSubmitPetitionControllerTest {
+
+    private static final String CASE_WORKER_TOKEN = "test-caseworker-token";
+
+    private static final String SOLICITOR_ROLE = "caseworker-divorce-solicitor";
+
+    private static final String CASEWORKER_ROLE = "caseworker-divorce";
+
+    private static final String SERVICE_AUTH_TOKEN = "test-service-auth-token";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -57,7 +87,7 @@ public class SolicitorSubmitPetitionControllerTest {
     private ObjectMapper objectMapper;
 
     @Autowired
-    private FeesAndPaymentsClient feesAndPaymentsClient;
+    private CcdAccessService ccdAccessService;
 
     @MockBean
     private RequestInterceptor requestInterceptor;
@@ -65,31 +95,53 @@ public class SolicitorSubmitPetitionControllerTest {
     @MockBean
     private WebMvcConfig webMvcConfig;
 
-    @BeforeEach
-    public void setUp() {
-        WireMock.reset();
+    @MockBean
+    private AuthTokenGenerator serviceTokenGenerator;
+
+    private static final WireMockServer IDAM_SERVER = new WireMockServer(wireMockConfig().dynamicPort());
+
+    private static final WireMockServer CASE_DATA_SERVER = new WireMockServer(wireMockConfig().dynamicPort());
+
+    private static final WireMockServer FEES_SERVER = new WireMockServer(wireMockConfig().dynamicPort());
+
+    @BeforeAll
+    static void setUp() {
+        IDAM_SERVER.start();
+        CASE_DATA_SERVER.start();
+        FEES_SERVER.start();
     }
+
+    @AfterAll
+    static void tearDown() {
+        IDAM_SERVER.stop();
+        IDAM_SERVER.resetAll();
+
+        CASE_DATA_SERVER.stop();
+        CASE_DATA_SERVER.resetAll();
+
+        FEES_SERVER.stop();
+        FEES_SERVER.resetAll();
+    }
+
 
     @Test
     public void givenValidCaseDataWhenCallbackIsInvokedThenOrderSummaryIsSet() throws Exception {
-        stubFor(
-            get(
-                urlEqualTo(
-                    "/fees-register/fees/lookup"
-                        + "?channel=default&event=issue&jurisdiction1=family&jurisdiction2=family%20court&service=divorce"
-                )
-            ).willReturn(
-                aResponse()
-                    .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .withBody(
-                        objectMapper.writeValueAsString(getFeeResponse())
-                    )
-            )
-        );
+        stubForFeesLookup();
 
-        mockMvc.perform(post(SUBMIT_PETITION_API_URL)
+        when(serviceTokenGenerator.generate()).thenReturn(SERVICE_AUTH_TOKEN);
+
+        stubForIdamDetails(TEST_AUTHORIZATION_TOKEN, SOLICITOR_USER_ID, SOLICITOR_ROLE);
+
+        stubForIdamDetails(CASE_WORKER_TOKEN, CASEWORKER_USER_ID, CASEWORKER_ROLE);
+
+        stubForIdamToken();
+
+        stubForCcdCaseRoles();
+
+        mockMvc.perform(MockMvcRequestBuilders.post(SUBMIT_PETITION_API_URL)
             .contentType(APPLICATION_JSON)
             .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
+            .header(TestConstants.AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
             .content(objectMapper.writeValueAsString(callbackRequest()))
             .accept(APPLICATION_JSON))
             .andExpect(
@@ -103,23 +155,12 @@ public class SolicitorSubmitPetitionControllerTest {
     @Test
     public void givenFeeEventIsNotAvailableWhenCallbackIsInvokedThenReturn404FeeEventNotFound()
         throws Exception {
-        stubFor(
-            get(
-                urlEqualTo(
-                    "/fees-register/fees/lookup"
-                        + "?channel=default&event=issue&jurisdiction1=family&jurisdiction2=family%20court&service=divorce"
-                )
-            ).willReturn(
-                aResponse()
-                    .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                    .withStatus(HttpStatus.NOT_FOUND.value())
-                    .withStatusMessage("Fee event not found")
-            )
-        );
+        stubForFeesNotFound();
 
-        mockMvc.perform(post(SUBMIT_PETITION_API_URL)
+        mockMvc.perform(MockMvcRequestBuilders.post(SUBMIT_PETITION_API_URL)
             .contentType(APPLICATION_JSON)
             .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
+            .header(TestConstants.AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
             .content(objectMapper.writeValueAsString(callbackRequest()))
             .accept(APPLICATION_JSON))
             .andExpect(
@@ -134,10 +175,92 @@ public class SolicitorSubmitPetitionControllerTest {
             );
     }
 
+    private void stubForCcdCaseRoles() {
+        CASE_DATA_SERVER.stubFor(put(urlMatching("/cases/[0-9]+/users/[0-9]+"))
+            .withHeader(AUTHORIZATION, new EqualToPattern("Bearer " + CASE_WORKER_TOKEN))
+            .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern(SERVICE_AUTH_TOKEN))
+            .withRequestBody(new EqualToJsonPattern(
+                "{\"user_id\" : \"1\", \"case_roles\":[\"[CREATOR]\",\"[PETSOLICITOR]\"]}",
+                true,
+                true)
+            )
+            .willReturn(aResponse().withStatus(200))
+        );
+    }
+
+    private void stubForIdamToken() throws UnsupportedEncodingException {
+        IDAM_SERVER.stubFor(post("/o/token")
+            .withRequestBody(new EqualToPattern(tokenBody()))
+            .willReturn(aResponse()
+                .withStatus(HttpStatus.OK.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .withBody("{ \"access_token\" : \"" + CASE_WORKER_TOKEN + "\" }")))
+        ;
+    }
+
+    private void stubForIdamDetails(String testAuthorizationToken, String solicitorUserId, String solicitorRole) {
+        IDAM_SERVER.stubFor(get("/details")
+            .withHeader(AUTHORIZATION, new EqualToPattern("Bearer " + testAuthorizationToken))
+            .willReturn(aResponse()
+                .withStatus(HttpStatus.OK.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .withBody(getUserDetailsForRole(solicitorUserId, solicitorRole)))
+        );
+    }
+
+    private void stubForFeesLookup() throws JsonProcessingException {
+        FEES_SERVER.stubFor(get("/fees-register/fees/lookup"
+                + "?channel=default&event=issue&jurisdiction1=family&jurisdiction2=family+court&service=divorce"
+            ).willReturn(aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .withBody(objectMapper.writeValueAsString(getFeeResponse())))
+        );
+    }
+    
+    private void stubForFeesNotFound() {
+        FEES_SERVER.stubFor(get(urlEqualTo(
+            "/fees-register/fees/lookup"
+                + "?channel=default&event=issue&jurisdiction1=family&jurisdiction2=family+court&service=divorce"
+            )
+            ).willReturn(aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .withStatus(HttpStatus.NOT_FOUND.value())
+                .withStatusMessage("Fee event not found")
+            )
+        );
+    }
+
     private String expectedCcdCallbackResponse() throws IOException {
         File issueFeesResponseJsonFile = ResourceUtils.getFile("classpath:wiremock/responses/issue-fees-response.json");
 
         return new String(Files.readAllBytes(issueFeesResponseJsonFile.toPath()));
+    }
+
+    private String getUserDetailsForRole(String userId, String role) {
+        return "{\"id\":\"" + userId
+            + "\",\"email\":\"" + TEST_USER_EMAIL
+            + "\",\"forename\":\"forename\",\"surname\":\"Surname\",\"roles\":[\"" + role + "\"]}";
+    }
+
+    private String tokenBody() throws UnsupportedEncodingException {
+        return "password=dummy"
+            + "&grant_type=password"
+            + "&scope=" + encode("openid profile roles", UTF_8.name())
+            + "&client_secret=BBBBBBBBBBBBBBBB"
+            + "&redirect_uri=" + encode("http://localhost:3001/oauth2/callback", UTF_8.name())
+            + "&client_id=divorce"
+            + "&username=" + encode("dummycaseworker@test.com", UTF_8.name());
+    }
+
+    static class PropertiesInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+        @Override
+        public void initialize(ConfigurableApplicationContext applicationContext) {
+            TestPropertyValues.of(
+                "idam.api.url=" + "http://localhost:" + IDAM_SERVER.port(),
+                "core_case_data.api.url=" + "http://localhost:" + CASE_DATA_SERVER.port(),
+                "fee.api.baseUrl=" + "http://localhost:" + FEES_SERVER.port()
+            ).applyTo(applicationContext.getEnvironment());
+        }
     }
 }
 

--- a/api/src/integrationTest/resources/application.yaml
+++ b/api/src/integrationTest/resources/application.yaml
@@ -20,13 +20,33 @@ uk:
 idam:
   s2s-auth:
     url: http://rpe-service-auth-provider-aat.service.core-compute-aat.internal
+    secret: AAAAAAAAAAAAAAAA
+    microservice: nfdiv_case_api
+  api:
+    url: http://localhost:5000
+  caseworker:
+    username: dummycaseworker@test.com
+    password: dummy
+  client:
+    id: 'divorce'
+    secret: BBBBBBBBBBBBBBBB
+    redirect_uri: http://localhost:3001/oauth2/callback
 
 s2s-authorised:
   services: ccd_data
 
 fee:
   api:
-    baseUrl: http://localhost:${wiremock.server.port}
+    baseUrl: http://localhost:4010
 
 s2s:
   stub: true
+
+core_case_data:
+  api:
+    url: http://localhost:4012
+
+spring:
+  main:
+    allow-bean-definition-overriding: true
+

--- a/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/CaseApiApplication.java
+++ b/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/CaseApiApplication.java
@@ -3,9 +3,20 @@ package uk.gov.hmcts.reform.divorce.caseapi;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
+import uk.gov.hmcts.reform.ccd.client.CaseUserApi;
+import uk.gov.hmcts.reform.divorce.caseapi.clients.FeesAndPaymentsClient;
+import uk.gov.hmcts.reform.idam.client.IdamApi;
 
 @SpringBootApplication
-@EnableFeignClients(basePackages = "uk.gov.hmcts.reform.divorce.caseapi.clients")
+@EnableFeignClients(
+    clients = {
+        IdamApi.class,
+        ServiceAuthorisationApi.class,
+        CaseUserApi.class,
+        FeesAndPaymentsClient.class
+    }
+)
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 public class CaseApiApplication {
 

--- a/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/config/AuthConfiguration.java
+++ b/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/config/AuthConfiguration.java
@@ -1,8 +1,11 @@
 package uk.gov.hmcts.reform.divorce.caseapi.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGeneratorFactory;
 import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
 import uk.gov.hmcts.reform.authorisation.validators.ServiceAuthTokenValidator;
 
@@ -11,5 +14,14 @@ public class AuthConfiguration {
     @Bean
     public AuthTokenValidator tokenValidator(ServiceAuthorisationApi s2sApi) {
         return new ServiceAuthTokenValidator(s2sApi);
+    }
+
+    @Bean
+    public AuthTokenGenerator serviceAuthTokenGenerator(
+        @Value("${idam.s2s-auth.secret}") final String secret,
+        @Value("${idam.s2s-auth.microservice}") final String microService,
+        final ServiceAuthorisationApi serviceAuthorisationApi
+    ) {
+        return AuthTokenGeneratorFactory.createDefaultGenerator(secret, microService, serviceAuthorisationApi);
     }
 }

--- a/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/enums/NotificationConstants.java
+++ b/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/enums/NotificationConstants.java
@@ -39,6 +39,11 @@ public final class NotificationConstants {
     public static final String FAMILY_COURT = "family court";
     public static final String DIVORCE = "divorce";
 
+    public static final String CREATOR_ROLE = "[CREATOR]";
+    public static final String PET_SOL_ROLE = "[PETSOLICITOR]";
+
+    public static final String BEARER_PREFIX = "Bearer" + " ";
+
     private NotificationConstants() {
     }
 }

--- a/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/service/CcdAccessService.java
+++ b/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/service/CcdAccessService.java
@@ -10,11 +10,12 @@ import uk.gov.hmcts.reform.idam.client.models.User;
 
 import java.util.Set;
 
+import static uk.gov.hmcts.reform.divorce.caseapi.enums.NotificationConstants.CREATOR_ROLE;
+import static uk.gov.hmcts.reform.divorce.caseapi.enums.NotificationConstants.PET_SOL_ROLE;
+
 @Service
 @Slf4j
 public class CcdAccessService {
-    public static final String CREATOR_ROLE = "[CREATOR]";
-    public static final String PET_SOL_ROLE = "[PETSOLICITOR]";
     @Autowired
     private CaseUserApi caseUserApi;
 

--- a/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/service/CcdAccessService.java
+++ b/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/service/CcdAccessService.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.divorce.caseapi.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.ccd.client.CaseUserApi;
+import uk.gov.hmcts.reform.ccd.client.model.CaseUser;
+import uk.gov.hmcts.reform.idam.client.models.User;
+
+import java.util.Set;
+
+@Service
+@Slf4j
+public class CcdAccessService {
+    public static final String CREATOR_ROLE = "[CREATOR]";
+    public static final String PET_SOL_ROLE = "[PETSOLICITOR]";
+    @Autowired
+    private CaseUserApi caseUserApi;
+
+    @Autowired
+    private IdamService idamService;
+
+    @Autowired
+    private AuthTokenGenerator authTokenGenerator;
+
+    public void addPetitionerSolicitorRole(String solicitorIdamToken, String caseId) {
+        User solicitorUser = idamService.retrieveUser(solicitorIdamToken);
+        User caseworkerUser = idamService.retrieveCaseWorkerDetails();
+
+        Set<String> caseRoles = Set.of(CREATOR_ROLE, PET_SOL_ROLE);
+
+        String solicitorUserId = solicitorUser.getUserDetails().getId();
+
+        log.info("Adding roles {} to case Id {} and user Id {}",
+            caseRoles,
+            caseId,
+            solicitorUserId
+        );
+
+        caseUserApi.updateCaseRolesForUser(
+            caseworkerUser.getAuthToken(),
+            authTokenGenerator.generate(),
+            caseId,
+            solicitorUserId,
+            new CaseUser(solicitorUserId, caseRoles)
+        );
+
+        log.info("Successfully added petitioner solicitor roles to case Id {} ", caseId);
+    }
+}

--- a/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/service/IdamService.java
+++ b/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/service/IdamService.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.divorce.caseapi.service;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.User;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+
+@Service
+public class IdamService {
+    private static final String BEARER = "Bearer" + " ";
+
+    @Value("${idam.caseworker.username}")
+    private String caseworkerUserName;
+
+    @Value("${idam.caseworker.password}")
+    private String caseworkerPassword;
+
+    @Autowired
+    private IdamClient idamClient;
+
+    public User retrieveUser(String authorisation) {
+        final String bearerToken = getBearerToken(authorisation);
+        final UserDetails userDetails = idamClient.getUserDetails(bearerToken);
+
+        return new User(bearerToken, userDetails);
+    }
+
+    public User retrieveCaseWorkerDetails() {
+        return retrieveUser(getIdamOauth2Token(caseworkerUserName, caseworkerPassword));
+    }
+
+    private String getIdamOauth2Token(String username, String password) {
+        return idamClient.getAccessToken(username, password);
+    }
+
+    private String getBearerToken(String token) {
+        if (StringUtils.isBlank(token)) {
+            return token;
+        }
+        return token.startsWith(BEARER) ? token : BEARER.concat(token);
+    }
+}

--- a/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/service/IdamService.java
+++ b/api/src/main/java/uk/gov/hmcts/reform/divorce/caseapi/service/IdamService.java
@@ -8,10 +8,10 @@ import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.User;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
+import static uk.gov.hmcts.reform.divorce.caseapi.enums.NotificationConstants.BEARER_PREFIX;
+
 @Service
 public class IdamService {
-    private static final String BEARER = "Bearer" + " ";
-
     @Value("${idam.caseworker.username}")
     private String caseworkerUserName;
 
@@ -40,6 +40,6 @@ public class IdamService {
         if (StringUtils.isBlank(token)) {
             return token;
         }
-        return token.startsWith(BEARER) ? token : BEARER.concat(token);
+        return token.startsWith(BEARER_PREFIX) ? token : BEARER_PREFIX.concat(token);
     }
 }

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -51,7 +51,7 @@ idam:
   s2s-auth:
     url: ${S2S_URL:http://rpe-service-auth-provider-aat.service.core-compute-aat.internal}
     secret: ${S2S_SECRET:AAAAAAAAAAAAAAAA}
-    microservice: nfdiv_case_api
+    microservice: nfdiv_cms # Temporarily use cms secret till ccd whitelists case api
   api:
     url: ${IDAM_API_BASEURL:http://localhost:5000}
   caseworker:

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -49,7 +49,14 @@ idam:
   s2s-auth:
     url: ${S2S_URL:http://rpe-service-auth-provider-aat.service.core-compute-aat.internal}
     secret: ${S2S_SECRET:AAAAAAAAAAAAAAAA}
-
+  api:
+    url: ${IDAM_API_BASEURL:http://localhost:5000}
+  client:
+    id: 'divorce'
+    secret: ${IDAM_CLIENT_SECRET:123456}
+    redirect_uri: ${IDAM_API_REDIRECT_URL:http://localhost:3001/oauth2/callback}
+    cache:
+      refresh-before-expire-in-sec: 300
 fee:
   api:
     baseUrl: ${FEE_API_URL:http://fees-register-api-aat.service.core-compute-aat.internal}

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -19,6 +19,8 @@ spring:
   jackson:
     mapper:
       accept_case_insensitive_enums: true
+  main:
+    allow-bean-definition-overriding: true
 azure:
   application-insights:
     instrumentation-key: ${APP_INSIGHTS_KEY:00000000-0000-0000-0000-000000000000}
@@ -49,17 +51,25 @@ idam:
   s2s-auth:
     url: ${S2S_URL:http://rpe-service-auth-provider-aat.service.core-compute-aat.internal}
     secret: ${S2S_SECRET:AAAAAAAAAAAAAAAA}
+    microservice: nfdiv_case_api
   api:
     url: ${IDAM_API_BASEURL:http://localhost:5000}
+  caseworker:
+    username: ${IDAM_CASEWORKER_USERNAME:dummycaseworker@test.com}
+    password: ${IDAM_CASEWORKER_PASSWORD:dummy}
   client:
     id: 'divorce'
     secret: ${IDAM_CLIENT_SECRET:123456}
     redirect_uri: ${IDAM_API_REDIRECT_URL:http://localhost:3001/oauth2/callback}
-    cache:
-      refresh-before-expire-in-sec: 300
+
 fee:
   api:
     baseUrl: ${FEE_API_URL:http://fees-register-api-aat.service.core-compute-aat.internal}
 
 s2s:
   stub: false
+
+core_case_data:
+  api:
+    url: ${CASE_DATA_STORE_BASEURL:http://ccd-data-store-api-aat.service.core-compute-aat.internal}
+

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -48,6 +48,7 @@ s2s-authorised:
 idam:
   s2s-auth:
     url: ${S2S_URL:http://rpe-service-auth-provider-aat.service.core-compute-aat.internal}
+    secret: ${S2S_SECRET:AAAAAAAAAAAAAAAA}
 
 fee:
   api:

--- a/api/src/test/java/uk/gov/hmcts/reform/divorce/caseapi/TestConstants.java
+++ b/api/src/test/java/uk/gov/hmcts/reform/divorce/caseapi/TestConstants.java
@@ -11,10 +11,24 @@ public final class TestConstants {
     public static final String AUTH_HEADER_VALUE = "auth-header-value";
     public static final String INVALID_AUTH_TOKEN = "invalid_token";
     public static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String TEST_AUTHORIZATION_TOKEN = "test-auth";
 
     public static final String CCD_DATA = "ccd_data";
     public static final String FEE_CODE = "FEECODE1";
     public static final String ISSUE_FEE = "Issue Fee";
+
+    public static final String PET_SOL_AUTH_TOKEN = "Bearer PetSolAuthToken";
+    public static final String CASEWORKER_AUTH_TOKEN = "Bearer CaseWorkerAuthToken";
+    public static final String SOLICITOR_USER_ID = "1";
+    public static final String CASEWORKER_USER_ID = "2";
+
+    public static final String TEST_SOL_USER_EMAIL = "testsol@test.com";
+    public static final String TEST_CASEWORKER_USER_EMAIL = "testcw@test.com";
+    public static final String TEST_CASEWORKER_USER_PASSWORD = "testpassword";
+
+    public static final String TEST_CASE_ID = "1616591401473378";
+    public static final String TEST_SERVICE_AUTH_TOKEN = "Bearer TestServiceAuth";
 
     private TestConstants() {
     }

--- a/api/src/test/java/uk/gov/hmcts/reform/divorce/caseapi/caseapi/util/TestDataHelper.java
+++ b/api/src/test/java/uk/gov/hmcts/reform/divorce/caseapi/caseapi/util/TestDataHelper.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.divorce.caseapi.caseapi.util;
 
+import feign.FeignException;
+import feign.Request;
+import feign.Response;
 import uk.gov.hmcts.ccd.sdk.type.Fee;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.ccd.sdk.type.OrderSummary;
@@ -9,10 +12,17 @@ import uk.gov.hmcts.reform.divorce.caseapi.model.payments.FeeResponse;
 import uk.gov.hmcts.reform.divorce.ccd.model.CaseData;
 import uk.gov.hmcts.reform.divorce.ccd.model.enums.DivorceOrDissolution;
 
+import java.util.Collections;
+import java.util.Map;
+
+import static feign.Request.HttpMethod.GET;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static uk.gov.hmcts.ccd.sdk.type.Fee.getValueInPence;
 import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.FEE_CODE;
 import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.ISSUE_FEE;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_FIRST_NAME;
 import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_LAST_NAME;
 import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_USER_EMAIL;
@@ -39,6 +49,7 @@ public class TestDataHelper {
                 CaseDetails
                     .builder()
                     .caseData(caseData())
+                    .caseId(TEST_CASE_ID)
                     .build()
             )
             .build();
@@ -78,5 +89,20 @@ public class TestDataHelper {
 
     public static ListValue<Fee> getDefaultFeeItem() {
         return getFeeItem(10.50, FEE_CODE, "Issue Petition Fee", 1);
+    }
+
+    public static FeignException feignException(int status, String reason) {
+        byte[] emptyBody = {};
+        Request request = Request.create(GET, EMPTY, Map.of(), emptyBody, UTF_8, null);
+
+        return FeignException.errorStatus(
+            "idamRequestFailed",
+            Response.builder()
+                .request(request)
+                .status(status)
+                .headers(Collections.emptyMap())
+                .reason(reason)
+                .build()
+        );
     }
 }

--- a/api/src/test/java/uk/gov/hmcts/reform/divorce/caseapi/controllers/SolicitorSubmitPetitionControllerTest.java
+++ b/api/src/test/java/uk/gov/hmcts/reform/divorce/caseapi/controllers/SolicitorSubmitPetitionControllerTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.ccd.sdk.type.OrderSummary;
 import uk.gov.hmcts.reform.divorce.caseapi.config.WebMvcConfig;
 import uk.gov.hmcts.reform.divorce.caseapi.config.interceptors.RequestInterceptor;
 import uk.gov.hmcts.reform.divorce.caseapi.model.CcdCallbackResponse;
+import uk.gov.hmcts.reform.divorce.caseapi.service.CcdAccessService;
 import uk.gov.hmcts.reform.divorce.caseapi.service.SolicitorSubmitPetitionService;
 import uk.gov.hmcts.reform.divorce.ccd.model.CaseData;
 
@@ -28,6 +29,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -36,9 +39,11 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.AUTH_HEADER_VALUE;
 import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.SUBMIT_PETITION_API_URL;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_AUTHORIZATION_TOKEN;
 import static uk.gov.hmcts.reform.divorce.caseapi.caseapi.util.TestDataHelper.callbackRequest;
 import static uk.gov.hmcts.reform.divorce.caseapi.caseapi.util.TestDataHelper.caseData;
 import static uk.gov.hmcts.reform.divorce.caseapi.caseapi.util.TestDataHelper.getDefaultOrderSummary;
@@ -62,19 +67,30 @@ public class SolicitorSubmitPetitionControllerTest {
     @MockBean
     private WebMvcConfig webMvcConfig;
 
+    @MockBean
+    private CcdAccessService ccdAccessService;
+
     @Test
-    public void givenValidCaseDataWhenCallbackIsInvokedThenOrderSummaryIsSet() throws Exception {
+    public void givenValidCaseDataWhenCallbackIsInvokedThenOrderSummaryAndSolicitorRolesAreSet()
+        throws Exception {
         OrderSummary orderSummary = getDefaultOrderSummary();
 
-        CaseData updatedCaseDate = caseData();
-        updatedCaseDate.setSolApplicationFeeOrderSummary(orderSummary);
+        CaseData updatedCaseData = caseData();
+        updatedCaseData.setSolApplicationFeeOrderSummary(orderSummary);
 
         when(solicitorSubmitPetitionService.getOrderSummary())
             .thenReturn(orderSummary);
 
+        doNothing()
+            .when(ccdAccessService)
+            .addPetitionerSolicitorRole(
+                anyString(),
+                anyString()
+            );
+
         CcdCallbackResponse ccdCallbackResponse = CcdCallbackResponse
             .builder()
-            .data(objectMapper.convertValue(updatedCaseDate, new TypeReference<Map<String, Object>>() {
+            .data(objectMapper.convertValue(updatedCaseData, new TypeReference<Map<String, Object>>() {
             }))
             .build();
 
@@ -82,6 +98,7 @@ public class SolicitorSubmitPetitionControllerTest {
             post(SUBMIT_PETITION_API_URL)
                 .contentType(APPLICATION_JSON)
                 .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
+                .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
                 .content(objectMapper.writeValueAsBytes(callbackRequest()))
         ).andExpect(
             status().isOk()
@@ -90,7 +107,11 @@ public class SolicitorSubmitPetitionControllerTest {
         );
 
         verify(solicitorSubmitPetitionService).getOrderSummary();
-        verifyNoMoreInteractions(solicitorSubmitPetitionService);
+        verify(ccdAccessService).addPetitionerSolicitorRole(
+            anyString(),
+            anyString()
+        );
+        verifyNoMoreInteractions(solicitorSubmitPetitionService, ccdAccessService);
     }
 
     @Test
@@ -114,6 +135,7 @@ public class SolicitorSubmitPetitionControllerTest {
             post(SUBMIT_PETITION_API_URL)
                 .contentType(APPLICATION_JSON)
                 .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
+                .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
                 .content(objectMapper.writeValueAsBytes(callbackRequest()))
         ).andExpect(
             status().isNotFound()
@@ -123,6 +145,44 @@ public class SolicitorSubmitPetitionControllerTest {
         ).andExpect(
             result -> assertThat(requireNonNull(result.getResolvedException()).getMessage())
                 .contains("404 Fee Not found")
+        );
+    }
+
+    @Test
+    public void shouldReturn401WhenCallbackIsInvokedAndAddingRolesThrowsException()
+        throws Exception {
+        byte[] emptyBody = {};
+        Request request = Request.create(GET, EMPTY, Map.of(), emptyBody, UTF_8, null);
+
+        FeignException feignException = FeignException.errorStatus(
+            "idamRequestFailed",
+            Response.builder()
+                .request(request)
+                .status(401)
+                .headers(Collections.emptyMap())
+                .reason("Failed to retrieve Idam user")
+                .build()
+        );
+
+        doThrow(feignException).when(ccdAccessService).addPetitionerSolicitorRole(
+            anyString(),
+            anyString()
+        );
+
+        mockMvc.perform(
+            post(SUBMIT_PETITION_API_URL)
+                .contentType(APPLICATION_JSON)
+                .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
+                .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
+                .content(objectMapper.writeValueAsBytes(callbackRequest()))
+        ).andExpect(
+            status().isUnauthorized()
+        ).andExpect(
+            result -> assertThat(result.getResolvedException())
+                .isExactlyInstanceOf(FeignException.Unauthorized.class)
+        ).andExpect(
+            result -> assertThat(requireNonNull(result.getResolvedException()).getMessage())
+                .contains("Failed to retrieve Idam user")
         );
     }
 }

--- a/api/src/test/java/uk/gov/hmcts/reform/divorce/caseapi/service/CcdAccessServiceTest.java
+++ b/api/src/test/java/uk/gov/hmcts/reform/divorce/caseapi/service/CcdAccessServiceTest.java
@@ -1,0 +1,191 @@
+package uk.gov.hmcts.reform.divorce.caseapi.service;
+
+import feign.FeignException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.ccd.client.CaseUserApi;
+import uk.gov.hmcts.reform.ccd.client.model.CaseUser;
+import uk.gov.hmcts.reform.idam.client.models.User;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.CASEWORKER_AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.CASEWORKER_USER_ID;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.PET_SOL_AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.SOLICITOR_USER_ID;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_CASEWORKER_USER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_SERVICE_AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_SOL_USER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.caseapi.caseapi.util.TestDataHelper.feignException;
+import static uk.gov.hmcts.reform.divorce.caseapi.enums.NotificationConstants.CREATOR_ROLE;
+import static uk.gov.hmcts.reform.divorce.caseapi.enums.NotificationConstants.PET_SOL_ROLE;
+
+@ExtendWith(MockitoExtension.class)
+public class CcdAccessServiceTest {
+    @InjectMocks
+    private CcdAccessService ccdAccessService;
+
+    @Mock
+    private CaseUserApi caseUserApi;
+
+    @Mock
+    private IdamService idamService;
+
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
+
+    @Test
+    public void shouldNotThrowAnyExceptionWhenAddPetitionerRoleIsInvoked() {
+        User solicitorUser = getIdamUser(PET_SOL_AUTH_TOKEN, SOLICITOR_USER_ID, TEST_SOL_USER_EMAIL);
+        User caseworkerUser = getIdamUser(CASEWORKER_AUTH_TOKEN, CASEWORKER_USER_ID, TEST_CASEWORKER_USER_EMAIL);
+
+        when(idamService.retrieveUser(PET_SOL_AUTH_TOKEN))
+            .thenReturn(solicitorUser);
+
+        when(idamService.retrieveCaseWorkerDetails())
+            .thenReturn(caseworkerUser);
+
+        when(authTokenGenerator.generate())
+            .thenReturn(TEST_SERVICE_AUTH_TOKEN);
+
+        doNothing()
+            .when(
+                caseUserApi
+            )
+            .updateCaseRolesForUser(
+                CASEWORKER_AUTH_TOKEN,
+                TEST_SERVICE_AUTH_TOKEN,
+                TEST_CASE_ID,
+                SOLICITOR_USER_ID,
+                new CaseUser(SOLICITOR_USER_ID, Set.of(CREATOR_ROLE, PET_SOL_ROLE))
+            );
+
+        assertThatCode(() -> ccdAccessService.addPetitionerSolicitorRole(PET_SOL_AUTH_TOKEN, TEST_CASE_ID))
+            .doesNotThrowAnyException();
+
+        verify(idamService).retrieveUser(PET_SOL_AUTH_TOKEN);
+        verify(idamService).retrieveCaseWorkerDetails();
+        verify(authTokenGenerator).generate();
+        verify(caseUserApi)
+            .updateCaseRolesForUser(
+                CASEWORKER_AUTH_TOKEN,
+                TEST_SERVICE_AUTH_TOKEN,
+                TEST_CASE_ID,
+                SOLICITOR_USER_ID,
+                new CaseUser(SOLICITOR_USER_ID, Set.of(CREATOR_ROLE, PET_SOL_ROLE))
+            );
+
+        verifyNoMoreInteractions(idamService, authTokenGenerator, caseUserApi);
+    }
+
+    @Test
+    public void shouldThrowFeignUnauthorizedExceptionWhenRetrievalOfSolicitorUserFails() {
+        doThrow(feignException(401, "Failed to retrieve Idam user"))
+            .when(idamService).retrieveUser(PET_SOL_AUTH_TOKEN);
+
+        assertThatThrownBy(() -> ccdAccessService.addPetitionerSolicitorRole(PET_SOL_AUTH_TOKEN, TEST_CASE_ID))
+            .isExactlyInstanceOf(FeignException.Unauthorized.class)
+            .hasMessageContaining("Failed to retrieve Idam user");
+    }
+
+    @Test
+    public void shouldThrowFeignUnauthorizedExceptionWhenRetrievalOfCaseworkerTokenFails() {
+        User solicitorUser = getIdamUser(PET_SOL_AUTH_TOKEN, SOLICITOR_USER_ID, TEST_SOL_USER_EMAIL);
+
+        when(idamService.retrieveUser(PET_SOL_AUTH_TOKEN))
+            .thenReturn(solicitorUser);
+
+        doThrow(feignException(401, "Failed to retrieve Idam user"))
+            .when(idamService).retrieveCaseWorkerDetails();
+
+        assertThatThrownBy(() -> ccdAccessService.addPetitionerSolicitorRole(PET_SOL_AUTH_TOKEN, TEST_CASE_ID))
+            .isExactlyInstanceOf(FeignException.Unauthorized.class)
+            .hasMessageContaining("Failed to retrieve Idam user");
+
+        verify(idamService).retrieveUser(PET_SOL_AUTH_TOKEN);
+
+        verifyNoMoreInteractions(idamService);
+    }
+
+    @Test
+    public void shouldThrowInvalidTokenExceptionWhenServiceAuthTokenGenerationFails() {
+        User solicitorUser = getIdamUser(PET_SOL_AUTH_TOKEN, SOLICITOR_USER_ID, TEST_SOL_USER_EMAIL);
+        User caseworkerUser = getIdamUser(CASEWORKER_AUTH_TOKEN, CASEWORKER_USER_ID, TEST_CASEWORKER_USER_EMAIL);
+
+        when(idamService.retrieveUser(PET_SOL_AUTH_TOKEN))
+            .thenReturn(solicitorUser);
+
+        when(idamService.retrieveCaseWorkerDetails())
+            .thenReturn(caseworkerUser);
+
+        doThrow(new InvalidTokenException("s2s secret is invalid"))
+            .when(authTokenGenerator).generate();
+
+        assertThatThrownBy(() -> ccdAccessService.addPetitionerSolicitorRole(PET_SOL_AUTH_TOKEN, TEST_CASE_ID))
+            .isExactlyInstanceOf(InvalidTokenException.class)
+            .hasMessageContaining("s2s secret is invalid");
+
+        verify(idamService).retrieveUser(PET_SOL_AUTH_TOKEN);
+        verify(idamService).retrieveCaseWorkerDetails();
+
+        verifyNoMoreInteractions(idamService);
+    }
+
+    @Test
+    public void shouldThrowFeignUnprocessableEntityExceptionWhenCcdClientThrowsException() {
+        User solicitorUser = getIdamUser(PET_SOL_AUTH_TOKEN, SOLICITOR_USER_ID, TEST_SOL_USER_EMAIL);
+        User caseworkerUser = getIdamUser(CASEWORKER_AUTH_TOKEN, CASEWORKER_USER_ID, TEST_CASEWORKER_USER_EMAIL);
+
+        when(idamService.retrieveUser(PET_SOL_AUTH_TOKEN))
+            .thenReturn(solicitorUser);
+
+        when(idamService.retrieveCaseWorkerDetails())
+            .thenReturn(caseworkerUser);
+
+        when(authTokenGenerator.generate())
+            .thenReturn(TEST_SERVICE_AUTH_TOKEN);
+
+        doThrow(feignException(422, "Case roles not valid"))
+            .when(
+                caseUserApi
+            )
+            .updateCaseRolesForUser(
+                CASEWORKER_AUTH_TOKEN,
+                TEST_SERVICE_AUTH_TOKEN,
+                TEST_CASE_ID,
+                SOLICITOR_USER_ID,
+                new CaseUser(SOLICITOR_USER_ID, Set.of(CREATOR_ROLE, PET_SOL_ROLE))
+            );
+
+        assertThatThrownBy(() -> ccdAccessService.addPetitionerSolicitorRole(PET_SOL_AUTH_TOKEN, TEST_CASE_ID))
+            .isExactlyInstanceOf(FeignException.UnprocessableEntity.class)
+            .hasMessageContaining("Case roles not valid");
+
+        verify(idamService).retrieveUser(PET_SOL_AUTH_TOKEN);
+        verify(idamService).retrieveCaseWorkerDetails();
+        verify(authTokenGenerator).generate();
+
+        verifyNoMoreInteractions(idamService, authTokenGenerator);
+    }
+
+    private User getIdamUser(String authToken, String userId, String email) {
+        return new User(
+            authToken,
+            UserDetails.builder().id(userId).email(email).build()
+        );
+    }
+}

--- a/api/src/test/java/uk/gov/hmcts/reform/divorce/caseapi/service/IdamServiceTest.java
+++ b/api/src/test/java/uk/gov/hmcts/reform/divorce/caseapi/service/IdamServiceTest.java
@@ -1,0 +1,100 @@
+package uk.gov.hmcts.reform.divorce.caseapi.service;
+
+import feign.FeignException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.INVALID_AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.PET_SOL_AUTH_TOKEN;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.SOLICITOR_USER_ID;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_CASEWORKER_USER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_CASEWORKER_USER_PASSWORD;
+import static uk.gov.hmcts.reform.divorce.caseapi.TestConstants.TEST_SOL_USER_EMAIL;
+import static uk.gov.hmcts.reform.divorce.caseapi.caseapi.util.TestDataHelper.feignException;
+
+@ExtendWith(MockitoExtension.class)
+public class IdamServiceTest {
+
+    @InjectMocks
+    private IdamService idamService;
+
+    @Mock
+    private IdamClient idamClient;
+
+    @Test
+    public void shouldRetrieveUserWhenValidAuthorizationTokenIsPassed() {
+        when(idamClient.getUserDetails(PET_SOL_AUTH_TOKEN))
+            .thenReturn(userDetails());
+
+        assertThatCode(() -> idamService.retrieveUser(PET_SOL_AUTH_TOKEN))
+            .doesNotThrowAnyException();
+
+        verify(idamClient).getUserDetails(PET_SOL_AUTH_TOKEN);
+        verifyNoMoreInteractions(idamClient);
+    }
+
+    @Test
+    public void shouldThrowFeignUnauthorizedExceptionWhenInValidAuthorizationTokenIsPassed() {
+        doThrow(feignException(401, "Failed to retrieve Idam user"))
+            .when(idamClient).getUserDetails("Bearer invalid_token");
+
+        assertThatThrownBy(() -> idamService.retrieveUser(INVALID_AUTH_TOKEN))
+            .isExactlyInstanceOf(FeignException.Unauthorized.class)
+            .hasMessageContaining("Failed to retrieve Idam user");
+    }
+
+    @Test
+    public void shouldNotThrowExceptionAndRetrieveCaseworkerUserSuccessfully() {
+        setCaseworkerCredentials();
+
+        when(idamClient.getAccessToken(TEST_CASEWORKER_USER_EMAIL, TEST_CASEWORKER_USER_PASSWORD))
+            .thenReturn(PET_SOL_AUTH_TOKEN);
+
+        when(idamClient.getUserDetails(PET_SOL_AUTH_TOKEN))
+            .thenReturn(userDetails());
+
+        assertThatCode(() -> idamService.retrieveCaseWorkerDetails())
+            .doesNotThrowAnyException();
+
+        verify(idamClient).getAccessToken(TEST_CASEWORKER_USER_EMAIL, TEST_CASEWORKER_USER_PASSWORD);
+        verify(idamClient).getUserDetails(PET_SOL_AUTH_TOKEN);
+        verifyNoMoreInteractions(idamClient);
+    }
+
+    @Test
+    public void shouldThrowFeignUnauthorizedExceptionWhenCaseworkerCredentialsAreInvalid() {
+        setCaseworkerCredentials();
+
+        doThrow(feignException(401, "Failed to retrieve Idam user"))
+            .when(idamClient).getAccessToken(TEST_CASEWORKER_USER_EMAIL, TEST_CASEWORKER_USER_PASSWORD);
+
+        assertThatThrownBy(() -> idamService.retrieveCaseWorkerDetails())
+            .isExactlyInstanceOf(FeignException.Unauthorized.class)
+            .hasMessageContaining("Failed to retrieve Idam user");
+    }
+
+    private void setCaseworkerCredentials() {
+        ReflectionTestUtils.setField(idamService, "caseworkerUserName", TEST_CASEWORKER_USER_EMAIL);
+        ReflectionTestUtils.setField(idamService, "caseworkerPassword", TEST_CASEWORKER_USER_PASSWORD);
+    }
+
+    private UserDetails userDetails() {
+        return UserDetails
+            .builder()
+            .id(SOLICITOR_USER_ID)
+            .email(TEST_SOL_USER_EMAIL)
+            .build();
+    }
+}

--- a/charts/nfdiv-case-api/Chart.yaml
+++ b/charts/nfdiv-case-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for nfdiv-case-api App
 name: nfdiv-case-api
 home: https://github.com/hmcts/nfdiv-case-api
-version: 0.0.14
+version: 0.0.15
 maintainers:
   - name: HMCTS nfdiv team
 dependencies:

--- a/charts/nfdiv-case-api/values.yaml
+++ b/charts/nfdiv-case-api/values.yaml
@@ -20,8 +20,12 @@ java:
           alias: UK_GOV_NOTIY_API_KEY
         - name: s2s-case-api-secret
           alias: S2S_SECRET
+        - name: idam-secret
+          alias: IDAM_CLIENT_SECRET
   environment:
       NOTIFY_TEMPLATE_SIGN_IN_DIVORCE_URL: https://nfdiv-apply-for-divorce.{{ .Values.global.environment }}.platform.hmcts.net/
       NOTIFY_TEMPLATE_SIGN_IN_DISSOLUTION_URL: https://nfdiv-end-civil-partnership.{{ .Values.global.environment }}.platform.hmcts.net/
       S2S_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
       FEE_API_URL: http://fees-register-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+      IDAM_API_REDIRECT_URL: https://div-pfe-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/authenticated
+      IDAM_API_BASEURL: "https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net"

--- a/charts/nfdiv-case-api/values.yaml
+++ b/charts/nfdiv-case-api/values.yaml
@@ -18,7 +18,7 @@ java:
           alias: APP_INSIGHTS_KEY
         - name: uk-gov-notify-api-key
           alias: UK_GOV_NOTIY_API_KEY
-        - name: s2s-case-api-secret
+        - name: s2s-cms-secret # Temporarily use cms secret till ccd whitelists case api
           alias: S2S_SECRET
         - name: idam-secret
           alias: IDAM_CLIENT_SECRET

--- a/charts/nfdiv-case-api/values.yaml
+++ b/charts/nfdiv-case-api/values.yaml
@@ -18,6 +18,8 @@ java:
           alias: APP_INSIGHTS_KEY
         - name: uk-gov-notify-api-key
           alias: UK_GOV_NOTIY_API_KEY
+        - name: s2s-case-api-secret
+          alias: S2S_SECRET
   environment:
       NOTIFY_TEMPLATE_SIGN_IN_DIVORCE_URL: https://nfdiv-apply-for-divorce.{{ .Values.global.environment }}.platform.hmcts.net/
       NOTIFY_TEMPLATE_SIGN_IN_DISSOLUTION_URL: https://nfdiv-end-civil-partnership.{{ .Values.global.environment }}.platform.hmcts.net/

--- a/charts/nfdiv-case-api/values.yaml
+++ b/charts/nfdiv-case-api/values.yaml
@@ -22,6 +22,10 @@ java:
           alias: S2S_SECRET
         - name: idam-secret
           alias: IDAM_CLIENT_SECRET
+        - name: idam-caseworker-username
+          alias: IDAM_CASEWORKER_USERNAME
+        - name: idam-caseworker-password
+          alias: IDAM_CASEWORKER_PASSWORD
   environment:
       NOTIFY_TEMPLATE_SIGN_IN_DIVORCE_URL: https://nfdiv-apply-for-divorce.{{ .Values.global.environment }}.platform.hmcts.net/
       NOTIFY_TEMPLATE_SIGN_IN_DISSOLUTION_URL: https://nfdiv-end-civil-partnership.{{ .Values.global.environment }}.platform.hmcts.net/
@@ -29,3 +33,4 @@ java:
       FEE_API_URL: http://fees-register-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
       IDAM_API_REDIRECT_URL: https://div-pfe-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/authenticated
       IDAM_API_BASEURL: "https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net"
+      CASE_DATA_STORE_BASEURL: "http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"


### PR DESCRIPTION
- https://tools.hmcts.net/jira/browse/NFDIV-558
- This PR adds functionality to add petitioner solicitor case roles as part of existing about to start callback for petitioner solicitor submit.
- For functional tests I am using an existing case id in AAT. Please let me know if that is fine or should I create new case in functional test everytime and use that case id ?
- Temporarily using `nfdiv_cms` s2s secret for token generation as cms is whitelisted in CCD and nfdiv case api is not. Will update once ccd has case api whitelisted.
