### PR TITLE
Added functionality to update respondent digital details fields

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/common/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/model/CaseData.java
@@ -703,6 +703,12 @@ public class CaseData {
     private YesOrNo respSolDigital;
 
     @CCD(
+        label = "Respondent is using digital channel?",
+        access = {DefaultAccess.class}
+    )
+    private YesOrNo respContactMethodIsDigital;
+
+    @CCD(
         label = "Respondent solicitor's firm",
         hint = "Respondent Organisation Details",
         access = {DefaultAccess.class}

--- a/src/main/java/uk/gov/hmcts/divorce/common/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/model/CaseData.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.google.common.base.Strings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -767,5 +768,19 @@ public class CaseData {
     @JsonIgnore
     public boolean hasPreviousCaseId() {
         return null != previousCaseId;
+    }
+
+    @JsonIgnore
+    public boolean hasDigitalDetailsForRespSol() {
+        return YES.equals(respSolDigital);
+    }
+
+    @JsonIgnore
+    public boolean hasRespondentOrgId() {
+        if (null != respondentOrganisationPolicy) {
+            String respondentOrgId = respondentOrganisationPolicy.getOrganisation().getOrganisationId();
+            return !Strings.isNullOrEmpty(respondentOrgId);
+        }
+        return false;
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorStatementOfTruthPaySubmit.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorStatementOfTruthPaySubmit.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.divorce.solicitor.event;
 
-import com.google.common.base.Strings;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -112,13 +111,10 @@ public class SolicitorStatementOfTruthPaySubmit implements CCDConfig<CaseData, S
     }
 
     private void updateRespondentDigitalDetails(CaseData caseData) {
-        if (null != caseData.getRespondentOrganisationPolicy()) {
-            String respondentOrgId = caseData.getRespondentOrganisationPolicy().getOrganisation().getOrganisationId();
-            if (YES.equals(caseData.getRespSolDigital()) && !Strings.isNullOrEmpty(respondentOrgId)) {
-                log.info("Respondent solicitor is digital and respondent org is populated");
-                caseData.setRespContactMethodIsDigital(YES);
-                caseData.setRespondentSolicitorRepresented(YES);
-            }
+        if (caseData.hasDigitalDetailsForRespSol() && caseData.hasRespondentOrgId()) {
+            log.info("Respondent solicitor is digital and respondent org is populated");
+            caseData.setRespContactMethodIsDigital(YES);
+            caseData.setRespondentSolicitorRepresented(YES);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitPetitionService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitPetitionService.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.divorce.solicitor.service;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.Fee;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.ccd.sdk.type.OrderSummary;
@@ -49,9 +50,13 @@ public class SolicitorSubmitPetitionService {
             .build();
     }
 
-    public State aboutToSubmit(final CaseData caseData, final Long caseId) {
+    public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(final CaseData caseData, final Long caseId) {
         applicantSubmittedNotification.send(caseData, caseId);
-        return SolicitorAwaitingPaymentConfirmation;
+
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(caseData)
+            .state(SolicitorAwaitingPaymentConfirmation)
+            .build();
     }
 
     private ListValue<Fee> getFee(FeeResponse feeResponse) {

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorStatementOfTruthPaySubmitTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorStatementOfTruthPaySubmitTest.java
@@ -9,6 +9,8 @@ import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.OrderSummary;
+import uk.gov.hmcts.ccd.sdk.type.Organisation;
+import uk.gov.hmcts.ccd.sdk.type.OrganisationPolicy;
 import uk.gov.hmcts.divorce.common.model.CaseData;
 import uk.gov.hmcts.divorce.common.model.State;
 import uk.gov.hmcts.divorce.common.model.UserRole;
@@ -31,6 +33,8 @@ import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.common.model.State.SOTAgreementPayAndSubmitRequired;
 import static uk.gov.hmcts.divorce.common.model.State.SolicitorAwaitingPaymentConfirmation;
 import static uk.gov.hmcts.divorce.solicitor.event.SolicitorStatementOfTruthPaySubmit.SOLICITOR_STATEMENT_OF_TRUTH_PAY_SUBMIT;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_ORG_NAME;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TES_ORG_ID;
 
 @ExtendWith(MockitoExtension.class)
 public class SolicitorStatementOfTruthPaySubmitTest {
@@ -98,7 +102,13 @@ public class SolicitorStatementOfTruthPaySubmitTest {
         caseDetails.setId(caseId);
         caseDetails.setState(SOTAgreementPayAndSubmitRequired);
 
-        when(solicitorSubmitPetitionService.aboutToSubmit(caseData, caseId)).thenReturn(SolicitorAwaitingPaymentConfirmation);
+        AboutToStartOrSubmitResponse<CaseData, State> aboutToStartOrSubmitResponse =
+            AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .data(caseData)
+                .state(SolicitorAwaitingPaymentConfirmation)
+                .build();
+
+        when(solicitorSubmitPetitionService.aboutToSubmit(caseData, caseId)).thenReturn(aboutToStartOrSubmitResponse);
 
         final AboutToStartOrSubmitResponse<CaseData, State> response = solicitorStatementOfTruthPaySubmit
             .aboutToSubmit(caseDetails, new CaseDetails<>());
@@ -180,5 +190,114 @@ public class SolicitorStatementOfTruthPaySubmitTest {
         assertThat(response.getData(), is(caseData));
         assertThat(response.getState(), is(SOTAgreementPayAndSubmitRequired));
         assertThat(response.getErrors(), contains(STATEMENT_OF_TRUTH_ERROR_MESSAGE));
+    }
+
+    @Test
+    void shouldSetRespondentDigitalDetailsWhenRespSolicitorIsDigitalAndRespOrganisationIsSet() {
+        final long caseId = 1L;
+        final OrganisationPolicy<UserRole> organisationPolicy = OrganisationPolicy.<UserRole>builder()
+            .organisation(Organisation
+                .builder()
+                .organisationId(TES_ORG_ID)
+                .organisationName(TEST_ORG_NAME)
+                .build()
+            )
+            .build();
+
+        final CaseData caseData = CaseData.builder()
+            .statementOfTruth(YES)
+            .solSignStatementOfTruth(YES)
+            .respSolDigital(YES)
+            .respondentOrganisationPolicy(organisationPolicy)
+            .build();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+        caseDetails.setId(caseId);
+        caseDetails.setState(SOTAgreementPayAndSubmitRequired);
+
+        AboutToStartOrSubmitResponse<CaseData, State> aboutToStartOrSubmitResponse =
+            AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .data(caseData)
+                .state(SolicitorAwaitingPaymentConfirmation)
+                .build();
+
+        when(solicitorSubmitPetitionService.aboutToSubmit(caseData, caseId)).thenReturn(aboutToStartOrSubmitResponse);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response = solicitorStatementOfTruthPaySubmit
+            .aboutToSubmit(caseDetails, new CaseDetails<>());
+
+        final CaseData expectedCaseData = CaseData.builder()
+            .statementOfTruth(YES)
+            .solSignStatementOfTruth(YES)
+            .respSolDigital(YES)
+            .respContactMethodIsDigital(YES)
+            .respondentSolicitorRepresented(YES)
+            .respondentOrganisationPolicy(organisationPolicy)
+            .build();
+
+        assertThat(response.getData(), is(expectedCaseData));
+        assertThat(response.getState(), is(SolicitorAwaitingPaymentConfirmation));
+        assertThat(response.getErrors(), is(nullValue()));
+    }
+
+    @Test
+    void shouldNotSetRespondentDigitalDetailsWhenRespSolicitorIsNotDigital() {
+        final long caseId = 1L;
+        final CaseData caseData = CaseData.builder()
+            .statementOfTruth(YES)
+            .solSignStatementOfTruth(YES)
+            .respSolDigital(NO)
+            .build();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+        caseDetails.setId(caseId);
+        caseDetails.setState(SOTAgreementPayAndSubmitRequired);
+
+        AboutToStartOrSubmitResponse<CaseData, State> aboutToStartOrSubmitResponse =
+            AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .data(caseData)
+                .state(SolicitorAwaitingPaymentConfirmation)
+                .build();
+
+        when(solicitorSubmitPetitionService.aboutToSubmit(caseData, caseId)).thenReturn(aboutToStartOrSubmitResponse);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response = solicitorStatementOfTruthPaySubmit
+            .aboutToSubmit(caseDetails, new CaseDetails<>());
+
+        assertThat(response.getData(), is(caseData));
+        assertThat(response.getState(), is(SolicitorAwaitingPaymentConfirmation));
+        assertThat(response.getErrors(), is(nullValue()));
+    }
+
+    @Test
+    void shouldNotSetRespondentDigitalDetailsWhenRespSolicitorIsDigitalAndRespOrgIsNotSet() {
+        final long caseId = 1L;
+        final CaseData caseData = CaseData.builder()
+            .statementOfTruth(YES)
+            .solSignStatementOfTruth(YES)
+            .respSolDigital(YES)
+            .build();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+        caseDetails.setId(caseId);
+        caseDetails.setState(SOTAgreementPayAndSubmitRequired);
+
+        AboutToStartOrSubmitResponse<CaseData, State> aboutToStartOrSubmitResponse =
+            AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .data(caseData)
+                .state(SolicitorAwaitingPaymentConfirmation)
+                .build();
+
+        when(solicitorSubmitPetitionService.aboutToSubmit(caseData, caseId)).thenReturn(aboutToStartOrSubmitResponse);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response = solicitorStatementOfTruthPaySubmit
+            .aboutToSubmit(caseDetails, new CaseDetails<>());
+
+        assertThat(response.getData(), is(caseData));
+        assertThat(response.getState(), is(SolicitorAwaitingPaymentConfirmation));
+        assertThat(response.getErrors(), is(nullValue()));
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitPetitionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitPetitionServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.Fee;
 import uk.gov.hmcts.ccd.sdk.type.OrderSummary;
 import uk.gov.hmcts.divorce.common.model.CaseData;
@@ -119,9 +120,10 @@ public class SolicitorSubmitPetitionServiceTest {
         final CaseData caseData = CaseData.builder().build();
         final long caseId = 1L;
 
-        final State resultState = solicitorSubmitPetitionService.aboutToSubmit(caseData, caseId);
+        final AboutToStartOrSubmitResponse<CaseData, State> aboutToStartOrSubmitResponse =
+            solicitorSubmitPetitionService.aboutToSubmit(caseData, caseId);
 
-        assertThat(resultState).isEqualTo(SolicitorAwaitingPaymentConfirmation);
+        assertThat(aboutToStartOrSubmitResponse.getState()).isEqualTo(SolicitorAwaitingPaymentConfirmation);
         verify(applicantSubmittedNotification).send(caseData, caseId);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/testutil/TestConstants.java
+++ b/src/test/java/uk/gov/hmcts/divorce/testutil/TestConstants.java
@@ -36,6 +36,8 @@ public final class TestConstants {
     public static final String WELSH_TEMPLATE_ID = "FL-DIV-GNO-WEL-00256.docx";
     public static final String BEARER = "Bearer ";
     public static final String LANGUAGE_PREFERENCE_WELSH = "languagePreferenceWelsh";
+    public static final String TES_ORG_ID = "ABC123";
+    public static final String TEST_ORG_NAME = "TEST ORG";
 
     private TestConstants() {
     }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-642

### Change description ###

-  This PR adds functionality to update digital details fields based on respondent organisation and if the respondent solicitor is digitally available.
- Haven't replaced respondent with applicant2 as we still not have got the confirmation.
- Includes minor refactoring as well.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
