### PR TITLE
Remove '',property or children' from the

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Applicant.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Applicant.java
@@ -127,8 +127,7 @@ public class Applicant {
     private Set<FinancialOrderFor> financialOrderFor;
 
     @CCD(
-        label = "Are there any existing or previous court proceedings relating to the applicant's marriage, "
-            + "property or children?"
+        label = "Are there any existing or previous court proceedings relating to the applicant's marriage?"
     )
     private YesOrNo legalProceedings;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/projects/NFDIV/issues/NFDIV-1096


### Change description ###
Need to remove the content relating to property & children
AC 1 - question on sol journey 
When I am on the 'Other legal proceedings' screen. 
AC 2 - When the mini application is generated
see same name branch in repo https://github.com/hmcts/rdo-docmosis 
 AC 3 - Application tab
When the caseworker clicks the application tab

**Does this PR introduce a breaking change?** (check one with "x")
[ ] Yes
[x] No
```
