### PR TITLE
Add schedule task for awaiting conditional order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,12 @@ plugins {
   id 'org.sonarqube' version '3.3'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.5.2'
-  id 'com.github.ben-manes.versions' version '0.39.0'
+  id 'com.github.ben-manes.versions' version '0.38.0'
   id 'hmcts.ccd.sdk' version '0.22.0'
 }
 
 apply plugin: 'cz.habarta.typescript-generator'
+apply plugin: 'com.github.ben-manes.versions'
 
 group = 'uk.gov.hmcts'
 version = '0.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -200,6 +200,7 @@ repositories {
 
 def versions = [
   assertJ           : '3.19.0',
+  awaitility        : '1.7.0',
   ccdStoreClient    : '4.7.6',
   elasticsearch     : '7.12.0',
   idamClient        : '2.0.0',
@@ -303,6 +304,8 @@ dependencies {
   testImplementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
   testImplementation group: 'org.mockito', name: 'mockito-inline', version: versions.mockitoInline
+
+  testImplementation group: 'com.jayway.awaitility', name: 'awaitility', version: versions.awaitility
 
   testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 

--- a/charts/nfdiv-case-api/Chart.yaml
+++ b/charts/nfdiv-case-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for nfdiv-case-api App
 name: nfdiv-case-api
 home: https://github.com/hmcts/nfdiv-case-api
-version: 0.0.26
+version: 0.0.27
 maintainers:
   - name: HMCTS nfdiv team
 dependencies:

--- a/charts/nfdiv-case-api/values.yaml
+++ b/charts/nfdiv-case-api/values.yaml
@@ -44,3 +44,4 @@ java:
     DOCUMENT_MANAGEMENT_URL: http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     PRD_API_BASEURL : "http://rd-professional-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     SEND_LETTER_SERVICE_BASEURL: "http://rpe-send-letter-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    AWAITING_CONDITIONAL_ORDER_SCHEDULED_CRON: 0 0 0 * * ? # Midnight each day

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
+        mavenCentral()
     }
 }
 

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -67,6 +67,7 @@ send-letter:
 
 schedule:
   issue_aos: '0 0 0 * * ?' # Midnight each day
+  awaiting_conditional_order: '0 0 0 * * ?' # Midnight each day
 
 aos_pack:
   due_date_offset_days: 30

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/schedule/CaseworkerAwaitingConditionalOrderTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/schedule/CaseworkerAwaitingConditionalOrderTaskTest.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.divorce.caseworker.schedule;
+
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class CaseworkerAwaitingConditionalOrderTaskTest {
+    @SpyBean
+    private CaseworkerAwaitingConditionalOrderTask awaitingConditionalOrderTask;
+
+    @Test
+    public void givenValidCaseDataWhenCallbackIsInvokedThenOrderSummaryAndSolicitorRolesAreSet() {
+        await(" Awaiting Conditional order task executed atleast once")
+            .atMost(60, TimeUnit.SECONDS)
+            .pollInterval(2, TimeUnit.SECONDS)
+            .until(() -> verify(awaitingConditionalOrderTask, atLeastOnce()).execute());
+    }
+}

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -80,6 +80,6 @@ send-letter:
 
 schedule:
   issue_aos: '0 0 0 * * ?' # Midnight each day
-
+  awaiting_conditional_order: '*/1 * * * * *'
 aos_pack:
   due_date_offset_days: 30

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAwaitingConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAwaitingConditionalOrder.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.divorce.caseworker.event;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.ccd.PageBuilder;
+import uk.gov.hmcts.divorce.common.model.CaseData;
+import uk.gov.hmcts.divorce.common.model.State;
+import uk.gov.hmcts.divorce.common.model.UserRole;
+
+import static uk.gov.hmcts.divorce.common.model.State.AwaitingConditionalOrder;
+import static uk.gov.hmcts.divorce.common.model.State.Holding;
+import static uk.gov.hmcts.divorce.common.model.UserRole.CASEWORKER_COURTADMIN_CTSC;
+import static uk.gov.hmcts.divorce.common.model.UserRole.CASEWORKER_COURTADMIN_RDU;
+import static uk.gov.hmcts.divorce.common.model.UserRole.CASEWORKER_LEGAL_ADVISOR;
+import static uk.gov.hmcts.divorce.common.model.UserRole.CASEWORKER_SUPERUSER;
+import static uk.gov.hmcts.divorce.common.model.UserRole.SOLICITOR;
+import static uk.gov.hmcts.divorce.common.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.common.model.access.Permissions.READ;
+
+@Component
+public class CaseworkerAwaitingConditionalOrder implements CCDConfig<CaseData, State, UserRole> {
+
+    public static final String CASEWORKER_AWAITING_CONDITIONAL_ORDER = "caseworker-awaiting-conditional-order";
+
+    @Override
+    public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
+        new PageBuilder(configBuilder
+            .event(CASEWORKER_AWAITING_CONDITIONAL_ORDER)
+            .forStateTransition(Holding, AwaitingConditionalOrder)
+            .name("Awaiting conditional order")
+            .description("Awaiting conditional order")
+            .displayOrder(3)
+            .explicitGrants()
+            .grant(CREATE_READ_UPDATE, CASEWORKER_COURTADMIN_CTSC, CASEWORKER_COURTADMIN_RDU)
+            .grant(READ, SOLICITOR, CASEWORKER_SUPERUSER, CASEWORKER_LEGAL_ADVISOR));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/schedule/CaseworkerAwaitingConditionalOrderTask.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/schedule/CaseworkerAwaitingConditionalOrderTask.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.divorce.caseworker.schedule;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.divorce.caseworker.service.CcdConflictException;
+import uk.gov.hmcts.divorce.caseworker.service.CcdManagementException;
+import uk.gov.hmcts.divorce.caseworker.service.CcdSearchCaseException;
+import uk.gov.hmcts.divorce.caseworker.service.CcdSearchService;
+import uk.gov.hmcts.divorce.caseworker.service.CcdUpdateService;
+import uk.gov.hmcts.divorce.common.model.CaseData;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static java.time.temporal.ChronoUnit.WEEKS;
+import static uk.gov.hmcts.divorce.caseworker.event.CaseworkerAwaitingConditionalOrder.CASEWORKER_AWAITING_CONDITIONAL_ORDER;
+import static uk.gov.hmcts.divorce.common.model.State.Holding;
+
+@Component
+@Slf4j
+/**
+ * Any cases that were issued > 20 weeks ago AND are in the Holding state will be moved to AwaitingConditionalOrder by this task.
+ */
+public class CaseworkerAwaitingConditionalOrderTask {
+
+    private static final int HOLDING_PERIOD_IN_WEEKS = 20;
+
+    @Autowired
+    private CcdUpdateService ccdUpdateService;
+
+    @Autowired
+    private CcdSearchService ccdSearchService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Scheduled(cron = "${schedule.awaiting_conditional_order}")
+    public void execute() {
+
+        log.info("Awaiting conditional order scheduled task started");
+
+        try {
+            final List<CaseDetails> casesInHoldingState = ccdSearchService.searchForAllCasesWithStateOf(Holding);
+
+            for (final CaseDetails caseDetails : casesInHoldingState) {
+                try {
+                    Map<String, Object> caseDataMap = caseDetails.getData();
+                    CaseData caseData = objectMapper.convertValue(caseDataMap, CaseData.class);
+                    long weeksBetweenIssueDateAndNow = WEEKS.between(caseData.getIssueDate(), LocalDate.now());
+
+                    if (weeksBetweenIssueDateAndNow > HOLDING_PERIOD_IN_WEEKS) {
+                        log.info("Case id {} has been in holding state for > 20 weeks hence moving state to AwaitingConditionalOrder",
+                            caseDetails.getId()
+                        );
+                        ccdUpdateService.submitEvent(caseDetails, CASEWORKER_AWAITING_CONDITIONAL_ORDER);
+                    }
+                } catch (final CcdManagementException e) {
+                    log.info("Submit event failed for case id: {}, continuing to next case", caseDetails.getId());
+                }
+            }
+
+            log.info("Awaiting conditional order scheduled task complete.");
+        } catch (final CcdSearchCaseException e) {
+            log.error("Awaiting conditional order schedule task stopped after search error", e);
+        } catch (final CcdConflictException e) {
+            log.info("Awaiting conditional order schedule task stopping "
+                + "due to conflict with another running awaiting conditional order task"
+            );
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -119,7 +119,7 @@ send-letter:
 
 schedule:
   issue_aos: '0 0 0 * * ?' # Midnight each day
-  awaiting_conditional_order: '0 0 0 * * ?' # Midnight each day
+  awaiting_conditional_order: ${AWAITING_CONDITIONAL_ORDER_SCHEDULED_CRON}
 
 aos_pack:
   due_date_offset_days: ${AOS_PACK_DUE_DATE_OFFSET_DAYS:30}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -119,7 +119,7 @@ send-letter:
 
 schedule:
   issue_aos: '0 0 0 * * ?' # Midnight each day
-  awaiting_conditional_order: ${AWAITING_CONDITIONAL_ORDER_SCHEDULED_CRON}
+  awaiting_conditional_order: ${AWAITING_CONDITIONAL_ORDER_SCHEDULED_CRON:0 0 0 * * ?}
 
 aos_pack:
   due_date_offset_days: ${AOS_PACK_DUE_DATE_OFFSET_DAYS:30}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -119,6 +119,7 @@ send-letter:
 
 schedule:
   issue_aos: '0 0 0 * * ?' # Midnight each day
+  awaiting_conditional_order: '0 0 0 * * ?' # Midnight each day
 
 aos_pack:
   due_date_offset_days: ${AOS_PACK_DUE_DATE_OFFSET_DAYS:30}

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAwaitingConditionalOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAwaitingConditionalOrderTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.caseworker.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.common.model.CaseData;
+import uk.gov.hmcts.divorce.common.model.State;
+import uk.gov.hmcts.divorce.common.model.UserRole;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class CaseworkerAwaitingConditionalOrderTest {
+
+    @InjectMocks
+    private CaseworkerAwaitingConditionalOrder caseworkerAwaitingConditionalOrder;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() {
+        final Set<State> stateSet = Set.of(State.class.getEnumConstants());
+        final ConfigBuilderImpl<CaseData, State, UserRole> configBuilder = new ConfigBuilderImpl<>(CaseData.class, stateSet);
+
+        caseworkerAwaitingConditionalOrder.configure(configBuilder);
+
+        assertThat(configBuilder.getEvents())
+            .extracting(Event::getId)
+            .contains(CaseworkerAwaitingConditionalOrder.CASEWORKER_AWAITING_CONDITIONAL_ORDER);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/schedule/CaseworkerAwaitingConditionalOrderTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/schedule/CaseworkerAwaitingConditionalOrderTaskTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import java.time.LocalDate;
 import java.util.List;
 
+import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -58,6 +59,20 @@ class CaseworkerAwaitingConditionalOrderTaskTest {
 
         verify(ccdUpdateService).submitEvent(caseDetails1, CASEWORKER_AWAITING_CONDITIONAL_ORDER);
         verify(ccdUpdateService).submitEvent(caseDetails2, CASEWORKER_AWAITING_CONDITIONAL_ORDER);
+    }
+
+    @Test
+    void shouldNotTriggerAwaitingConditionalOrderWhenCaseIsInHoldingForLessThan20Weeks() {
+        final CaseDetails caseDetails1 = mock(CaseDetails.class);
+
+        CaseData caseData1 = CaseData.builder().issueDate(LocalDate.now()).build();
+        when(objectMapper.convertValue(caseDetails1.getData(), CaseData.class)).thenReturn(caseData1);
+
+        when(ccdSearchService.searchForAllCasesWithStateOf(Holding)).thenReturn(singletonList(caseDetails1));
+
+        awaitingConditionalOrderTask.execute();
+
+        verifyNoInteractions(ccdUpdateService);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/schedule/CaseworkerAwaitingConditionalOrderTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/schedule/CaseworkerAwaitingConditionalOrderTaskTest.java
@@ -1,0 +1,95 @@
+package uk.gov.hmcts.divorce.caseworker.schedule;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.divorce.caseworker.service.CcdManagementException;
+import uk.gov.hmcts.divorce.caseworker.service.CcdSearchCaseException;
+import uk.gov.hmcts.divorce.caseworker.service.CcdSearchService;
+import uk.gov.hmcts.divorce.caseworker.service.CcdUpdateService;
+import uk.gov.hmcts.divorce.common.model.CaseData;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.divorce.caseworker.event.CaseworkerAwaitingConditionalOrder.CASEWORKER_AWAITING_CONDITIONAL_ORDER;
+import static uk.gov.hmcts.divorce.common.model.State.Holding;
+
+@ExtendWith(MockitoExtension.class)
+class CaseworkerAwaitingConditionalOrderTaskTest {
+
+    @Mock
+    private CcdUpdateService ccdUpdateService;
+
+    @Mock
+    private CcdSearchService ccdSearchService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private CaseworkerAwaitingConditionalOrderTask awaitingConditionalOrderTask;
+
+    @Test
+    void shouldTriggerAwaitingConditionalOrderOnEachCaseWhenCaseIsInHoldingForMoreThan20Weeks() {
+        final CaseDetails caseDetails1 = mock(CaseDetails.class);
+        final CaseDetails caseDetails2 = mock(CaseDetails.class);
+        final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
+
+        CaseData caseData1 = CaseData.builder().issueDate(LocalDate.of(2021, 1, 1)).build();
+        when(objectMapper.convertValue(caseDetails1.getData(), CaseData.class)).thenReturn(caseData1);
+
+        CaseData caseData2 = CaseData.builder().issueDate(LocalDate.of(2021, 1, 2)).build();
+        when(objectMapper.convertValue(caseDetails2.getData(), CaseData.class)).thenReturn(caseData2);
+
+        when(ccdSearchService.searchForAllCasesWithStateOf(Holding)).thenReturn(caseDetailsList);
+
+        awaitingConditionalOrderTask.execute();
+
+        verify(ccdUpdateService).submitEvent(caseDetails1, CASEWORKER_AWAITING_CONDITIONAL_ORDER);
+        verify(ccdUpdateService).submitEvent(caseDetails2, CASEWORKER_AWAITING_CONDITIONAL_ORDER);
+    }
+
+    @Test
+    void shouldNotSubmitEventIfSearchFails() {
+        when(ccdSearchService.searchForAllCasesWithStateOf(Holding))
+            .thenThrow(new CcdSearchCaseException("Failed to search cases", mock(FeignException.class)));
+
+        awaitingConditionalOrderTask.execute();
+
+        verifyNoInteractions(ccdUpdateService);
+    }
+
+    @Test
+    void shouldContinueToNextCaseIfExceptionIsThrownWhileProcessingPreviousCase() {
+        final CaseDetails caseDetails1 = mock(CaseDetails.class);
+        final CaseDetails caseDetails2 = mock(CaseDetails.class);
+        final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
+
+        CaseData caseData1 = CaseData.builder().issueDate(LocalDate.of(2021, 1, 1)).build();
+        when(objectMapper.convertValue(caseDetails1.getData(), CaseData.class)).thenReturn(caseData1);
+
+        CaseData caseData2 = CaseData.builder().issueDate(LocalDate.of(2021, 1, 2)).build();
+        when(objectMapper.convertValue(caseDetails2.getData(), CaseData.class)).thenReturn(caseData2);
+
+        when(ccdSearchService.searchForAllCasesWithStateOf(Holding)).thenReturn(caseDetailsList);
+
+        doThrow(new CcdManagementException("Failed processing of case", mock(FeignException.class)))
+            .when(ccdUpdateService).submitEvent(caseDetails1, CASEWORKER_AWAITING_CONDITIONAL_ORDER);
+
+        awaitingConditionalOrderTask.execute();
+
+        verify(ccdUpdateService).submitEvent(caseDetails1, CASEWORKER_AWAITING_CONDITIONAL_ORDER);
+        verify(ccdUpdateService).submitEvent(caseDetails2, CASEWORKER_AWAITING_CONDITIONAL_ORDER);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-983

### Change description ###

- Added event to move case state from `Holding` to `AwaitingConditionalOrder`.
- Added scheduled task to trigger the event if case is in holding state for more than 20 weeks.
- Integration test verifies if the scheduled job is executed only once.
- We will have to rely on manual testing till we e2e test in place as integration and functional tests for scheduled tasks is bit difficult.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
