### PR TITLE
chore(NFDIV-656): Remove isInternational fields & use formatted AddressGlobalUK only

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/common/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/model/CaseData.java
@@ -281,12 +281,6 @@ public class CaseData {
     private AddressGlobalUK applicantHomeAddress;
 
     @CCD(
-        label = "Is petitioners home address an international address?",
-        access = {DefaultAccess.class}
-    )
-    private YesOrNo petitionerHomeAddressIsInternational;
-
-    @CCD(
         label = "Petitioner's phone number",
         regex = "^[0-9 +().-]{9,}$",
         access = {DefaultAccess.class}
@@ -568,12 +562,6 @@ public class CaseData {
         access = {DefaultAccess.class}
     )
     private AddressGlobalUK respondentHomeAddress;
-
-    @CCD(
-        label = "Is respondents home address an international address?",
-        access = {DefaultAccess.class}
-    )
-    private YesOrNo respondentHomeAddressIsInternational;
 
     @CCD(
         label = "Are there any existing or previous court proceedings relating to the petitioner's marriage, "


### PR DESCRIPTION
### JIRA link ###

[NFDIV-656](https://tools.hmcts.net/jira/browse/NFDIV-656) Remove "IsInternational" fields from CaseDefination and Citizen Journey. 

### Change description ###

Removes the `isInternational` fields. Requires https://github.com/hmcts/nfdiv-frontend/pull/557 to be merged first. The frontend will now use the address country to determine if the address should be displayed in international format.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
