### PR TITLE
Removed bintray repo for gov notifiy and added jitpack repo for generator

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -138,7 +138,7 @@ repositories {
     jcenter()
     mavenCentral()
     maven {
-        url "https://dl.bintray.com/gov-uk-notify/maven"
+      url "https://jitpack.io"
     }
 }
 


### PR DESCRIPTION
- Notify Java API client will be required to be downloaded from Maven central as bintray will be deactivated from 1 May 2021.

- Configured jitpack repo to install ccd generator.