### PR TITLE
Fetch ben manes plugin from maven central instead of jitpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,12 @@ buildscript {
     mavenLocal()
     mavenCentral()
     maven {
-      url 'https://jitpack.io'
+      url "https://jitpack.io"
+      content {
+        excludeGroup "com.github.ben-manes.versions"
+      }
     }
+
   }
   dependencies {
     classpath group: 'cz.habarta.typescript-generator', name: 'typescript-generator-gradle-plugin', version: '2.32.889'


### PR DESCRIPTION

### Change description ###

- In general it's better to use jitpack only when necessary and mavenCentral as a general purpose repository due to jitpack being a potential attack vector https://github.com/ben-manes/gradle-versions-plugin/issues/541#issuecomment-878461574