### PR TITLE
Set Europe/London timezone for the app

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/CaseApiApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/CaseApiApplication.java
@@ -20,8 +20,8 @@ import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataClientAutoConfiguration;
 import uk.gov.hmcts.reform.idam.client.IdamApi;
 
-import javax.annotation.PostConstruct;
 import java.util.TimeZone;
+import javax.annotation.PostConstruct;
 
 @SpringBootApplication(
     exclude = {CoreCaseDataClientAutoConfiguration.class},
@@ -66,8 +66,7 @@ public class CaseApiApplication implements CommandLineRunner {
     }
 
     @PostConstruct
-    public void init(){
-        // Setting Spring Boot SetTimeZone
+    public void init() {
         TimeZone.setDefault(TimeZone.getTimeZone("Europe/London"));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/CaseApiApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/CaseApiApplication.java
@@ -20,6 +20,9 @@ import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataClientAutoConfiguration;
 import uk.gov.hmcts.reform.idam.client.IdamApi;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @SpringBootApplication(
     exclude = {CoreCaseDataClientAutoConfiguration.class},
     scanBasePackages = {"uk.gov.hmcts.ccd.sdk", "uk.gov.hmcts.divorce"}
@@ -60,5 +63,11 @@ public class CaseApiApplication implements CommandLineRunner {
         if (System.getenv("TASK_NAME") != null) {
             taskRunner.run(System.getenv("TASK_NAME"));
         }
+    }
+
+    @PostConstruct
+    public void init(){
+        // Setting Spring Boot SetTimeZone
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/London"));
     }
 }


### PR DESCRIPTION
### Change description ###

- By default UTC timezone is used due to which documents generated during issue/reissue has time stamp which is one hour behind.
- Set Europe/London as default timezone for the app.
- Tested on local docker and is working fine.
<img width="1373" alt="image" src="https://user-images.githubusercontent.com/13840402/134354360-921240dc-c9bb-48e2-947d-1c3e905f5844.png">



