### PR TITLE
NFDIV-249: new field petitionerKnowsRespondentsEmailAddress

### DIFF
--- a/ccd-definitions/src/main/java/uk/gov/hmcts/reform/divorce/ccd/model/CaseData.java
+++ b/ccd-definitions/src/main/java/uk/gov/hmcts/reform/divorce/ccd/model/CaseData.java
@@ -481,5 +481,11 @@ public class CaseData {
         label = "Do you know their email address",
         access = { DefaultAccess.class }
     )
+    private YesOrNo petitionerKnowsRespondentsEmailAddress;
+
+    @CCD(
+        label = "Do you know their address",
+        access = { DefaultAccess.class }
+    )
     private YesOrNo petitionerKnowsRespondentsAddress;
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/NFDIV-249


### Change description ###
New field created so that https://tools.hmcts.net/jira/browse/NFDIV-249 can use petitionerKnowsRespondentsAddress field


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
