### PR TITLE
Fix service details page incorrect label displayed

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/Applicant2ServiceDetails.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/Applicant2ServiceDetails.java
@@ -34,7 +34,7 @@ public class Applicant2ServiceDetails implements CcdPageConfiguration {
                         .optional(OrganisationPolicy::getOrgPolicyReference, NEVER_SHOW)
                         .done()
                     .done()
-                .mandatoryWithLabel(Applicant::getHomeAddress, "applicant2SolicitorRepresented=\"No\"")
+                .mandatory(Applicant::getHomeAddress, "applicant2SolicitorRepresented=\"No\"")
                 .optional(Applicant::getEmail, "applicant2SolicitorRepresented=\"No\"")
                 .mandatory(Applicant::getCorrespondenceAddress, "applicant2SolicitorRepresented=\"No\"")
             .done();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/NFDIV-1082


### Change description ###
Fix service details page field that was displaying incorrect label