### PR TITLE
NFDIV-890 Add update language events

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUpdateLanguage.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUpdateLanguage.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.divorce.caseworker.event;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
+import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASEWORKER_COURTADMIN_CTSC;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASEWORKER_COURTADMIN_RDU;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASEWORKER_LEGAL_ADVISOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASEWORKER_SUPERUSER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE_DELETE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
+
+@Component
+public class CaseworkerUpdateLanguage implements CCDConfig<CaseData, State, UserRole> {
+
+    public static final String CASEWORKER_UPDATE_LANGUAGE = "caseworker-update-language";
+
+    @Override
+    public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
+        new PageBuilder(configBuilder
+            .event(CASEWORKER_UPDATE_LANGUAGE)
+            .forAllStates()
+            .name("Update Language")
+            .description("Update Language")
+            .showSummary()
+            .explicitGrants()
+            .grant(CREATE_READ_UPDATE_DELETE, CASEWORKER_SUPERUSER)
+            .grant(READ, SOLICITOR)
+            .grant(CREATE_READ_UPDATE,
+                CASEWORKER_COURTADMIN_CTSC,
+                CASEWORKER_COURTADMIN_RDU,
+                CASEWORKER_LEGAL_ADVISOR))
+            .page("caseworkerLangPref")
+            .pageLabel("Select Language")
+            .complex(CaseData::getApplicant1)
+                .mandatory(Applicant::getLanguagePreferenceWelsh, null, null, "Applicant's language preference")
+                .done()
+            .complex(CaseData::getApplicant2)
+                .mandatory(Applicant::getLanguagePreferenceWelsh, null, null, "Respondent's language preference")
+                .done();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateApplicant1Language.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateApplicant1Language.java
@@ -9,33 +9,31 @@ import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 
-import static uk.gov.hmcts.divorce.divorcecase.model.State.Draft;
-import static uk.gov.hmcts.divorce.divorcecase.model.State.Submitted;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_1_SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASEWORKER_COURTADMIN_CTSC;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASEWORKER_COURTADMIN_RDU;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASEWORKER_LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASEWORKER_SUPERUSER;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ_UPDATE;
 import static uk.gov.hmcts.divorce.solicitor.event.page.CommonFieldSettings.SOLICITOR_NFD_PREVIEW_BANNER;
 
 @Component
-public class SolicitorUpdateLanguage implements CCDConfig<CaseData, State, UserRole> {
+public class SolicitorUpdateApplicant1Language implements CCDConfig<CaseData, State, UserRole> {
 
-    public static final String SOLICITOR_UPDATE_LANGUAGE = "solicitor-update-language";
+    public static final String SOLICITOR_UPDATE_APPLICANT_1_LANGUAGE = "solicitor-update-applicant1-language";
 
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         new PageBuilder(configBuilder
-            .event(SOLICITOR_UPDATE_LANGUAGE)
-            .forStates(Draft, Submitted)
+            .event(SOLICITOR_UPDATE_APPLICANT_1_LANGUAGE)
+            .forAllStates()
             .name("Update Language")
             .description("Update Language")
             .showSummary()
             .explicitGrants()
-            .grant(CREATE_READ_UPDATE, SOLICITOR)
+            .grant(CREATE_READ_UPDATE, APPLICANT_1_SOLICITOR)
             .grant(READ_UPDATE, CASEWORKER_SUPERUSER)
             .grant(READ,
                 CASEWORKER_COURTADMIN_CTSC,
@@ -43,7 +41,7 @@ public class SolicitorUpdateLanguage implements CCDConfig<CaseData, State, UserR
                 CASEWORKER_LEGAL_ADVISOR))
             .page("langPref")
             .pageLabel("Select Language")
-            .label("LabelNFDBanner-MarriageIrretrievablyBroken", SOLICITOR_NFD_PREVIEW_BANNER)
+            .label("LabelNFDBanner-UpdateApplicant1Language", SOLICITOR_NFD_PREVIEW_BANNER)
             .complex(CaseData::getApplicant1)
                 .mandatory(Applicant::getLanguagePreferenceWelsh)
                 .done();

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateApplicant2Language.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateApplicant2Language.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.divorce.solicitor.event;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
+import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2_SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASEWORKER_COURTADMIN_CTSC;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASEWORKER_COURTADMIN_RDU;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASEWORKER_LEGAL_ADVISOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASEWORKER_SUPERUSER;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ_UPDATE;
+import static uk.gov.hmcts.divorce.solicitor.event.page.CommonFieldSettings.SOLICITOR_NFD_PREVIEW_BANNER;
+
+@Component
+public class SolicitorUpdateApplicant2Language implements CCDConfig<CaseData, State, UserRole> {
+
+    public static final String SOLICITOR_UPDATE_APPLICANT_2_LANGUAGE = "solicitor-update-applicant2-language";
+
+    @Override
+    public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
+        new PageBuilder(configBuilder
+            .event(SOLICITOR_UPDATE_APPLICANT_2_LANGUAGE)
+            .forAllStates()
+            .name("Update Language")
+            .description("Update Language")
+            .showSummary()
+            .explicitGrants()
+            .grant(CREATE_READ_UPDATE, APPLICANT_2_SOLICITOR)
+            .grant(READ_UPDATE, CASEWORKER_SUPERUSER)
+            .grant(READ,
+                CASEWORKER_COURTADMIN_CTSC,
+                CASEWORKER_COURTADMIN_RDU,
+                CASEWORKER_LEGAL_ADVISOR))
+            .page("langPref2")
+            .pageLabel("Select Language")
+            .label("LabelNFDBanner-UpdateApplicant2Language", SOLICITOR_NFD_PREVIEW_BANNER)
+            .complex(CaseData::getApplicant2)
+                .mandatory(Applicant::getLanguagePreferenceWelsh)
+                .done();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUpdateLanguageTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUpdateLanguageTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.divorce.solicitor.event;
+package uk.gov.hmcts.divorce.caseworker.event;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,24 +11,24 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.hmcts.divorce.solicitor.event.SolicitorUpdateLanguage.SOLICITOR_UPDATE_LANGUAGE;
+import static uk.gov.hmcts.divorce.caseworker.event.CaseworkerUpdateLanguage.CASEWORKER_UPDATE_LANGUAGE;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
 
 @ExtendWith(MockitoExtension.class)
-public class SolicitorUpdateApplicationLanguageTest {
+public class CaseworkerUpdateLanguageTest {
 
     @InjectMocks
-    private SolicitorUpdateLanguage solicitorUpdateLanguage;
+    private CaseworkerUpdateLanguage caseworkerUpdateLanguage;
 
     @Test
     void shouldAddConfigurationToConfigBuilder() {
         final ConfigBuilderImpl<CaseData, State, UserRole> configBuilder = createCaseDataConfigBuilder();
 
-        solicitorUpdateLanguage.configure(configBuilder);
+        caseworkerUpdateLanguage.configure(configBuilder);
 
         assertThat(getEventsFrom(configBuilder).values())
             .extracting(Event::getId)
-            .contains(SOLICITOR_UPDATE_LANGUAGE);
+            .contains(CASEWORKER_UPDATE_LANGUAGE);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateApplicant1LanguageTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateApplicant1LanguageTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.solicitor.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.solicitor.event.SolicitorUpdateApplicant1Language.SOLICITOR_UPDATE_APPLICANT_1_LANGUAGE;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+
+@ExtendWith(MockitoExtension.class)
+public class SolicitorUpdateApplicant1LanguageTest {
+
+    @InjectMocks
+    private SolicitorUpdateApplicant1Language solicitorUpdateApplicant1Language;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() {
+        final ConfigBuilderImpl<CaseData, State, UserRole> configBuilder = createCaseDataConfigBuilder();
+
+        solicitorUpdateApplicant1Language.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(SOLICITOR_UPDATE_APPLICANT_1_LANGUAGE);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateApplicant2LanguageTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateApplicant2LanguageTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.solicitor.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.solicitor.event.SolicitorUpdateApplicant2Language.SOLICITOR_UPDATE_APPLICANT_2_LANGUAGE;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+
+@ExtendWith(MockitoExtension.class)
+public class SolicitorUpdateApplicant2LanguageTest {
+
+    @InjectMocks
+    private SolicitorUpdateApplicant2Language solicitorUpdateApplicant2Language;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() {
+        final ConfigBuilderImpl<CaseData, State, UserRole> configBuilder = createCaseDataConfigBuilder();
+
+        solicitorUpdateApplicant2Language.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(SOLICITOR_UPDATE_APPLICANT_2_LANGUAGE);
+    }
+}


### PR DESCRIPTION
This PR adds separate events for Solicitor 1 and 2 to update their clients language preference and an event for caseworkers to update either applicants language preference