### PR TITLE
feat(NFDIV-680): Allowing adding of payments while AwaitingPayment

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenAddPayment.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenAddPayment.java
@@ -67,7 +67,12 @@ public class CitizenAddPayment implements CCDConfig<CaseData, State, UserRole> {
         List<String> errors = Stream.concat(submittedErrors.stream(), awaitingDocumentsErrors.stream())
             .collect(Collectors.toList());
 
-        if (data.wasLastPaymentUnsuccessful()) {
+        if (data.isLastPaymentInProgress()) {
+            log.info("Case {} payment in progress", details.getId());
+
+            state = AwaitingPayment;
+            errors.clear();
+        } else if (data.wasLastPaymentUnsuccessful()) {
             log.info("Case {} payment canceled", details.getId());
 
             state = Draft;

--- a/src/main/java/uk/gov/hmcts/divorce/common/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/model/CaseData.java
@@ -36,6 +36,7 @@ import static uk.gov.hmcts.ccd.sdk.type.FieldType.FixedList;
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.FixedRadioList;
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.TextArea;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
+import static uk.gov.hmcts.divorce.payment.model.PaymentStatus.IN_PROGRESS;
 import static uk.gov.hmcts.divorce.payment.model.PaymentStatus.SUCCESS;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -569,6 +570,16 @@ public class CaseData {
             .filter(p -> SUCCESS.equals(p.getValue().getPaymentStatus()))
             .map(p -> p.getValue().getPaymentAmount())
             .reduce(0, Integer::sum);
+    }
+
+    @JsonIgnore
+    public Boolean isLastPaymentInProgress() {
+        return payments != null && payments
+            .stream()
+            .reduce((previous, current) -> current)
+            .get()
+            .getValue()
+            .getPaymentStatus() == IN_PROGRESS;
     }
 
     @JsonIgnore


### PR DESCRIPTION
### JIRA link ###

[NFDIV-680](https://tools.hmcts.net/jira/browse/NFDIV-680) Payment - State Changes

### Change description ###

Allow adding of payments while the case is in an `AwaitingPayment` state.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```