### PR TITLE
PBA Account number retrieval and payments using payments v2 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.5.3'
   id 'com.github.ben-manes.versions' version '0.38.0'
-  id 'hmcts.ccd.sdk' version '0.23.7'
+  id 'hmcts.ccd.sdk' version '0.23.8'
 }
 
 apply plugin: 'cz.habarta.typescript-generator'

--- a/charts/nfdiv-case-api/values.yaml
+++ b/charts/nfdiv-case-api/values.yaml
@@ -46,6 +46,7 @@ java:
     DOCUMENT_MANAGEMENT_URL: http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     PRD_API_BASEURL : "http://rd-professional-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     SEND_LETTER_SERVICE_BASEURL: "http://rpe-send-letter-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    PAYMENT_API_BASEURL: "http://payment-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     AWAITING_CONDITIONAL_ORDER_SCHEDULED_CRON: 0 0 0 * * ? # Midnight each day
     AOS_OVERDUE_SCHEDULED_CRON: 0 0 0 * * ? # Midnight each day
     JOINT_APPLICATION_OVERDUE_SCHEDULED_CRON: '0 0 10 * * ?' # 10am each day

--- a/src/functionalTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorPaymentMidEventCallbackTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorPaymentMidEventCallbackTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.divorce.solicitor;
+
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import uk.gov.hmcts.divorce.testutil.FunctionalTestSuite;
+
+import java.util.Map;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.OK;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+import static uk.gov.hmcts.divorce.divorcecase.search.CaseFieldsConstants.FINANCIAL_ORDER;
+import static uk.gov.hmcts.divorce.solicitor.event.SolicitorSubmitApplication.SOLICITOR_SUBMIT;
+import static uk.gov.hmcts.divorce.testutil.CaseDataUtil.caseData;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SOL_PAYMENT_MID_EVENT_URL;
+import static uk.gov.hmcts.divorce.testutil.TestResourceUtil.expectedResponse;
+
+@SpringBootTest
+public class SolicitorPaymentMidEventCallbackTest extends FunctionalTestSuite {
+
+    private static final String REQUEST = "classpath:request/casedata/ccd-callback-casedata.json";
+    private static final String LANGUAGE_PREFERENCE_WELSH = "languagePreferenceWelsh";
+
+    @Test
+    public void shouldRetrieveAndSetPbaNumbersWhenMidEventCallbackIsInvoked() throws Exception {
+        Map<String, Object> caseData = caseData(REQUEST);
+        caseData.put(LANGUAGE_PREFERENCE_WELSH, NO);
+        caseData.put(FINANCIAL_ORDER, NO);
+
+        Response response = triggerCallback(caseData, SOLICITOR_SUBMIT, SOL_PAYMENT_MID_EVENT_URL);
+
+        assertThat(response.getStatusCode()).isEqualTo(OK.value());
+
+        assertThatJson(response.asString())
+            .when(IGNORING_EXTRA_FIELDS)
+            .isEqualTo(json(expectedResponse(
+                "classpath:responses/response-solicitor-create-mid-event.json"
+            )));
+    }
+}

--- a/src/functionalTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorPaymentMidEventCallbackTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorPaymentMidEventCallbackTest.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.OK;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
@@ -36,9 +36,9 @@ public class SolicitorPaymentMidEventCallbackTest extends FunctionalTestSuite {
         assertThat(response.getStatusCode()).isEqualTo(OK.value());
 
         assertThatJson(response.asString())
-            .when(IGNORING_EXTRA_FIELDS)
+            .when(TREATING_NULL_AS_ABSENT)
             .isEqualTo(json(expectedResponse(
-                "classpath:responses/response-solicitor-create-mid-event.json"
+                "classpath:responses/response-solicitor-payment-mid-event.json"
             )));
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorSubmitApplicationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorSubmitApplicationTest.java
@@ -10,7 +10,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 import static org.skyscreamer.jsonassert.JSONCompareMode.STRICT;
@@ -80,7 +80,7 @@ public class SolicitorSubmitApplicationTest extends FunctionalTestSuite {
         assertThat(response.getStatusCode()).isEqualTo(OK.value());
 
         assertThatJson(response.asString())
-            .when(IGNORING_EXTRA_FIELDS)
+            .when(TREATING_NULL_AS_ABSENT)
             .isEqualTo(json(expectedResponse(VALID_ABOUT_TO_SUBMIT_RESPONSE)));
     }
 }

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -26,11 +26,11 @@ idam:
     url: ${IDAM_API_BASEURL:https://idam-api.aat.platform.hmcts.net}
   s2s-auth:
     url: ${TEST_S2S_URL:http://rpe-service-auth-provider-aat.service.core-compute-aat.internal}
-    secret: ${S2S_SECRET:dummy}
+    secret: HDNIOOGINKEIB5ZZ
     microservice: nfdiv_case_api
   solicitor:
-    username: ${IDAM_SOLICITOR_USERNAME:dummysolicitor@test.com}
-    password: ${IDAM_SOLICITOR_PASSWORD:dummy}
+    username: TEST_SOLICITOR@mailinator.com
+    password: genericPassword123
   caseworker:
     username: ${IDAM_CASEWORKER_USERNAME:dummycaseworker@test.com}
     password: ${IDAM_CASEWORKER_PASSWORD:dummy}
@@ -39,7 +39,7 @@ idam:
     password: ${IDAM_SYSTEM_UPDATE_PASSWORD:dummy}
   client:
     id: 'divorce'
-    secret: ${OAUTH2_CLIENT_SECRET:dummy}
+    secret: thUphEveC2Ekuqedaneh4jEcRuba4t2t
     redirect_uri: ${IDAM_API_REDIRECT_URL:http://localhost:3001/oauth2/callback}
 
 s2s-authorised:
@@ -91,3 +91,9 @@ court:
       postCode: 'CM20 9QT'
       email: 'divorcecase@justice.gov.uk'
       phoneNumber: '0300 303 0642'
+
+pba:
+  ref:
+    data:
+      service:
+        url: ${PRD_API_BASEURL:http://rd-professional-api-aat.service.core-compute-aat.internal}

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -26,11 +26,11 @@ idam:
     url: ${IDAM_API_BASEURL:https://idam-api.aat.platform.hmcts.net}
   s2s-auth:
     url: ${TEST_S2S_URL:http://rpe-service-auth-provider-aat.service.core-compute-aat.internal}
-    secret: HDNIOOGINKEIB5ZZ
+    secret: ${S2S_SECRET:dummy}
     microservice: nfdiv_case_api
   solicitor:
-    username: TEST_SOLICITOR@mailinator.com
-    password: genericPassword123
+    username: ${IDAM_SOLICITOR_USERNAME:dummysolicitor@test.com}
+    password: ${IDAM_SOLICITOR_PASSWORD:dummy}
   caseworker:
     username: ${IDAM_CASEWORKER_USERNAME:dummycaseworker@test.com}
     password: ${IDAM_CASEWORKER_PASSWORD:dummy}
@@ -39,7 +39,7 @@ idam:
     password: ${IDAM_SYSTEM_UPDATE_PASSWORD:dummy}
   client:
     id: 'divorce'
-    secret: thUphEveC2Ekuqedaneh4jEcRuba4t2t
+    secret: ${OAUTH2_CLIENT_SECRET:dummy}
     redirect_uri: ${IDAM_API_REDIRECT_URL:http://localhost:3001/oauth2/callback}
 
 s2s-authorised:

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -97,3 +97,9 @@ pba:
     data:
       service:
         url: ${PRD_API_BASEURL:http://rd-professional-api-aat.service.core-compute-aat.internal}
+
+
+payment:
+  service:
+    api:
+      baseurl: ${PAYMENT_API_BASEURL:http://payment-api-aat.service.core-compute-aat.internal}

--- a/src/functionalTest/resources/request/casedata/ccd-callback-casedata.json
+++ b/src/functionalTest/resources/request/casedata/ccd-callback-casedata.json
@@ -3,5 +3,6 @@
   "applicant1FirstName": "John",
   "applicant1LastName": "Smith",
   "applicant1Email": "simulate-delivered@notifications.service.gov.uk",
-  "applicant2Gender": "female"
+  "applicant2Gender": "female",
+  "solPaymentHowToPay": "feePayByAccount"
 }

--- a/src/functionalTest/resources/request/casedata/ccd-callback-solicitor-submit-application-about-to-submit.json
+++ b/src/functionalTest/resources/request/casedata/ccd-callback-solicitor-submit-application-about-to-submit.json
@@ -19,5 +19,32 @@
         }
       }
     ]
-  }
+  },
+  "solPaymentHowToPay": "feePayByAccount",
+  "pbaNumbers": {
+    "value": {
+      "code": "93018b67-a1af-4c1e-afa0-22de272bb5f2",
+      "label": "PBA0082311"
+    },
+    "list_items": [
+      {
+        "code": "93018b67-a1af-4c1e-afa0-22de272bb5f2",
+        "label": "PBA0082311"
+      },
+      {
+        "code": "93018b67-a1af-4c1e-afa0-22de272bb5f2",
+        "label": "PBA0087672"
+      }
+    ],
+    "valueLabel": null,
+    "valueCode": null
+  },
+  "applicant1SolicitorOrganisationPolicy": {
+    "Organisation": {
+      "OrganisationName": "Test 1 Organisation",
+      "OrganisationID": "ABC456"
+    }
+  },
+  "applicant1SolicitorReference": "customerRef1",
+  "selectedDivorceCentreSiteId": "AA04"
 }

--- a/src/functionalTest/resources/responses/response-solicitor-payment-mid-event.json
+++ b/src/functionalTest/resources/responses/response-solicitor-payment-mid-event.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "divorceOrDissolution": "divorce",
+    "applicant1FirstName": "John",
+    "applicant1LastName": "Smith",
+    "applicant1Email": "simulate-delivered@notifications.service.gov.uk",
+    "applicant1FinancialOrder": "No",
+    "applicant2Gender": "female",
+    "solPaymentHowToPay": "feePayByAccount",
+    "pbaNumbers": {
+      "value": null,
+      "list_items": [
+        {
+          "code": "${json-unit.any-string}",
+          "label": "PBA0082311"
+        },
+        {
+          "code": "${json-unit.any-string}",
+          "label": "PBA0087672"
+        }
+      ],
+      "valueLabel": null,
+      "valueCode": null
+    }
+  },
+  "errors": null,
+  "warnings": null,
+  "state": null
+}

--- a/src/functionalTest/resources/responses/response-solicitor-submit-application-about-to-submit.json
+++ b/src/functionalTest/resources/responses/response-solicitor-submit-application-about-to-submit.json
@@ -1,100 +1,74 @@
 {
   "data": {
     "divorceOrDissolution": "divorce",
-    "marriageApplicant1Name": null,
-    "marriageApplicant2Name": null,
     "applicant1FirstName": "John",
     "applicant1LastName": "Smith",
     "applicant1Email": "simulate-delivered@notifications.service.gov.uk",
-    "applicant1MiddleName": null,
-    "applicant1AgreedToReceiveEmails": null,
-    "applicant1NameChangedHow": null,
-    "applicant1NameDifferentToMarriageCertificate": null,
-    "applicant1LastNameChangedWhenMarried": null,
-    "applicant1PhoneNumber": null,
-    "applicant1NameChangedHowOtherDetails": null,
-    "applicant1LanguagePreferenceWelsh": null,
-    "applicant1ContactDetailsConfidential": null,
-    "applicant1Gender": null,
-    "applicant1CorrespondenceAddress": null,
-    "applicant1SolicitorRepresented": null,
-    "applicant2CorrespondenceAddress": null,
+    "applicant1SolicitorReference": "customerRef1",
     "applicant2SolicitorRepresented": "Yes",
-    "confirmReadPetition": null,
-    "jurisdictionAgree": null,
-    "jurisdictionDisagreeReason": null,
-    "legalProceedingsExist": null,
-    "legalProceedingsDescription": null,
-    "agreeToCosts": null,
-    "costsAmount": null,
-    "costsReason": null,
-    "dateAosSubmitted": null,
-    "applicant2Gender": null,
-    "applicant2FirstName": null,
-    "applicant2MiddleName": null,
-    "applicant2LastName": null,
-    "applicant2AgreedToReceiveEmails": null,
-    "applicant2Email": null,
-    "applicant2LanguagePreferenceWelsh": null,
-    "applicant2NameChangedHow": null,
-    "applicant2NameDifferentToMarriageCertificate": null,
-    "applicant2LastNameChangedWhenMarried": null,
-    "applicant2NameChangedHowOtherDetails": null,
-    "applicant2PhoneNumber": null,
-    "applicant2ContactDetailsConfidential": null,
-    "solSignStatementOfTruth": "Yes",
-    "applicant1HWFAppliedForFees": null,
-    "applicant1HWFReferenceNumber": null,
-    "applicant1HWFNeedHelp": null,
-    "jurisdictionApplicant1Residence": null,
-    "jurisdictionApplicant2Residence":null,
-    "jurisdictionApplicant1Domicile":null,
-    "jurisdictionApplicant2Domicile":null,
-    "jurisdictionApp1HabituallyResLastTwelveMonths":null,
-    "jurisdictionApp1HabituallyResLastSixMonths":null,
-    "jurisdictionResidualEligible":null,
-    "jurisdictionBothLastHabituallyResident":null,
-    "jurisdictionConnections": null,
-    "jurisdictionLegalConnections": null,
-    "marriageMarriedInUk":null,
-    "marriageCertificateInEnglish":null,
-    "marriageCertifiedTranslation":null,
-    "marriageCountryOfMarriage":null,
-    "marriagePlaceOfMarriage":null,
-    "marriageDate":null,
-    "marriageIsSameSexCouple":null,
-    "marriageCertifyMarriageCertificateIsCorrect": null,
-    "marriageMarriageCertificateIsIncorrectDetails": null,
-    "marriageIssueApplicationWithoutMarriageCertificate": null,
-    "dateSubmitted": "${json-unit.ignore}",
+    "applicant1SolicitorOrganisationPolicy": {
+      "Organisation": {
+        "OrganisationName": "Test 1 Organisation",
+        "OrganisationID": "ABC456"
+      }
+    },
     "applicant1WantsToHavePapersServedAnotherWay": "No",
+    "solPaymentHowToPay": "feePayByAccount",
+    "pbaNumbers": {
+      "value": {
+        "code": "93018b67-a1af-4c1e-afa0-22de272bb5f2",
+        "label": "PBA0082311"
+      },
+      "list_items": [
+        {
+          "code": "93018b67-a1af-4c1e-afa0-22de272bb5f2",
+          "label": "PBA0082311"
+        },
+        {
+          "code": "93018b67-a1af-4c1e-afa0-22de272bb5f2",
+          "label": "PBA0087672"
+        }
+      ],
+      "valueLabel": "PBA0082311",
+      "valueCode": "93018b67-a1af-4c1e-afa0-22de272bb5f2"
+    },
     "applicationFeeOrderSummary": {
-      "PaymentTotal": "55000",
       "PaymentReference": null,
       "Fees": [
         {
           "id": null,
           "value": {
-            "FeeDescription": "Filing an application for a divorce, nullity or civil partnership dissolution",
-            "FeeVersion": "5",
+            "FeeAmount": "55000",
             "FeeCode": "FEE0002",
-            "FeeAmount": "55000"
+            "FeeDescription": "Filing an application for a divorce, nullity or civil partnership dissolution",
+            "FeeVersion": "5"
           }
         }
-      ]
+      ],
+      "PaymentTotal": "55000"
     },
-    "applicationPayments": [{
-      "id": null,
-      "value": {
-        "created": null,
-        "feeCode": "FEE0001",
-        "amount": 55000,
-        "status": "success",
-        "channel": "online",
-        "reference": null,
-        "transactionId": "ge7po9h5bhbtbd466424src9tk"
+    "app2ContactMethodIsDigital": "Yes",
+    "dateSubmitted": "${json-unit.any-string}",
+    "applicant2ConfirmApplicant1Information": null,
+    "applicant2ExplainsApplicant1IncorrectInformation": null,
+    "solSignStatementOfTruth": "Yes",
+    "applicationPayments": [
+      {
+        "id": "${json-unit.any-string}",
+        "value": {
+          "created": null,
+          "updated": null,
+          "feeCode": "FEE0002",
+          "amount": 55000,
+          "status": "success",
+          "channel": "online",
+          "reference": "${json-unit.any-string}",
+          "transactionId": null
+        }
       }
-    }]
+    ],
+    "selectedDivorceCentreSiteId": "AA04",
+    "dueDate": "2021-09-02"
   },
   "errors": null,
   "warnings": null,

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorSubmitApplicationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorSubmitApplicationTest.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,7 +17,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.divorce.common.config.WebMvcConfig;
 import uk.gov.hmcts.divorce.notification.NotificationService;
 import uk.gov.hmcts.divorce.payment.model.CreditAccountPaymentResponse;
-import uk.gov.hmcts.divorce.payment.model.PaymentStatus;
 import uk.gov.hmcts.divorce.testutil.CaseDataWireMock;
 import uk.gov.hmcts.divorce.testutil.FeesWireMock;
 import uk.gov.hmcts.divorce.testutil.IdamWireMock;
@@ -30,7 +28,7 @@ import java.io.IOException;
 import static java.util.Objects.requireNonNull;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -38,6 +36,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -46,6 +45,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
 import static uk.gov.hmcts.divorce.divorcecase.model.SolicitorPaymentMethod.FEE_PAY_BY_ACCOUNT;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Draft;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.SOL_APPLICANT_SOLICITOR_APPLICATION_SUBMITTED;
+import static uk.gov.hmcts.divorce.payment.model.PaymentStatus.SUCCESS;
 import static uk.gov.hmcts.divorce.solicitor.event.SolicitorSubmitApplication.SOLICITOR_SUBMIT;
 import static uk.gov.hmcts.divorce.testutil.CaseDataWireMock.stubForCcdCaseRoles;
 import static uk.gov.hmcts.divorce.testutil.CaseDataWireMock.stubForCcdCaseRolesUpdateFailure;
@@ -232,10 +232,10 @@ public class SolicitorSubmitApplicationTest {
         throws Exception {
 
         stubCreditAccountPayment(
-            HttpStatus.CREATED,
+            CREATED,
             CreditAccountPaymentResponse
                 .builder()
-                .status(PaymentStatus.SUCCESS.toString())
+                .status(SUCCESS.toString())
                 .caseReference(TEST_CASE_ID.toString())
                 .build()
         );
@@ -262,7 +262,7 @@ public class SolicitorSubmitApplicationTest {
             .andReturn();
 
         assertThatJson(mvcResult.getResponse().getContentAsString())
-            .when(TREATING_NULL_AS_ABSENT)
+            .when(IGNORING_EXTRA_FIELDS)
             .isEqualTo(json(expectedCcdAboutToSubmitCallbackResponse()));
 
         verify(notificationService)

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorSubmitApplicationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorSubmitApplicationTest.java
@@ -10,19 +10,27 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.divorce.common.config.WebMvcConfig;
 import uk.gov.hmcts.divorce.notification.NotificationService;
+import uk.gov.hmcts.divorce.payment.model.CreditAccountPaymentResponse;
+import uk.gov.hmcts.divorce.payment.model.PaymentStatus;
 import uk.gov.hmcts.divorce.testutil.CaseDataWireMock;
 import uk.gov.hmcts.divorce.testutil.FeesWireMock;
 import uk.gov.hmcts.divorce.testutil.IdamWireMock;
+import uk.gov.hmcts.divorce.testutil.PaymentWireMock;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 
 import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -35,6 +43,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
+import static uk.gov.hmcts.divorce.divorcecase.model.SolicitorPaymentMethod.FEE_PAY_BY_ACCOUNT;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Draft;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.SOL_APPLICANT_SOLICITOR_APPLICATION_SUBMITTED;
 import static uk.gov.hmcts.divorce.solicitor.event.SolicitorSubmitApplication.SOLICITOR_SUBMIT;
@@ -48,6 +57,7 @@ import static uk.gov.hmcts.divorce.testutil.IdamWireMock.SYSTEM_USER_ROLE;
 import static uk.gov.hmcts.divorce.testutil.IdamWireMock.stubForIdamDetails;
 import static uk.gov.hmcts.divorce.testutil.IdamWireMock.stubForIdamFailure;
 import static uk.gov.hmcts.divorce.testutil.IdamWireMock.stubForIdamToken;
+import static uk.gov.hmcts.divorce.testutil.PaymentWireMock.stubCreditAccountPayment;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.ABOUT_TO_START_URL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.ABOUT_TO_SUBMIT_URL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.AUTHORIZATION;
@@ -59,11 +69,16 @@ import static uk.gov.hmcts.divorce.testutil.TestConstants.SOLICITOR_USER_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_USER_USER_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_AUTHORIZATION_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SERVICE_AUTH_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.callbackRequest;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseDataWithOrderSummary;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseDataWithStatementOfTruth;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getFeeResponseAsJson;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getPbaNumbersForAccount;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.orderSummaryWithFee;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.organisationPolicy;
 import static uk.gov.hmcts.divorce.testutil.TestResourceUtil.expectedResponse;
 
 @ExtendWith(SpringExtension.class)
@@ -72,7 +87,8 @@ import static uk.gov.hmcts.divorce.testutil.TestResourceUtil.expectedResponse;
 @ContextConfiguration(initializers = {
     FeesWireMock.PropertiesInitializer.class,
     IdamWireMock.PropertiesInitializer.class,
-    CaseDataWireMock.PropertiesInitializer.class})
+    CaseDataWireMock.PropertiesInitializer.class,
+    PaymentWireMock.PropertiesInitializer.class})
 public class SolicitorSubmitApplicationTest {
 
     @Autowired
@@ -95,6 +111,7 @@ public class SolicitorSubmitApplicationTest {
         IdamWireMock.start();
         CaseDataWireMock.start();
         FeesWireMock.start();
+        PaymentWireMock.start();
     }
 
     @AfterAll
@@ -102,6 +119,7 @@ public class SolicitorSubmitApplicationTest {
         IdamWireMock.stopAndReset();
         CaseDataWireMock.stopAndReset();
         FeesWireMock.stopAndReset();
+        PaymentWireMock.stopAndReset();
     }
 
     @Test
@@ -118,11 +136,11 @@ public class SolicitorSubmitApplicationTest {
         stubForCcdCaseRoles();
 
         mockMvc.perform(post(ABOUT_TO_START_URL)
-            .contentType(APPLICATION_JSON)
-            .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
-            .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
-            .content(objectMapper.writeValueAsString(callbackRequest(caseDataWithOrderSummary(), SOLICITOR_SUBMIT)))
-            .accept(APPLICATION_JSON))
+                .contentType(APPLICATION_JSON)
+                .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
+                .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
+                .content(objectMapper.writeValueAsString(callbackRequest(caseDataWithOrderSummary(), SOLICITOR_SUBMIT)))
+                .accept(APPLICATION_JSON))
             .andExpect(
                 status().isOk()
             )
@@ -140,11 +158,11 @@ public class SolicitorSubmitApplicationTest {
         stubForFeesNotFound();
 
         mockMvc.perform(post(ABOUT_TO_START_URL)
-            .contentType(APPLICATION_JSON)
-            .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
-            .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
-            .content(objectMapper.writeValueAsString(callbackRequest(caseDataWithOrderSummary(), SOLICITOR_SUBMIT)))
-            .accept(APPLICATION_JSON))
+                .contentType(APPLICATION_JSON)
+                .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
+                .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
+                .content(objectMapper.writeValueAsString(callbackRequest(caseDataWithOrderSummary(), SOLICITOR_SUBMIT)))
+                .accept(APPLICATION_JSON))
             .andExpect(
                 status().isNotFound()
             )
@@ -165,11 +183,11 @@ public class SolicitorSubmitApplicationTest {
         stubForIdamFailure();
 
         mockMvc.perform(post(ABOUT_TO_START_URL)
-            .contentType(APPLICATION_JSON)
-            .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
-            .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
-            .content(objectMapper.writeValueAsString(callbackRequest(caseDataWithOrderSummary(), SOLICITOR_SUBMIT)))
-            .accept(APPLICATION_JSON))
+                .contentType(APPLICATION_JSON)
+                .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
+                .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
+                .content(objectMapper.writeValueAsString(callbackRequest(caseDataWithOrderSummary(), SOLICITOR_SUBMIT)))
+                .accept(APPLICATION_JSON))
             .andExpect(
                 status().isUnauthorized()
             )
@@ -196,11 +214,11 @@ public class SolicitorSubmitApplicationTest {
         stubForCcdCaseRolesUpdateFailure();
 
         mockMvc.perform(post(ABOUT_TO_START_URL)
-            .contentType(APPLICATION_JSON)
-            .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
-            .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
-            .content(objectMapper.writeValueAsString(callbackRequest(caseDataWithOrderSummary(), SOLICITOR_SUBMIT)))
-            .accept(APPLICATION_JSON))
+                .contentType(APPLICATION_JSON)
+                .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
+                .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
+                .content(objectMapper.writeValueAsString(callbackRequest(caseDataWithOrderSummary(), SOLICITOR_SUBMIT)))
+                .accept(APPLICATION_JSON))
             .andExpect(
                 status().isForbidden()
             )
@@ -212,24 +230,40 @@ public class SolicitorSubmitApplicationTest {
     @Test
     void givenValidCaseDataWhenAboutToSubmitCallbackIsInvokedThenStateIsChangedAndEmailIsSentToApplicant()
         throws Exception {
+
+        stubCreditAccountPayment(
+            HttpStatus.CREATED,
+            CreditAccountPaymentResponse
+                .builder()
+                .status(PaymentStatus.SUCCESS.toString())
+                .caseReference(TEST_CASE_ID.toString())
+                .build()
+        );
+
         var data = caseDataWithStatementOfTruth();
         data.getApplication().setApplicationPayments(null);
+        data.getApplication().setSolPaymentHowToPay(FEE_PAY_BY_ACCOUNT);
+        data.getApplication().setPbaNumbers(getPbaNumbersForAccount("PBA0012345"));
+        data.getApplication().setApplicationFeeOrderSummary(orderSummaryWithFee());
+        data.getApplicant1().getSolicitor().setOrganisationPolicy(organisationPolicy());
 
-        mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
-            .contentType(APPLICATION_JSON)
-            .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
-            .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
-            .content(objectMapper.writeValueAsString(callbackRequest(
-                data,
-                SOLICITOR_SUBMIT,
-                Draft.name())))
-            .accept(APPLICATION_JSON))
+        MvcResult mvcResult = mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
+                .contentType(APPLICATION_JSON)
+                .header(SERVICE_AUTHORIZATION, TEST_SERVICE_AUTH_TOKEN)
+                .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
+                .content(objectMapper.writeValueAsString(callbackRequest(
+                    data,
+                    SOLICITOR_SUBMIT,
+                    Draft.name())))
+                .accept(APPLICATION_JSON))
             .andExpect(
                 status().isOk()
             )
-            .andExpect(
-                content().json(expectedCcdAboutToSubmitCallbackResponse())
-            );
+            .andReturn();
+
+        assertThatJson(mvcResult.getResponse().getContentAsString())
+            .when(TREATING_NULL_AS_ABSENT)
+            .isEqualTo(json(expectedCcdAboutToSubmitCallbackResponse()));
 
         verify(notificationService)
             .sendEmail(
@@ -246,14 +280,14 @@ public class SolicitorSubmitApplicationTest {
         throws Exception {
 
         mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
-            .contentType(APPLICATION_JSON)
-            .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
-            .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
-            .content(objectMapper.writeValueAsString(callbackRequest(
-                caseDataWithOrderSummary(),
-                SOLICITOR_SUBMIT,
-                Draft.name())))
-            .accept(APPLICATION_JSON))
+                .contentType(APPLICATION_JSON)
+                .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
+                .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
+                .content(objectMapper.writeValueAsString(callbackRequest(
+                    caseDataWithOrderSummary(),
+                    SOLICITOR_SUBMIT,
+                    Draft.name())))
+                .accept(APPLICATION_JSON))
             .andExpect(
                 status().isOk()
             )

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/testutil/FeesWireMock.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/testutil/FeesWireMock.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.divorce.testutil;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ApplicationContextInitializer;
@@ -34,7 +33,7 @@ public final class FeesWireMock {
         }
     }
 
-    public static void stubForFeesLookup(final String feeResponse) throws JsonProcessingException {
+    public static void stubForFeesLookup(final String feeResponse) {
         FEES_SERVER.stubFor(get("/fees-register/fees/lookup"
             + "?channel=default&event=issue&jurisdiction1=family&jurisdiction2=family+court&service=divorce")
             .willReturn(aResponse()

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/testutil/PaymentWireMock.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/testutil/PaymentWireMock.java
@@ -1,0 +1,105 @@
+package uk.gov.hmcts.divorce.testutil;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.http.HttpStatus;
+import uk.gov.hmcts.ccd.sdk.type.Fee;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.ccd.sdk.type.OrderSummary;
+import uk.gov.hmcts.divorce.payment.model.CreditAccountPaymentRequest;
+import uk.gov.hmcts.divorce.payment.model.CreditAccountPaymentResponse;
+import uk.gov.hmcts.divorce.payment.model.PaymentItem;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.util.Collections.singletonList;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_AUTHORIZATION_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.orderSummaryWithFee;
+
+public final class PaymentWireMock {
+
+    private static final WireMockServer PAYMENTS_SERVER = new WireMockServer(wireMockConfig().dynamicPort());
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private PaymentWireMock() {
+    }
+
+    public static void start() {
+        if (!PAYMENTS_SERVER.isRunning()) {
+            PAYMENTS_SERVER.start();
+        }
+    }
+
+    public static void stopAndReset() {
+        if (PAYMENTS_SERVER.isRunning()) {
+            PAYMENTS_SERVER.stop();
+            PAYMENTS_SERVER.resetAll();
+        }
+    }
+
+    public static void stubCreditAccountPayment(HttpStatus status, CreditAccountPaymentResponse response) throws JsonProcessingException {
+
+        var orderSummary = orderSummaryWithFee();
+        CreditAccountPaymentRequest request = getCreditAccountPaymentRequest(orderSummary);
+
+        PAYMENTS_SERVER.stubFor(post("/credit-account-payments")
+            .withHeader(AUTHORIZATION, new EqualToPattern(TEST_AUTHORIZATION_TOKEN))
+            // .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern(TEST_SERVICE_AUTH_TOKEN))
+            .withRequestBody(equalToJson(OBJECT_MAPPER.writeValueAsString(request)))
+            .willReturn(aResponse()
+                .withStatus(status.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .withBody(OBJECT_MAPPER.writeValueAsString(response))));
+    }
+
+    public static class PropertiesInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+        @Override
+        public void initialize(ConfigurableApplicationContext applicationContext) {
+            TestPropertyValues
+                .of("payment.service.api.baseurl=" + "http://localhost:" + PAYMENTS_SERVER.port())
+                .applyTo(applicationContext.getEnvironment());
+        }
+    }
+
+    private static CreditAccountPaymentRequest getCreditAccountPaymentRequest(OrderSummary orderSummary) {
+        var request = new CreditAccountPaymentRequest();
+        request.setService("divorce");
+        request.setCurrency("GBP");
+        request.setAmount(orderSummary.getPaymentTotal());
+        request.setCcdCaseNumber(TEST_CASE_ID.toString());
+        request.setAccountNumber("PBA0012345");
+        request.setOrganisationName("Test Organisation");
+        request.setDescription("fees for divorce");
+
+        ListValue<Fee> feeItem = orderSummary.getFees().get(0);
+        Fee fee = feeItem.getValue();
+
+        PaymentItem paymentItem = getPaymentItem(orderSummary, fee);
+
+        request.setFees(singletonList(paymentItem));
+
+        return request;
+    }
+
+    private static PaymentItem getPaymentItem(OrderSummary orderSummary, Fee fee) {
+        return PaymentItem
+            .builder()
+            .ccdCaseNumber(String.valueOf(TEST_CASE_ID))
+            .calculatedAmount(orderSummary.getPaymentTotal())
+            .code(fee.getCode())
+            .version(fee.getVersion())
+            .build();
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/testutil/PaymentWireMock.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/testutil/PaymentWireMock.java
@@ -75,7 +75,7 @@ public final class PaymentWireMock {
 
     private static CreditAccountPaymentRequest getCreditAccountPaymentRequest(OrderSummary orderSummary) {
         var request = new CreditAccountPaymentRequest();
-        request.setService("divorce");
+        request.setService("DIVORCE");
         request.setCurrency("GBP");
         request.setAmount(orderSummary.getPaymentTotal());
         request.setCcdCaseNumber(TEST_CASE_ID.toString());

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -105,3 +105,9 @@ court:
       postCode: 'CM20 9QT'
       email: 'divorcecase@justice.gov.uk'
       phoneNumber: '0300 303 0642'
+
+pba:
+  ref:
+    data:
+      service:
+        url: ${PRD_API_BASEURL:http://rd-professional-api-aat.service.core-compute-aat.internal}

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -111,3 +111,9 @@ pba:
     data:
       service:
         url: ${PRD_API_BASEURL:http://rd-professional-api-aat.service.core-compute-aat.internal}
+
+
+payment:
+  service:
+    api:
+      baseurl: http://localhost:4015

--- a/src/integrationTest/resources/wiremock/responses/about-to-submit-statement-of-truth.json
+++ b/src/integrationTest/resources/wiremock/responses/about-to-submit-statement-of-truth.json
@@ -7,10 +7,9 @@
     "applicant1LastName": "test_last_name",
     "applicant1Email": "test@test.com",
     "applicant1LanguagePreferenceWelsh": "No",
-    "solicitorPaymentMethodPba": true,
-    "applicant1SolicitorEmail": "solicitor@test.com",
     "applicant1ContactDetailsConfidential": "share",
     "applicant1Gender": "female",
+    "applicant1SolicitorEmail": "solicitor@test.com",
     "applicant1SolicitorOrganisationPolicy": {
       "Organisation": {
         "OrganisationName": "Test Organisation",
@@ -22,14 +21,13 @@
     "solPaymentHowToPay": "feePayByAccount",
     "pbaNumbers": {
       "value": {
-        "code": "${json-unit.ignore}",
+        "code": "${json-unit.any-string}",
         "label": "PBA0012345"
       },
       "list_items": null,
       "valueLabel": "PBA0012345",
-      "valueCode": "${json-unit.ignore}"
+      "valueCode": "${json-unit.any-string}"
     },
-    "feeAccountReference": null,
     "applicationFeeOrderSummary": {
       "PaymentReference": null,
       "Fees": [
@@ -46,10 +44,10 @@
       "PaymentTotal": "55000"
     },
     "app2ContactMethodIsDigital": "Yes",
-    "dateSubmitted": "${json-unit.ignore}",
+    "dateSubmitted": "${json-unit.any-string}",
     "applicationPayments": [
       {
-        "id": "${json-unit.ignore}",
+        "id": "${json-unit.any-string}",
         "value": {
           "created": null,
           "updated": null,

--- a/src/integrationTest/resources/wiremock/responses/about-to-submit-statement-of-truth.json
+++ b/src/integrationTest/resources/wiremock/responses/about-to-submit-statement-of-truth.json
@@ -1,11 +1,68 @@
 {
   "data": {
     "divorceOrDissolution": "divorce",
+    "labelContentUnionType": "dissolution",
     "applicant1FirstName": "test_first_name",
+    "applicant1MiddleName": "test_middle_name",
     "applicant1LastName": "test_last_name",
     "applicant1Email": "test@test.com",
+    "applicant1LanguagePreferenceWelsh": "No",
+    "solicitorPaymentMethodPba": true,
     "applicant1SolicitorEmail": "solicitor@test.com",
-    "solSignStatementOfTruth": "Yes"
+    "applicant1ContactDetailsConfidential": "share",
+    "applicant1Gender": "female",
+    "applicant1SolicitorOrganisationPolicy": {
+      "Organisation": {
+        "OrganisationName": "Test Organisation",
+        "OrganisationID": "ABC123"
+      }
+    },
+    "applicant2SolicitorRepresented": "Yes",
+    "solSignStatementOfTruth": "Yes",
+    "solPaymentHowToPay": "feePayByAccount",
+    "pbaNumbers": {
+      "value": {
+        "code": "${json-unit.ignore}",
+        "label": "PBA0012345"
+      },
+      "list_items": null,
+      "valueLabel": "PBA0012345",
+      "valueCode": "${json-unit.ignore}"
+    },
+    "feeAccountReference": null,
+    "applicationFeeOrderSummary": {
+      "PaymentReference": null,
+      "Fees": [
+        {
+          "id": null,
+          "value": {
+            "FeeAmount": "550",
+            "FeeCode": "FEE002",
+            "FeeDescription": "fees for divorce",
+            "FeeVersion": null
+          }
+        }
+      ],
+      "PaymentTotal": "55000"
+    },
+    "app2ContactMethodIsDigital": "Yes",
+    "dateSubmitted": "${json-unit.ignore}",
+    "applicationPayments": [
+      {
+        "id": "${json-unit.ignore}",
+        "value": {
+          "created": null,
+          "updated": null,
+          "feeCode": "FEE002",
+          "amount": 55000,
+          "status": "success",
+          "channel": "online",
+          "reference": null,
+          "transactionId": null
+        }
+      }
+    ],
+    "dueDate": "2021-09-02"
   },
   "errors": null,
   "warnings": null,

--- a/src/main/java/uk/gov/hmcts/divorce/CaseApiApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/CaseApiApplication.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.divorce.document.DocAssemblyClient;
 import uk.gov.hmcts.divorce.document.DocumentManagementClient;
 import uk.gov.hmcts.divorce.payment.FeesAndPaymentsClient;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationClient;
+import uk.gov.hmcts.divorce.solicitor.client.pba.PbaRefDataClient;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.ccd.client.CaseUserApi;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
@@ -27,7 +28,8 @@ import uk.gov.hmcts.reform.idam.client.IdamApi;
         DocAssemblyClient.class,
         CoreCaseDataApi.class,
         DocumentManagementClient.class,
-        OrganisationClient.class
+        OrganisationClient.class,
+        PbaRefDataClient.class
     }
 )
 @EnableScheduling

--- a/src/main/java/uk/gov/hmcts/divorce/CaseApiApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/CaseApiApplication.java
@@ -7,6 +7,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import uk.gov.hmcts.divorce.document.DocAssemblyClient;
 import uk.gov.hmcts.divorce.document.DocumentManagementClient;
 import uk.gov.hmcts.divorce.payment.FeesAndPaymentsClient;
+import uk.gov.hmcts.divorce.payment.PaymentPbaClient;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationClient;
 import uk.gov.hmcts.divorce.solicitor.client.pba.PbaRefDataClient;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
@@ -29,7 +30,8 @@ import uk.gov.hmcts.reform.idam.client.IdamApi;
         CoreCaseDataApi.class,
         DocumentManagementClient.class,
         OrganisationClient.class,
-        PbaRefDataClient.class
+        PbaRefDataClient.class,
+        PaymentPbaClient.class
     }
 )
 @EnableScheduling

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Application.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Application.java
@@ -33,6 +33,7 @@ import static uk.gov.hmcts.ccd.sdk.type.FieldType.TextArea;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.ServiceMethod.SOLICITOR_SERVICE;
 import static uk.gov.hmcts.divorce.divorcecase.model.SolicitorPaymentMethod.FEES_HELP_WITH;
+import static uk.gov.hmcts.divorce.divorcecase.model.SolicitorPaymentMethod.FEE_PAY_BY_ACCOUNT;
 import static uk.gov.hmcts.divorce.payment.model.PaymentStatus.SUCCESS;
 
 @Data
@@ -406,5 +407,9 @@ public class Application {
     @JsonIgnore
     public boolean isSolicitorApplication() {
         return hasSolSignStatementOfTruth();
+    }
+
+    public boolean isSolicitorPaymentMethodPba() {
+        return FEE_PAY_BY_ACCOUNT.equals(this.getSolPaymentHowToPay());
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Application.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Application.java
@@ -409,6 +409,7 @@ public class Application {
         return hasSolSignStatementOfTruth();
     }
 
+    @JsonIgnore
     public boolean isSolicitorPaymentMethodPba() {
         return FEE_PAY_BY_ACCOUNT.equals(this.getSolPaymentHowToPay());
     }

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/State.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/State.java
@@ -8,7 +8,6 @@ import uk.gov.hmcts.divorce.divorcecase.model.access.CaseAccessAdministrator;
 import java.util.ArrayList;
 import java.util.List;
 
-import static uk.gov.hmcts.divorce.divorcecase.validation.ValidationUtil.isPaymentIncomplete;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ValidationUtil.validateApplicant1BasicCase;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ValidationUtil.validateApplicant2BasicCase;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ValidationUtil.validateApplicant2RequestChanges;
@@ -241,10 +240,6 @@ public enum State {
         @Override
         public List<String> validate(CaseData caseData) {
             List<String> errors = new ArrayList<>();
-
-            if (isPaymentIncomplete(caseData)) {
-                errors.add("Payment incomplete");
-            }
 
             if (!caseData.getApplication().applicant1HasStatementOfTruth() && !caseData.getApplication().hasSolSignStatementOfTruth()) {
                 errors.add("Statement of truth must be accepted by the person making the application");

--- a/src/main/java/uk/gov/hmcts/divorce/payment/FeesAndPaymentsClient.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/FeesAndPaymentsClient.java
@@ -2,12 +2,19 @@ package uk.gov.hmcts.divorce.payment;
 
 import io.swagger.annotations.ApiOperation;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
+import uk.gov.hmcts.divorce.payment.model.CreditAccountPaymentRequest;
+import uk.gov.hmcts.divorce.payment.model.CreditAccountPaymentResponse;
 import uk.gov.hmcts.divorce.payment.model.FeeResponse;
 
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.divorce.common.config.ControllerConstants.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.divorce.payment.FeesAndPayConstants.CHANNEL;
 import static uk.gov.hmcts.divorce.payment.FeesAndPayConstants.EVENT;
 import static uk.gov.hmcts.divorce.payment.FeesAndPayConstants.JURISDICTION_1;
@@ -30,4 +37,12 @@ public interface FeesAndPaymentsClient {
         @RequestParam(SERVICE) final String service,
         @RequestParam(KEYWORD) final String keyword
     );
+
+    @ApiOperation("Handles Solicitor Payment By Account (PBA) Payments")
+    @PostMapping(value = "/credit-account-payments")
+    ResponseEntity<CreditAccountPaymentResponse> creditAccountPayment(
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
+        @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
+        CreditAccountPaymentRequest creditAccountPaymentRequest);
+
 }

--- a/src/main/java/uk/gov/hmcts/divorce/payment/FeesAndPaymentsClient.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/FeesAndPaymentsClient.java
@@ -2,19 +2,12 @@ package uk.gov.hmcts.divorce.payment;
 
 import io.swagger.annotations.ApiOperation;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
-import uk.gov.hmcts.divorce.payment.model.CreditAccountPaymentRequest;
-import uk.gov.hmcts.divorce.payment.model.CreditAccountPaymentResponse;
 import uk.gov.hmcts.divorce.payment.model.FeeResponse;
 
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static uk.gov.hmcts.divorce.common.config.ControllerConstants.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.divorce.payment.FeesAndPayConstants.CHANNEL;
 import static uk.gov.hmcts.divorce.payment.FeesAndPayConstants.EVENT;
 import static uk.gov.hmcts.divorce.payment.FeesAndPayConstants.JURISDICTION_1;
@@ -37,12 +30,4 @@ public interface FeesAndPaymentsClient {
         @RequestParam(SERVICE) final String service,
         @RequestParam(KEYWORD) final String keyword
     );
-
-    @ApiOperation("Handles Solicitor Payment By Account (PBA) Payments")
-    @PostMapping(value = "/credit-account-payments")
-    ResponseEntity<CreditAccountPaymentResponse> creditAccountPayment(
-        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
-        @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
-        CreditAccountPaymentRequest creditAccountPaymentRequest);
-
 }

--- a/src/main/java/uk/gov/hmcts/divorce/payment/PaymentPbaClient.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/PaymentPbaClient.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.divorce.payment;
+
+import io.swagger.annotations.ApiOperation;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import uk.gov.hmcts.divorce.payment.model.CreditAccountPaymentRequest;
+import uk.gov.hmcts.divorce.payment.model.CreditAccountPaymentResponse;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static uk.gov.hmcts.divorce.common.config.ControllerConstants.SERVICE_AUTHORIZATION;
+
+@FeignClient(name = "fees-and-payments-client", url = "${payment.service.api.baseurl}")
+@SuppressWarnings("PMD.UseObjectForClearerAPI")
+public interface PaymentPbaClient {
+
+    @ApiOperation("Handles Solicitor Payment By Account (PBA) Payments")
+    @PostMapping(value = "/credit-account-payments")
+    ResponseEntity<CreditAccountPaymentResponse> creditAccountPayment(
+        @RequestHeader(AUTHORIZATION) String authorisation,
+        @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
+        CreditAccountPaymentRequest creditAccountPaymentRequest);
+
+}

--- a/src/main/java/uk/gov/hmcts/divorce/payment/PaymentService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/PaymentService.java
@@ -1,16 +1,38 @@
 package uk.gov.hmcts.divorce.payment;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.sdk.type.Fee;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.ccd.sdk.type.OrderSummary;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
+import uk.gov.hmcts.divorce.payment.model.CreditAccountPaymentRequest;
+import uk.gov.hmcts.divorce.payment.model.CreditAccountPaymentResponse;
 import uk.gov.hmcts.divorce.payment.model.FeeResponse;
+import uk.gov.hmcts.divorce.payment.model.PaymentItem;
+import uk.gov.hmcts.divorce.payment.model.PbaErrorMessage;
+import uk.gov.hmcts.divorce.payment.model.PbaResponse;
+import uk.gov.hmcts.divorce.payment.model.StatusHistoriesItem;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 
 import static java.util.Collections.singletonList;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.util.CollectionUtils.isEmpty;
 import static uk.gov.hmcts.ccd.sdk.type.Fee.getValueInPence;
 
 @Service
+@Slf4j
 public class PaymentService {
 
     private static final String DEFAULT_CHANNEL = "default";
@@ -18,9 +40,21 @@ public class PaymentService {
     private static final String FAMILY = "family";
     private static final String FAMILY_COURT = "family court";
     private static final String DIVORCE = "divorce";
+    public static final String GBP = "GBP";
+    private static final String CAE0001 = "CA-E0001";
+    private static final String CAE0004 = "CA-E0004";
+
+    @Autowired
+    private HttpServletRequest httpServletRequest;
 
     @Autowired
     private FeesAndPaymentsClient feesAndPaymentsClient;
+
+    @Autowired
+    private AuthTokenGenerator authTokenGenerator;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     public OrderSummary getOrderSummary() {
         final var feeResponse = feesAndPaymentsClient.getApplicationIssueFee(
@@ -52,5 +86,149 @@ public class PaymentService {
                     .build()
             )
             .build();
+    }
+
+    public PbaResponse processPbaPayment(CaseData caseData, Long caseId) {
+        log.info("Processing PBA payment for case id {}", caseId);
+
+        feesAndPaymentsClient.creditAccountPayment(
+            httpServletRequest.getHeader(AUTHORIZATION),
+            authTokenGenerator.generate(),
+            creditAccountPaymentRequest(caseData, caseId)
+        );
+
+        ResponseEntity<CreditAccountPaymentResponse> paymentResponseResponseEntity = null;
+
+        String pbaNumber = getPbaNumber(caseData);
+
+        String errorMessage = null;
+        try {
+            paymentResponseResponseEntity = feesAndPaymentsClient.creditAccountPayment(
+                httpServletRequest.getHeader(AUTHORIZATION),
+                authTokenGenerator.generate(),
+                creditAccountPaymentRequest(caseData, caseId)
+            );
+        } catch (FeignException exception) {
+            log.error("For case id {} unsuccessful payment for account number {} with exception {}",
+                caseId,
+                getPbaNumber(caseData),
+                exception.getMessage()
+            );
+            return getPbaErrorResponse(pbaNumber, exception);
+        }
+
+        log.info("For case id {} successfully processed PBA payment for account number {}",
+            caseId,
+            getPbaNumber(caseData)
+        );
+
+        return new PbaResponse(paymentResponseResponseEntity.getStatusCode(), null);
+    }
+
+    private PbaResponse getPbaErrorResponse(String pbaNumber, FeignException exception) {
+        String errorMessage = null;
+        HttpStatus httpStatus = Optional.ofNullable(HttpStatus.resolve(exception.status()))
+            .orElseGet(() -> HttpStatus.INTERNAL_SERVER_ERROR);
+
+        CreditAccountPaymentResponse creditAccountPaymentResponse = null;
+        try {
+            creditAccountPaymentResponse = objectMapper.readValue(
+                exception.contentUTF8().getBytes(),
+                CreditAccountPaymentResponse.class
+            );
+        } catch (IOException ioException) {
+            log.warn("Could not convert error response to CreditAccountPaymentResponse object. Error message was {}",
+                exception.contentUTF8()
+            );
+            errorMessage = PbaErrorMessage.GENERAL.value();
+        }
+
+        List<StatusHistoriesItem> statusHistories = creditAccountPaymentResponse.getStatusHistories();
+
+        if (isEmpty(statusHistories)) {
+            return new PbaResponse(httpStatus, PbaErrorMessage.GENERAL.value());
+        }
+
+        StatusHistoriesItem statusHistoriesItem = statusHistories.get(0);
+
+        String errorCode = statusHistoriesItem.getErrorCode();
+
+        if (httpStatus == HttpStatus.FORBIDDEN) {
+            if (errorCode.equalsIgnoreCase(CAE0001)) {
+                log.info("Payment Reference: {} Generating error message for {} error code",
+                    creditAccountPaymentResponse.getPaymentReference(),
+                    CAE0001
+                );
+                errorMessage = String.format(PbaErrorMessage.CAE0001.value(), pbaNumber);
+            }
+            if (errorCode.equalsIgnoreCase(CAE0004)) {
+                log.info("Payment Reference: {} Generating error message for {} error code",
+                    creditAccountPaymentResponse.getPaymentReference(),
+                    CAE0004
+                );
+                errorMessage = String.format(PbaErrorMessage.CAE0004.value(), pbaNumber);
+            }
+        } else if (httpStatus == HttpStatus.NOT_FOUND) {
+            errorMessage = String.format(PbaErrorMessage.NOT_FOUND.value(), pbaNumber);
+        } else {
+            errorMessage = PbaErrorMessage.GENERAL.value();
+        }
+        return new PbaResponse(httpStatus, errorMessage);
+    }
+
+    private CreditAccountPaymentRequest creditAccountPaymentRequest(CaseData caseData, Long caseId) {
+        CreditAccountPaymentRequest creditAccountPaymentRequest = new CreditAccountPaymentRequest();
+        OrderSummary orderSummary = caseData.getApplication().getApplicationFeeOrderSummary();
+
+        creditAccountPaymentRequest.setService(DIVORCE);
+        creditAccountPaymentRequest.setCurrency(GBP);
+        creditAccountPaymentRequest.setSiteId(caseData.getSelectedDivorceCentreSiteId());
+        creditAccountPaymentRequest.setAccountNumber(getPbaNumber(caseData));
+
+        final Solicitor solicitor = caseData.getApplicant1().getSolicitor();
+        creditAccountPaymentRequest.setOrganisationName(solicitor.getOrganisationPolicy().getOrganisation().getOrganisationName());
+
+        creditAccountPaymentRequest.setCustomerReference(solicitor.getReference());
+
+        final Fee fee = getFeeValue(orderSummary);
+        creditAccountPaymentRequest.setDescription(fee.getDescription());
+
+        creditAccountPaymentRequest.setAmount(orderSummary.getPaymentTotal());
+        creditAccountPaymentRequest.setCcdCaseNumber(String.valueOf(caseId));
+
+        List<PaymentItem> paymentItemList = populateFeesPaymentItems(caseData, caseId, orderSummary.getPaymentTotal(), fee, solicitor.getReference());
+        creditAccountPaymentRequest.setFees(paymentItemList);
+
+        return creditAccountPaymentRequest;
+    }
+
+    private String getPbaNumber(CaseData caseData) {
+        return caseData.getApplication().getPbaNumbers().getValue().getLabel();
+    }
+
+    private List<PaymentItem> populateFeesPaymentItems(
+        CaseData caseData,
+        Long caseId,
+        String paymentTotal,
+        Fee fee,
+        String reference
+    ) {
+        var paymentItem = PaymentItem
+            .builder()
+            .ccdCaseNumber(String.valueOf(caseId))
+            .calculatedAmount(paymentTotal)
+            .code(fee.getCode())
+            .reference(reference)
+            .version(fee.getVersion())
+            .build();
+
+
+        return singletonList(paymentItem);
+    }
+
+    private Fee getFeeValue(OrderSummary orderSummary) {
+        // We are always interested in the first fee. There may be a change in the future
+        ListValue<Fee> feeItem = orderSummary.getFees().get(0);
+        return feeItem.getValue();
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/payment/PaymentService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/PaymentService.java
@@ -43,6 +43,7 @@ public class PaymentService {
     private static final String FAMILY = "family";
     private static final String FAMILY_COURT = "family court";
     private static final String DIVORCE = "divorce";
+    private static final String DIVORCE_SERVICE = "DIVORCE";
     private static final String GBP = "GBP";
     public static final String CA_E0001 = "CA-E0001";
     public static final String CA_E0004 = "CA-E0004";
@@ -96,14 +97,15 @@ public class PaymentService {
             String paymentReference = Optional.ofNullable(paymentResponseEntity)
                 .map(response ->
                     Optional.ofNullable(response.getBody())
-                        .map(CreditAccountPaymentResponse::getPaymentReference)
+                        .map(CreditAccountPaymentResponse::getReference)
                         .orElseGet(() -> null)
                 )
                 .orElseGet(() -> null);
 
-            log.info("For case id {} successfully processed PBA payment for account number {}",
+            log.info("For case id {} successfully processed PBA payment for account number {} and payment reference {}",
                 caseId,
-                getPbaNumber(caseData)
+                pbaNumber,
+                paymentReference
             );
 
             return new PbaResponse(paymentResponseEntity.getStatusCode(), null, paymentReference);
@@ -212,7 +214,7 @@ public class PaymentService {
         var creditAccountPaymentRequest = new CreditAccountPaymentRequest();
         var orderSummary = caseData.getApplication().getApplicationFeeOrderSummary();
 
-        creditAccountPaymentRequest.setService(DIVORCE);
+        creditAccountPaymentRequest.setService(DIVORCE_SERVICE);
         creditAccountPaymentRequest.setCurrency(GBP);
         creditAccountPaymentRequest.setSiteId(caseData.getSelectedDivorceCentreSiteId());
         creditAccountPaymentRequest.setAccountNumber(getPbaNumber(caseData));
@@ -227,6 +229,7 @@ public class PaymentService {
 
         creditAccountPaymentRequest.setAmount(orderSummary.getPaymentTotal());
         creditAccountPaymentRequest.setCcdCaseNumber(String.valueOf(caseId));
+        creditAccountPaymentRequest.setSiteId(caseData.getSelectedDivorceCentreSiteId());
 
         List<PaymentItem> paymentItemList =
             populateFeesPaymentItems(caseData, caseId, orderSummary.getPaymentTotal(), fee, solicitor.getReference());

--- a/src/main/java/uk/gov/hmcts/divorce/payment/model/CreditAccountPaymentRequest.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/model/CreditAccountPaymentRequest.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.divorce.payment.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.ToString;
+
+import java.util.List;
+import java.util.Optional;
+
+@Data
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CreditAccountPaymentRequest {
+
+    @JsonProperty("ccd_case_number")
+    private String ccdCaseNumber;
+
+    @JsonProperty("account_number")
+    private String accountNumber;
+
+    @JsonProperty("amount")
+    private String amount;
+
+    @JsonProperty("case_reference")
+    private String caseReference;
+
+    @JsonProperty("fees")
+    private List<PaymentItem> fees;
+
+    @JsonProperty("service")
+    private String service;
+
+    @JsonProperty("customer_reference")
+    private String customerReference;
+
+    @JsonProperty("site_id")
+    private String siteId;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("currency")
+    private String currency;
+
+    @JsonProperty("organisation_name")
+    private String organisationName;
+
+    public void setAmount(String amount) {
+        this.amount = Optional.ofNullable(amount)
+                .map(Double::parseDouble).map(i -> i / 100)
+                .map(String::valueOf).orElse(amount);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/divorce/payment/model/CreditAccountPaymentResponse.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/model/CreditAccountPaymentResponse.java
@@ -2,8 +2,10 @@ package uk.gov.hmcts.divorce.payment.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import uk.gov.hmcts.ccd.sdk.type.Fee;
 
@@ -12,6 +14,8 @@ import java.util.List;
 @Data
 @ToString
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreditAccountPaymentResponse {
 

--- a/src/main/java/uk/gov/hmcts/divorce/payment/model/CreditAccountPaymentResponse.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/model/CreditAccountPaymentResponse.java
@@ -1,0 +1,86 @@
+package uk.gov.hmcts.divorce.payment.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+import uk.gov.hmcts.ccd.sdk.type.Fee;
+
+import java.util.List;
+
+@Data
+@ToString
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CreditAccountPaymentResponse {
+
+    @JsonProperty("account_number")
+    private String accountNumber;
+
+    @JsonProperty("ccd_case_number")
+    private String ccdCaseNumber;
+
+    @JsonProperty("amount")
+    private int amount;
+
+    @JsonProperty("fees")
+    private List<Fee> fees;
+
+    @JsonProperty("date_updated")
+    private String dateUpdated;
+
+    @JsonProperty("method")
+    private String method;
+
+    @JsonProperty("status_histories")
+    private List<StatusHistoriesItem> statusHistories;
+
+    @JsonProperty("date_created")
+    private String dateCreated;
+
+    @JsonProperty("service_name")
+    private String serviceName;
+
+    @JsonProperty("channel")
+    private String channel;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("organisation_name")
+    private String organisationName;
+
+    @JsonProperty("payment_reference")
+    private String paymentReference;
+
+    @JsonProperty("external_provider")
+    private String externalProvider;
+
+    @JsonProperty("reference")
+    private String reference;
+
+    @JsonProperty("case_reference")
+    private String caseReference;
+
+    @JsonProperty("customer_reference")
+    private String customerReference;
+
+    @JsonProperty("external_reference")
+    private String externalReference;
+
+    @JsonProperty("site_id")
+    private String siteId;
+
+    @JsonProperty("payment_group_reference")
+    private String paymentGroupReference;
+
+    @JsonProperty("currency")
+    private String currency;
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("status")
+    private String status;
+}

--- a/src/main/java/uk/gov/hmcts/divorce/payment/model/PaymentItem.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/model/PaymentItem.java
@@ -1,0 +1,48 @@
+package uk.gov.hmcts.divorce.payment.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+
+import java.util.Optional;
+
+@Data
+@ToString
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PaymentItem {
+
+    @JsonProperty("reference")
+    private String reference;
+
+    @JsonProperty("volume")
+    private String volume;
+
+    @JsonProperty("ccd_case_number")
+    private String ccdCaseNumber;
+
+    @JsonProperty("memo_line")
+    private String memoLine;
+
+    @JsonProperty("natural_account_code")
+    private String naturalAccountCode;
+
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("calculated_amount")
+    private String calculatedAmount;
+
+    @JsonProperty("version")
+    private String version;
+
+    public void setCalculatedAmount(String calculatedAmount) {
+        this.calculatedAmount = Optional.ofNullable(calculatedAmount)
+                .map(Double::parseDouble)
+                .map(i -> i / 100).map(String::valueOf)
+                .orElse(calculatedAmount);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/divorce/payment/model/PbaErrorMessage.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/model/PbaErrorMessage.java
@@ -10,7 +10,8 @@ public enum PbaErrorMessage {
     private final String message;
 
     public static final String ERROR_INFO = "Please try again after 2 minutes with a different Payment Account, or alternatively "
-        + "use a different payment method. For Payment Account support call 01633 652125 (Option 3) or email MiddleOffice.DDServices@liberata.com.";
+        + "use a different payment method. "
+        + "For Payment Account support call 01633 652125 (Option 3) or email MiddleOffice.DDServices@liberata.com.";
 
     PbaErrorMessage(String errorMessage) {
         this.message = errorMessage + " " + ERROR_INFO;

--- a/src/main/java/uk/gov/hmcts/divorce/payment/model/PbaErrorMessage.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/model/PbaErrorMessage.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.divorce.payment.model;
+
+public enum PbaErrorMessage {
+
+    CAE0001("Fee account %s has insufficient funds available."),
+    CAE0004("Payment Account %s has been deleted or is on hold."),
+    NOT_FOUND("Payment Account %s cannot be found."),
+    GENERAL("Payment request failed.");
+
+    private final String message;
+
+    public static final String ERROR_INFO = "Please try again after 2 minutes with a different Payment Account, or alternatively "
+        + "use a different payment method. For Payment Account support call 01633 652125 (Option 3) or email MiddleOffice.DDServices@liberata.com.";
+
+    PbaErrorMessage(String errorMessage) {
+        this.message = errorMessage + " " + ERROR_INFO;
+    }
+
+    public String value() {
+        return message;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/payment/model/PbaResponse.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/model/PbaResponse.java
@@ -11,4 +11,6 @@ public class PbaResponse {
     private HttpStatus httpStatus;
 
     private String errorMessage;
+
+    private String paymentReference;
 }

--- a/src/main/java/uk/gov/hmcts/divorce/payment/model/PbaResponse.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/model/PbaResponse.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.divorce.payment.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+@Data
+@AllArgsConstructor
+public class PbaResponse {
+
+    private HttpStatus httpStatus;
+
+    private String errorMessage;
+}

--- a/src/main/java/uk/gov/hmcts/divorce/payment/model/StatusHistoriesItem.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/model/StatusHistoriesItem.java
@@ -2,13 +2,17 @@ package uk.gov.hmcts.divorce.payment.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Data
 @ToString
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StatusHistoriesItem {
 

--- a/src/main/java/uk/gov/hmcts/divorce/payment/model/StatusHistoriesItem.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/model/StatusHistoriesItem.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.divorce.payment.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@ToString
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StatusHistoriesItem {
+
+    @JsonProperty("date_updated")
+    private String dateUpdated;
+
+    @JsonProperty("date_created")
+    private String dateCreated;
+
+    @JsonProperty("external_status")
+    private String externalStatus;
+
+    @JsonProperty("status")
+    private String status;
+
+    @JsonProperty("error_code")
+    private String errorCode;
+
+    @JsonProperty("error_message")
+    private String errorMessage;
+}

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/ContactInformationResponse.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/ContactInformationResponse.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.divorce.solicitor.client.pba;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ContactInformationResponse {
+
+    @JsonProperty(value = "addressLine1")
+    private String addressLine1;
+    @JsonProperty(value = "addressLine2")
+    private String addressLine2;
+    @JsonProperty(value = "addressLine3")
+    private String addressLine3;
+    @JsonProperty(value = "townCity")
+    private String townCity;
+    @JsonProperty(value = "county")
+    private String county;
+    @JsonProperty(value = "country")
+    private String country;
+    @JsonProperty(value = "postCode")
+    private String postCode;
+    @JsonProperty(value = "dxAddress")
+    private List<DxAddressResponse> dxAddress;
+}
+

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/DxAddressResponse.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/DxAddressResponse.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.divorce.solicitor.client.pba;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DxAddressResponse {
+
+    @JsonProperty
+    private String dxNumber;
+    @JsonProperty
+    private String dxExchange;
+
+}
+

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/OrganisationEntityResponse.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/OrganisationEntityResponse.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.divorce.solicitor.client.pba;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OrganisationEntityResponse {
+
+    @JsonProperty("organisationIdentifier")
+    private String organisationIdentifier;
+
+    @JsonProperty(value = "name")
+    private String name;
+
+    @JsonProperty(value = "status")
+    private String status;
+
+    @JsonProperty(value = "sraId")
+    private String sraId;
+
+    @JsonProperty(value = "sraRegulated")
+    private boolean sraRegulated;
+
+    @JsonProperty(value = "companyNumber")
+    private String companyNumber;
+
+    @JsonProperty(value = "companyUrl")
+    private String companyUrl;
+
+    @JsonProperty(value = "paymentAccount")
+    private List<String> paymentAccount;
+
+    @JsonProperty(value = "superUser")
+    private SuperUserResponse superUser;
+
+    @JsonProperty(value = "contactInformation")
+    private List<ContactInformationResponse> contactInformation;
+}
+

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/PBAOrganisationResponse.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/PBAOrganisationResponse.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.divorce.solicitor.client.pba;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PBAOrganisationResponse {
+
+    @JsonProperty
+    private OrganisationEntityResponse organisationEntityResponse;
+}

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/PbaOrganisationResponse.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/PbaOrganisationResponse.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class PBAOrganisationResponse {
+public class PbaOrganisationResponse {
 
     @JsonProperty
     private OrganisationEntityResponse organisationEntityResponse;

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/PbaRefDataClient.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/PbaRefDataClient.java
@@ -5,7 +5,6 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.divorce.common.config.ControllerConstants.SERVICE_AUTHORIZATION;
@@ -19,5 +18,5 @@ public interface PbaRefDataClient {
     ResponseEntity<PBAOrganisationResponse> retrievePbaNumbers(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
-        @RequestParam(name = "email") String email);
+        @RequestHeader("UserEmail") String email);
 }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/PbaRefDataClient.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/PbaRefDataClient.java
@@ -15,7 +15,7 @@ public interface PbaRefDataClient {
 
     @ApiOperation("Retrieves Solicitor Pay By Account (PBA) numbers for payment")
     @GetMapping(value = "/refdata/external/v1/organisations/pbas")
-    ResponseEntity<PBAOrganisationResponse> retrievePbaNumbers(
+    ResponseEntity<PbaOrganisationResponse> retrievePbaNumbers(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
         @RequestHeader("UserEmail") String email);

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/PbaRefDataClient.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/PbaRefDataClient.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.divorce.solicitor.client.pba;
+
+import io.swagger.annotations.ApiOperation;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static uk.gov.hmcts.divorce.common.config.ControllerConstants.SERVICE_AUTHORIZATION;
+
+
+@FeignClient(name = "pba-ref-data-client", url = "${pba.ref.data.service..url}")
+public interface PbaRefDataClient {
+
+    @ApiOperation("Retrieves Solicitor Pay By Account (PBA) numbers for payment")
+    @GetMapping(value = "/refdata/external/v1/organisations/pbas")
+    ResponseEntity<PBAOrganisationResponse> retrievePbaNumbers(
+        @RequestHeader(AUTHORIZATION) String authorisation,
+        @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
+        @RequestParam(name = "email") String email);
+}

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/SuperUserResponse.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/SuperUserResponse.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.divorce.solicitor.client.pba;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SuperUserResponse {
+    @JsonProperty(value = "firstName")
+    private String firstName;
+    @JsonProperty(value = "lastName")
+    private String lastName;
+    @JsonProperty(value = "email")
+    private String email;
+}
+

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitApplication.java
@@ -65,11 +65,14 @@ public class SolicitorSubmitApplication implements CCDConfig<CaseData, State, Us
     private HttpServletRequest httpServletRequest;
 
     @Autowired
+    private SolPayment solPayment;
+
+    @Autowired
     private SubmissionService submissionService;
 
     private final List<CcdPageConfiguration> pages = asList(
         new SolStatementOfTruth(),
-        new SolPayment(),
+        solPayment,
         new HelpWithFeesPage(),
         new SolPayAccount(),
         new SolPaymentSummary(),

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/SolPayment.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/SolPayment.java
@@ -1,23 +1,110 @@
 package uk.gov.hmcts.divorce.solicitor.event.page;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.DynamicList;
+import uk.gov.hmcts.ccd.sdk.type.DynamicListElement;
 import uk.gov.hmcts.divorce.common.ccd.CcdPageConfiguration;
 import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
 import uk.gov.hmcts.divorce.divorcecase.model.Application;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.idam.IdamService;
+import uk.gov.hmcts.divorce.solicitor.client.pba.PBAOrganisationResponse;
+import uk.gov.hmcts.divorce.solicitor.client.pba.PbaRefDataClient;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static uk.gov.hmcts.divorce.divorcecase.model.SolicitorPaymentMethod.FEE_PAY_BY_ACCOUNT;
+
+@Component
+@Slf4j
 public class SolPayment implements CcdPageConfiguration {
+
+    @Autowired
+    private HttpServletRequest httpServletRequest;
+
+    @Autowired
+    private IdamService idamService;
+
+    @Autowired
+    private PbaRefDataClient pbaRefDataClient;
+
+    @Autowired
+    private AuthTokenGenerator authTokenGenerator;
 
     @Override
     public void addTo(final PageBuilder pageBuilder) {
 
         pageBuilder
-            .page("SolPayment")
+            .page("SolPayment", this::midEvent)
             .pageLabel("Payment")
             .label(
                 "LabelSolPaymentPara-1",
                 "Amount to pay: **£${solApplicationFeeInPounds}**")
             .complex(CaseData::getApplication)
-                .mandatory(Application::getSolPaymentHowToPay)
-                .done();
+            .mandatory(Application::getSolPaymentHowToPay)
+            .done();
     }
+
+    public AboutToStartOrSubmitResponse<CaseData, State> midEvent(
+        CaseDetails<CaseData, State> details,
+        CaseDetails<CaseData, State> detailsBefore
+    ) {
+        log.info("Mid-event callback triggered for SolPayment page");
+
+        CaseData caseData = details.getData();
+        if (!isSolicitorPaymentMethodPba(caseData)) {
+            log.info("Payment method is not PBA for case id {}  :", details.getId());
+            return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .data(caseData)
+                .build();
+        }
+
+        List<DynamicListElement> pbaAccountNumbers = retrievePbaNumbers()
+            .stream()
+            .map(pbaNumber -> DynamicListElement.builder().label(pbaNumber).code(UUID.randomUUID()).build())
+            .collect(Collectors.toList());
+
+        DynamicList pbaNumbersDynamicList = DynamicList
+            .builder()
+            .listItems(pbaAccountNumbers)
+            .build();
+
+        caseData.getApplication().setPbaNumbers(pbaNumbersDynamicList);
+
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(caseData)
+            .build();
+    }
+
+    private List<String> retrievePbaNumbers() {
+        String solicitorAuthToken = httpServletRequest.getHeader(AUTHORIZATION);
+        UserDetails solUserDetails = idamService.retrieveUser(solicitorAuthToken).getUserDetails();
+        String solicitorEmail = solUserDetails.getEmail();
+
+        ResponseEntity<PBAOrganisationResponse> responseEntity =
+            pbaRefDataClient.retrievePbaNumbers(solicitorAuthToken, authTokenGenerator.generate(), solicitorEmail);
+
+        PBAOrganisationResponse pbaOrganisationResponse = Objects.requireNonNull(responseEntity.getBody());
+
+        return pbaOrganisationResponse.getOrganisationEntityResponse().getPaymentAccount();
+    }
+
+    private boolean isSolicitorPaymentMethodPba(CaseData caseData) {
+        return FEE_PAY_BY_ACCOUNT.equals(caseData.getApplication().getSolPaymentHowToPay());
+    }
+
+
 }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/SolPayment.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/SolPayment.java
@@ -99,6 +99,7 @@ public class SolPayment implements CcdPageConfiguration {
 
         PBAOrganisationResponse pbaOrganisationResponse = Objects.requireNonNull(responseEntity.getBody());
 
+        System.out.println("PBA Numbers " + pbaOrganisationResponse.getOrganisationEntityResponse().getPaymentAccount());
         return pbaOrganisationResponse.getOrganisationEntityResponse().getPaymentAccount();
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -170,3 +170,8 @@ pba:
     data:
       service:
         url: ${PRD_API_BASEURL:http://rd-professional-api-aat.service.core-compute-aat.internal}
+
+payment:
+  service:
+    api:
+      baseurl: ${PAYMENT_API_BASEURL:http://payment-api-aat.service.core-compute-aat.internal}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -164,3 +164,9 @@ court:
       postCode: 'CM20 9QT'
       email: 'divorcecase@justice.gov.uk'
       phoneNumber: '0300 303 0642'
+
+pba:
+  ref:
+    data:
+      service:
+        url: ${PRD_API_BASEURL:http://rd-professional-api-aat.service.core-compute-aat.internal}

--- a/src/test/java/uk/gov/hmcts/divorce/payment/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/payment/PaymentServiceTest.java
@@ -67,6 +67,9 @@ public class PaymentServiceTest {
     private FeesAndPaymentsClient feesAndPaymentsClient;
 
     @Mock
+    private PaymentPbaClient paymentPbaClient;
+
+    @Mock
     private HttpServletRequest httpServletRequest;
 
     @Mock
@@ -154,7 +157,7 @@ public class PaymentServiceTest {
         when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn(TEST_AUTHORIZATION_TOKEN);
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
 
-        when(feesAndPaymentsClient.creditAccountPayment(
+        when(paymentPbaClient.creditAccountPayment(
                 eq(TEST_AUTHORIZATION_TOKEN),
                 eq(TEST_SERVICE_AUTH_TOKEN),
                 any(CreditAccountPaymentRequest.class)
@@ -170,7 +173,7 @@ public class PaymentServiceTest {
 
         verify(httpServletRequest).getHeader(AUTHORIZATION);
         verify(authTokenGenerator).generate();
-        verify(feesAndPaymentsClient).creditAccountPayment(
+        verify(paymentPbaClient).creditAccountPayment(
             eq(TEST_AUTHORIZATION_TOKEN),
             eq(TEST_SERVICE_AUTH_TOKEN),
             any(CreditAccountPaymentRequest.class)
@@ -194,7 +197,7 @@ public class PaymentServiceTest {
         )).thenReturn(creditAccountPaymentResponse);
 
         doThrow(feignException)
-            .when(feesAndPaymentsClient).creditAccountPayment(
+            .when(paymentPbaClient).creditAccountPayment(
                 eq(TEST_AUTHORIZATION_TOKEN),
                 eq(TEST_SERVICE_AUTH_TOKEN),
                 any(CreditAccountPaymentRequest.class)
@@ -229,7 +232,7 @@ public class PaymentServiceTest {
         )).thenReturn(creditAccountPaymentResponse);
 
         doThrow(feignException)
-            .when(feesAndPaymentsClient).creditAccountPayment(
+            .when(paymentPbaClient).creditAccountPayment(
                 eq(TEST_AUTHORIZATION_TOKEN),
                 eq(TEST_SERVICE_AUTH_TOKEN),
                 any(CreditAccountPaymentRequest.class)
@@ -259,7 +262,7 @@ public class PaymentServiceTest {
         FeignException feignException = new FeignException.FeignClientException(NOT_FOUND.value(), "error", request, body);
 
         doThrow(feignException)
-            .when(feesAndPaymentsClient).creditAccountPayment(
+            .when(paymentPbaClient).creditAccountPayment(
                 eq(TEST_AUTHORIZATION_TOKEN),
                 eq(TEST_SERVICE_AUTH_TOKEN),
                 any(CreditAccountPaymentRequest.class)
@@ -294,7 +297,7 @@ public class PaymentServiceTest {
             );
 
         doThrow(feignException)
-            .when(feesAndPaymentsClient).creditAccountPayment(
+            .when(paymentPbaClient).creditAccountPayment(
                 eq(TEST_AUTHORIZATION_TOKEN),
                 eq(TEST_SERVICE_AUTH_TOKEN),
                 any(CreditAccountPaymentRequest.class)

--- a/src/test/java/uk/gov/hmcts/divorce/payment/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/payment/PaymentServiceTest.java
@@ -22,10 +22,10 @@ import uk.gov.hmcts.divorce.payment.model.PbaResponse;
 import uk.gov.hmcts.divorce.payment.model.StatusHistoriesItem;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
 
 import static feign.Request.HttpMethod.GET;
 import static feign.Request.HttpMethod.POST;
@@ -48,8 +48,8 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static uk.gov.hmcts.divorce.payment.PaymentService.CAE0001;
-import static uk.gov.hmcts.divorce.payment.PaymentService.CAE0004;
+import static uk.gov.hmcts.divorce.payment.PaymentService.CA_E0001;
+import static uk.gov.hmcts.divorce.payment.PaymentService.CA_E0004;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.FEE_CODE;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.ISSUE_FEE;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_AUTHORIZATION_TOKEN;
@@ -178,15 +178,15 @@ public class PaymentServiceTest {
     }
 
     @Test
-    public void shouldReturn403WithErrorCodeCAE0004WhenAccountIsDeletedOrOnHold() throws Exception {
+    public void shouldReturn403WithErrorCodeCae0004WhenAccountIsDeletedOrOnHold() throws Exception {
         var caseData = caseData();
 
         when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn(TEST_AUTHORIZATION_TOKEN);
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
 
-        CreditAccountPaymentResponse creditAccountPaymentResponse = buildPaymentClientResponse(CAE0004, "Your account is on hold");
+        CreditAccountPaymentResponse creditAccountPaymentResponse = buildPaymentClientResponse(CA_E0004, "Your account is on hold");
 
-        FeignException feignException = feignException(creditAccountPaymentResponse, FORBIDDEN);
+        FeignException feignException = feignException(creditAccountPaymentResponse);
 
         when(objectMapper.readValue(
             feignException.contentUTF8().getBytes(),
@@ -212,15 +212,16 @@ public class PaymentServiceTest {
     }
 
     @Test
-    public void shouldReturn403WithErrorCodeCAE0001WhenAccountHasInsufficientBalance() throws Exception {
+    public void shouldReturn403WithErrorCodeCae0001WhenAccountHasInsufficientBalance() throws Exception {
         var caseData = caseData();
 
         when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn(TEST_AUTHORIZATION_TOKEN);
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
 
-        CreditAccountPaymentResponse creditAccountPaymentResponse = buildPaymentClientResponse(CAE0001, "Fee account has insufficient funds available");
+        CreditAccountPaymentResponse creditAccountPaymentResponse =
+            buildPaymentClientResponse(CA_E0001, "Fee account has insufficient funds available");
 
-        FeignException feignException = feignException(creditAccountPaymentResponse, FORBIDDEN);
+        FeignException feignException = feignException(creditAccountPaymentResponse);
 
         when(objectMapper.readValue(
             feignException.contentUTF8().getBytes(),
@@ -284,7 +285,7 @@ public class PaymentServiceTest {
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
 
 
-        FeignException feignException = feignException(null, FORBIDDEN);
+        FeignException feignException = feignException(null);
 
         doThrow(new IOException("error parsing response"))
             .when(objectMapper).readValue(
@@ -345,10 +346,10 @@ public class PaymentServiceTest {
             .build();
     }
 
-    private FeignException feignException(CreditAccountPaymentResponse creditAccountPaymentResponse, HttpStatus httpStatus) throws JsonProcessingException {
+    private FeignException feignException(CreditAccountPaymentResponse creditAccountPaymentResponse) throws JsonProcessingException {
         byte[] body = new ObjectMapper().writeValueAsString(creditAccountPaymentResponse).getBytes();
         Request request = Request.create(POST, EMPTY, Map.of(), null, UTF_8, null);
 
-        return new FeignException.FeignClientException(httpStatus.value(), "error", request, body);
+        return new FeignException.FeignClientException(HttpStatus.FORBIDDEN.value(), "error", request, body);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/page/SolPaymentTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/page/SolPaymentTest.java
@@ -1,0 +1,95 @@
+package uk.gov.hmcts.divorce.solicitor.event.page;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.DynamicList;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.idam.IdamService;
+import uk.gov.hmcts.divorce.solicitor.client.pba.OrganisationEntityResponse;
+import uk.gov.hmcts.divorce.solicitor.client.pba.PbaOrganisationResponse;
+import uk.gov.hmcts.divorce.solicitor.client.pba.PbaRefDataClient;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.idam.client.models.User;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static uk.gov.hmcts.divorce.divorcecase.model.ApplicationType.SOLE_APPLICATION;
+import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DIVORCE;
+import static uk.gov.hmcts.divorce.divorcecase.model.SolicitorPaymentMethod.FEE_PAY_BY_ACCOUNT;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_AUTHORIZATION_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SERVICE_AUTH_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_EMAIL;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
+
+@ExtendWith(MockitoExtension.class)
+public class SolPaymentTest {
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    @Mock
+    private IdamService idamService;
+
+    @Mock
+    private PbaRefDataClient pbaRefDataClient;
+
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
+
+    @InjectMocks
+    private SolPayment solPayment;
+
+    @Mock
+    private ResponseEntity<PbaOrganisationResponse> responseEntity;
+
+    @Test
+    public void shouldRetrieveAndSetPbaNumbersWhenPaymentMethodIsPba() {
+        final CaseData caseData = caseData();
+        caseData.setDivorceOrDissolution(DIVORCE);
+        caseData.setApplicationType(SOLE_APPLICATION);
+        caseData.getApplication().setSolPaymentHowToPay(FEE_PAY_BY_ACCOUNT);
+
+        final CaseDetails<CaseData, State> details = new CaseDetails<>();
+        details.setData(caseData);
+
+        UserDetails solUserDetails = UserDetails.builder().email(TEST_SOLICITOR_EMAIL).build();
+
+        when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
+        when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn(TEST_AUTHORIZATION_TOKEN);
+        when(idamService.retrieveUser(TEST_AUTHORIZATION_TOKEN)).thenReturn(new User(TEST_AUTHORIZATION_TOKEN, solUserDetails));
+
+        when(pbaRefDataClient.retrievePbaNumbers(TEST_AUTHORIZATION_TOKEN, TEST_SERVICE_AUTH_TOKEN, TEST_SOLICITOR_EMAIL))
+            .thenReturn(responseEntity);
+
+        var pbaOrganisationResponse = PbaOrganisationResponse
+            .builder()
+            .organisationEntityResponse(
+                OrganisationEntityResponse
+                    .builder()
+                    .paymentAccount(List.of("PBA0012345", "PBA0012346"))
+                    .build()
+            )
+            .build();
+
+        when(responseEntity.getBody()).thenReturn(pbaOrganisationResponse);
+
+        AboutToStartOrSubmitResponse<CaseData, State> response = solPayment.midEvent(details, details);
+
+        DynamicList pbaNumbers = response.getData().getApplication().getPbaNumbers();
+
+        assertThat(pbaNumbers).isNotNull();
+        assertThat(pbaNumbers.getListItems()).extracting("label").containsExactlyInAnyOrder("PBA0012345", "PBA0012346");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/testutil/TestConstants.java
+++ b/src/test/java/uk/gov/hmcts/divorce/testutil/TestConstants.java
@@ -16,6 +16,7 @@ public final class TestConstants {
     public static final String ABOUT_TO_SUBMIT_URL = "/callbacks/about-to-submit";
     public static final String SUBMITTED_URL = "/callbacks/submitted";
     public static final String ABOUT_THE_SOL_MID_EVENT_URL = "/callbacks/mid-event?page=SolAboutTheSolicitor";
+    public static final String SOL_PAYMENT_MID_EVENT_URL = "/callbacks/mid-event?page=SolPayment";
     public static final String SOLICITOR_UPDATE_CONTACT_MID_EVENT_URL = "/callbacks/mid-event?page=SolUpdateContactDetails";
     public static final String CREATE_GENERAL_ORDER_MID_EVENT_URL = "/callbacks/mid-event?page=CreateGeneralOrder";
 

--- a/src/test/java/uk/gov/hmcts/divorce/testutil/TestDataHelper.java
+++ b/src/test/java/uk/gov/hmcts/divorce/testutil/TestDataHelper.java
@@ -182,13 +182,7 @@ public class TestDataHelper {
 
     public static CaseData caseDataWithOrderSummary() {
         var application = Application.builder()
-            .applicationFeeOrderSummary(
-                OrderSummary
-                    .builder()
-                    .paymentTotal("55000")
-                    .fees(singletonList(getFeeListValue()))
-                    .build()
-            )
+            .applicationFeeOrderSummary(orderSummaryWithFee())
             .build();
 
         return CaseData
@@ -198,7 +192,6 @@ public class TestDataHelper {
             .application(application)
             .build();
     }
-
 
     public static CaseData validJointApplicant1CaseData() {
         var marriageDetails = new MarriageDetails();
@@ -551,6 +544,14 @@ public class TestDataHelper {
                 .code("FEE002")
                 .build()
             )
+            .build();
+    }
+
+    public static OrderSummary orderSummaryWithFee() {
+        return OrderSummary
+            .builder()
+            .paymentTotal("55000")
+            .fees(singletonList(getFeeListValue()))
             .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/testutil/TestDataHelper.java
+++ b/src/test/java/uk/gov/hmcts/divorce/testutil/TestDataHelper.java
@@ -521,7 +521,8 @@ public class TestDataHelper {
                     .builder()
                     .code(UUID.randomUUID())
                     .label(accountNumber)
-                    .build())
+                    .build()
+            )
             .build();
     }
 

--- a/src/test/java/uk/gov/hmcts/divorce/testutil/TestDataHelper.java
+++ b/src/test/java/uk/gov/hmcts/divorce/testutil/TestDataHelper.java
@@ -541,7 +541,7 @@ public class TestDataHelper {
             .build();
     }
 
-    private static ListValue<Fee> getFeeListValue() {
+    public static ListValue<Fee> getFeeListValue() {
         return ListValue
             .<Fee>builder()
             .value(Fee

--- a/src/test/java/uk/gov/hmcts/divorce/testutil/TestDataHelper.java
+++ b/src/test/java/uk/gov/hmcts/divorce/testutil/TestDataHelper.java
@@ -8,6 +8,9 @@ import feign.FeignException;
 import feign.Request;
 import feign.Response;
 import uk.gov.hmcts.ccd.sdk.type.Document;
+import uk.gov.hmcts.ccd.sdk.type.DynamicList;
+import uk.gov.hmcts.ccd.sdk.type.DynamicListElement;
+import uk.gov.hmcts.ccd.sdk.type.Fee;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.ccd.sdk.type.OrderSummary;
 import uk.gov.hmcts.ccd.sdk.type.Organisation;
@@ -179,7 +182,13 @@ public class TestDataHelper {
 
     public static CaseData caseDataWithOrderSummary() {
         var application = Application.builder()
-            .applicationFeeOrderSummary(OrderSummary.builder().paymentTotal("55000").build())
+            .applicationFeeOrderSummary(
+                OrderSummary
+                    .builder()
+                    .paymentTotal("55000")
+                    .fees(singletonList(getFeeListValue()))
+                    .build()
+            )
             .build();
 
         return CaseData
@@ -189,6 +198,7 @@ public class TestDataHelper {
             .application(application)
             .build();
     }
+
 
     public static CaseData validJointApplicant1CaseData() {
         var marriageDetails = new MarriageDetails();
@@ -510,12 +520,37 @@ public class TestDataHelper {
             .build();
     }
 
+    public static DynamicList getPbaNumbersForAccount(String accountNumber) {
+        return DynamicList
+            .builder()
+            .value(
+                DynamicListElement
+                    .builder()
+                    .code(UUID.randomUUID())
+                    .label(accountNumber)
+                    .build())
+            .build();
+    }
+
     private static CaseDetails caseDetailsBefore(CaseData caseData) {
         return CaseDetails
             .builder()
             .data(OBJECT_MAPPER.convertValue(caseData, TYPE_REFERENCE))
             .id(TEST_CASE_ID)
             .caseTypeId(CASE_TYPE)
+            .build();
+    }
+
+    private static ListValue<Fee> getFeeListValue() {
+        return ListValue
+            .<Fee>builder()
+            .value(Fee
+                .builder()
+                .amount("550")
+                .description("fees for divorce")
+                .code("FEE002")
+                .build()
+            )
             .build();
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-546

### Change description ###

- Retrieval of PBA numbers for a given solicitor account.
- Making PBA Payment using Payment API v2.
- Error handling for payment failures.
- Added/Updated unit, integration and functional tests.
- Removed unwanted method in solicitor submit application.

### Pending
- Add some more integration and functional tests
- This PR needs to be merged after docker setup is available for PBA account retrieval and payments.