### PR TITLE
Make less idam calls

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemMigrateCasesTask.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemMigrateCasesTask.java
@@ -4,12 +4,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.divorce.divorcecase.model.RetiredFields;
+import uk.gov.hmcts.divorce.idam.IdamService;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchService;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.idam.client.models.User;
 
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCase.SYSTEM_MIGRATE_CASE;
 
@@ -23,24 +26,33 @@ public class SystemMigrateCasesTask implements Runnable {
     @Autowired
     private CcdUpdateService ccdUpdateService;
 
+    @Autowired
+    private IdamService idamService;
+
+    @Autowired
+    private AuthTokenGenerator authTokenGenerator;
+
     @Override
     public void run() {
         log.info("Migrate cases scheduled task started");
 
+        final User user = idamService.retrieveSystemUpdateUserDetails();
+        final String serviceAuthorization = authTokenGenerator.generate();
+
         try {
             ccdSearchService
-                .searchForCasesWithVersionLessThan(RetiredFields.getVersion())
+                .searchForCasesWithVersionLessThan(RetiredFields.getVersion(), user, serviceAuthorization)
                 .parallelStream()
-                .forEach(this::migrateCase);
+                .forEach(details -> migrateCase(details, user, serviceAuthorization));
 
         } catch (final CcdSearchCaseException e) {
             log.error("Case migration schedule task stopped after search error", e);
         }
     }
 
-    private void migrateCase(CaseDetails caseDetails) {
+    private void migrateCase(final CaseDetails caseDetails, final User user, final String serviceAuthorization) {
         try {
-            ccdUpdateService.submitEvent(caseDetails, SYSTEM_MIGRATE_CASE);
+            ccdUpdateService.submitEvent(caseDetails, SYSTEM_MIGRATE_CASE, user, serviceAuthorization);
             log.info("Migration complete for case id: {}", caseDetails.getId());
         } catch (final CcdConflictException e) {
             log.error("Could not get lock for case id: {}, continuing to next case", caseDetails.getId());

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemProgressCasesToAosOverdueTask.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemProgressCasesToAosOverdueTask.java
@@ -3,12 +3,15 @@ package uk.gov.hmcts.divorce.systemupdate.schedule;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.divorce.idam.IdamService;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchService;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.idam.client.models.User;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -30,15 +33,23 @@ public class SystemProgressCasesToAosOverdueTask implements Runnable {
     @Autowired
     private CcdSearchService ccdSearchService;
 
+    @Autowired
+    private IdamService idamService;
+
+    @Autowired
+    private AuthTokenGenerator authTokenGenerator;
+
     private static final String DUE_DATE = "dueDate";
 
     @Override
     public void run() {
-
         log.info("Aos overdue scheduled task started");
 
+        final User user = idamService.retrieveSystemUpdateUserDetails();
+        final String serviceAuth = authTokenGenerator.generate();
+
         try {
-            final List<CaseDetails> casesInAwaitingAosState = ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos);
+            final List<CaseDetails> casesInAwaitingAosState = ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos, user, serviceAuth);
 
             for (final CaseDetails caseDetails : casesInAwaitingAosState) {
                 try {
@@ -60,7 +71,7 @@ public class SystemProgressCasesToAosOverdueTask implements Runnable {
                                 aosDueDate,
                                 caseDetails.getId()
                             );
-                            ccdUpdateService.submitEvent(caseDetails, SYSTEM_PROGRESS_TO_AOS_OVERDUE);
+                            ccdUpdateService.submitEvent(caseDetails, SYSTEM_PROGRESS_TO_AOS_OVERDUE, user, serviceAuth);
                         }
                     }
                 } catch (final CcdManagementException e) {

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemProgressHeldCasesTask.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemProgressHeldCasesTask.java
@@ -6,13 +6,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.divorce.common.service.HoldingPeriodService;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.idam.IdamService;
 import uk.gov.hmcts.divorce.solicitor.notification.AwaitingConditionalOrderNotification;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchService;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.idam.client.models.User;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -42,15 +45,23 @@ public class SystemProgressHeldCasesTask implements Runnable {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private IdamService idamService;
+
+    @Autowired
+    private AuthTokenGenerator authTokenGenerator;
+
     private static final String DUE_DATE = "dueDate";
 
     @Override
     public void run() {
-
         log.info("Awaiting conditional order scheduled task started");
 
+        final User user = idamService.retrieveSystemUpdateUserDetails();
+        final String serviceAuth = authTokenGenerator.generate();
+
         try {
-            final List<CaseDetails> casesInHoldingState = ccdSearchService.searchForAllCasesWithStateOf(Holding);
+            final List<CaseDetails> casesInHoldingState = ccdSearchService.searchForAllCasesWithStateOf(Holding, user, serviceAuth);
 
             for (final CaseDetails caseDetails : casesInHoldingState) {
                 try {
@@ -75,7 +86,7 @@ public class SystemProgressHeldCasesTask implements Runnable {
                             //Set due date as null
                             caseDetails.getData().put(DUE_DATE, null);
 
-                            ccdUpdateService.submitEvent(caseDetails, SYSTEM_PROGRESS_HELD_CASE);
+                            ccdUpdateService.submitEvent(caseDetails, SYSTEM_PROGRESS_HELD_CASE, user, serviceAuth);
 
                             // trigger notification to applicant's solicitor
                             triggerEmailNotification(caseData, caseDetails.getId());

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemMigrateCasesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemMigrateCasesTaskTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.divorce.systemupdate.schedule;
 
 import feign.FeignException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -9,12 +10,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.divorce.divorcecase.model.RetiredFields;
+import uk.gov.hmcts.divorce.idam.IdamService;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchService;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.idam.client.models.User;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
 import java.util.List;
 
@@ -25,6 +30,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCase.SYSTEM_MIGRATE_CASE;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -39,20 +46,36 @@ class SystemMigrateCasesTaskTest {
     @InjectMocks
     private SystemMigrateCasesTask systemMigrateCasesTask;
 
+    @Mock
+    private IdamService idamService;
+
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(SYSTEM_UPDATE_AUTH_TOKEN, UserDetails.builder().build());
+        when(idamService.retrieveSystemUpdateUserDetails()).thenReturn(user);
+        when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION);
+    }
+
     @Test
     void shouldNotTriggerAosOverdueTaskOnEachCaseWhenCaseDueDateIsAfterCurrentDate() {
         final CaseDetails caseDetails = mock(CaseDetails.class);
 
-        when(ccdSearchService.searchForCasesWithVersionLessThan(RetiredFields.getVersion())).thenReturn(singletonList(caseDetails));
+        when(ccdSearchService.searchForCasesWithVersionLessThan(RetiredFields.getVersion(), user, SERVICE_AUTHORIZATION))
+            .thenReturn(singletonList(caseDetails));
 
         systemMigrateCasesTask.run();
 
-        verify(ccdUpdateService).submitEvent(caseDetails, SYSTEM_MIGRATE_CASE);
+        verify(ccdUpdateService).submitEvent(caseDetails, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
     }
 
     @Test
     void shouldNotSubmitEventIfSearchFails() {
-        when(ccdSearchService.searchForCasesWithVersionLessThan(3))
+        when(ccdSearchService.searchForCasesWithVersionLessThan(3, user, SERVICE_AUTHORIZATION))
             .thenThrow(new CcdSearchCaseException("Failed to search cases", mock(FeignException.class)));
 
         systemMigrateCasesTask.run();
@@ -66,15 +89,16 @@ class SystemMigrateCasesTaskTest {
         final CaseDetails caseDetails2 = mock(CaseDetails.class);
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
-        when(ccdSearchService.searchForCasesWithVersionLessThan(RetiredFields.getVersion())).thenReturn(caseDetailsList);
+        when(ccdSearchService.searchForCasesWithVersionLessThan(RetiredFields.getVersion(), user, SERVICE_AUTHORIZATION))
+            .thenReturn(caseDetailsList);
 
         doThrow(new CcdConflictException("Case is modified by another transaction", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE);
+            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
 
         systemMigrateCasesTask.run();
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE);
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE);
+        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
     }
 
     @Test
@@ -84,15 +108,16 @@ class SystemMigrateCasesTaskTest {
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
-        when(ccdSearchService.searchForCasesWithVersionLessThan(RetiredFields.getVersion())).thenReturn(caseDetailsList);
+        when(ccdSearchService.searchForCasesWithVersionLessThan(RetiredFields.getVersion(), user, SERVICE_AUTHORIZATION))
+            .thenReturn(caseDetailsList);
 
         doThrow(new CcdManagementException("Failed processing of case", mock(FeignException.class)))
             .doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE);
+            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
 
         systemMigrateCasesTask.run();
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE);
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE);
+        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemProgressCasesToAosOverdueTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemProgressCasesToAosOverdueTaskTest.java
@@ -1,17 +1,22 @@
 package uk.gov.hmcts.divorce.systemupdate.schedule;
 
 import feign.FeignException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.divorce.idam.IdamService;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchService;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.idam.client.models.User;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -27,6 +32,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingAos;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemProgressCaseToAosOverdue.SYSTEM_PROGRESS_TO_AOS_OVERDUE;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
 
 @ExtendWith(MockitoExtension.class)
 class SystemProgressCasesToAosOverdueTaskTest {
@@ -40,6 +47,21 @@ class SystemProgressCasesToAosOverdueTaskTest {
     @InjectMocks
     private SystemProgressCasesToAosOverdueTask progressCasesToAosOverdueTask;
 
+    @Mock
+    private IdamService idamService;
+
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(SYSTEM_UPDATE_AUTH_TOKEN, UserDetails.builder().build());
+        when(idamService.retrieveSystemUpdateUserDetails()).thenReturn(user);
+        when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION);
+    }
+
     @Test
     void shouldTriggerAosOverdueTaskOnEachCaseWhenCaseDueDateIsBeforeOrSameAsCurrentDate() {
         final CaseDetails caseDetails1 = mock(CaseDetails.class);
@@ -50,12 +72,12 @@ class SystemProgressCasesToAosOverdueTaskTest {
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
-        when(ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos)).thenReturn(caseDetailsList);
+        when(ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos, user, SERVICE_AUTHORIZATION)).thenReturn(caseDetailsList);
 
         progressCasesToAosOverdueTask.run();
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_TO_AOS_OVERDUE);
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_PROGRESS_TO_AOS_OVERDUE);
+        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_TO_AOS_OVERDUE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_PROGRESS_TO_AOS_OVERDUE, user, SERVICE_AUTHORIZATION);
     }
 
     @Test
@@ -67,11 +89,11 @@ class SystemProgressCasesToAosOverdueTaskTest {
 
         when(caseDetails.getData()).thenReturn(caseDataMap);
 
-        when(ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos)).thenReturn(List.of(caseDetails));
+        when(ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos, user, SERVICE_AUTHORIZATION)).thenReturn(List.of(caseDetails));
 
         progressCasesToAosOverdueTask.run();
 
-        verify(ccdUpdateService, never()).submitEvent(caseDetails, SYSTEM_PROGRESS_TO_AOS_OVERDUE);
+        verify(ccdUpdateService, never()).submitEvent(caseDetails, SYSTEM_PROGRESS_TO_AOS_OVERDUE, user, SERVICE_AUTHORIZATION);
     }
 
     @Test
@@ -80,7 +102,8 @@ class SystemProgressCasesToAosOverdueTaskTest {
 
         when(caseDetails.getData()).thenReturn(Map.of("dueDate", LocalDate.now().plusDays(5).toString()));
 
-        when(ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos)).thenReturn(singletonList(caseDetails));
+        when(ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos, user, SERVICE_AUTHORIZATION))
+            .thenReturn(singletonList(caseDetails));
 
         progressCasesToAosOverdueTask.run();
 
@@ -89,7 +112,7 @@ class SystemProgressCasesToAosOverdueTaskTest {
 
     @Test
     void shouldNotSubmitEventIfSearchFails() {
-        when(ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos))
+        when(ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos, user, SERVICE_AUTHORIZATION))
             .thenThrow(new CcdSearchCaseException("Failed to search cases", mock(FeignException.class)));
 
         progressCasesToAosOverdueTask.run();
@@ -105,15 +128,15 @@ class SystemProgressCasesToAosOverdueTaskTest {
 
         when(caseDetails1.getData()).thenReturn(Map.of("dueDate", LocalDate.now().toString()));
 
-        when(ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos)).thenReturn(caseDetailsList);
+        when(ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos, user, SERVICE_AUTHORIZATION)).thenReturn(caseDetailsList);
 
         doThrow(new CcdConflictException("Case is modified by another transaction", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_TO_AOS_OVERDUE);
+            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_TO_AOS_OVERDUE, user, SERVICE_AUTHORIZATION);
 
         progressCasesToAosOverdueTask.run();
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_TO_AOS_OVERDUE);
-        verify(ccdUpdateService, never()).submitEvent(caseDetails2, SYSTEM_PROGRESS_TO_AOS_OVERDUE);
+        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_TO_AOS_OVERDUE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService, never()).submitEvent(caseDetails2, SYSTEM_PROGRESS_TO_AOS_OVERDUE, user, SERVICE_AUTHORIZATION);
     }
 
     @Test
@@ -126,14 +149,14 @@ class SystemProgressCasesToAosOverdueTaskTest {
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
-        when(ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos)).thenReturn(caseDetailsList);
+        when(ccdSearchService.searchForAllCasesWithStateOf(AwaitingAos, user, SERVICE_AUTHORIZATION)).thenReturn(caseDetailsList);
 
         doThrow(new CcdManagementException("Failed processing of case", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_TO_AOS_OVERDUE);
+            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_TO_AOS_OVERDUE, user, SERVICE_AUTHORIZATION);
 
         progressCasesToAosOverdueTask.run();
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_TO_AOS_OVERDUE);
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_PROGRESS_TO_AOS_OVERDUE);
+        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_TO_AOS_OVERDUE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_PROGRESS_TO_AOS_OVERDUE, user, SERVICE_AUTHORIZATION);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemProgressHeldCasesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemProgressHeldCasesTaskTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.divorce.systemupdate.schedule;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,6 +13,7 @@ import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.Application;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
+import uk.gov.hmcts.divorce.idam.IdamService;
 import uk.gov.hmcts.divorce.solicitor.notification.AwaitingConditionalOrderNotification;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
@@ -19,7 +21,10 @@ import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchService;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService;
 import uk.gov.hmcts.divorce.testutil.TestConstants;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.idam.client.models.User;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -41,6 +46,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Holding;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemProgressHeldCase.SYSTEM_PROGRESS_HELD_CASE;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
 
 @ExtendWith(MockitoExtension.class)
 class SystemProgressHeldCasesTaskTest {
@@ -63,6 +70,21 @@ class SystemProgressHeldCasesTaskTest {
     @InjectMocks
     private SystemProgressHeldCasesTask awaitingConditionalOrderTask;
 
+    @Mock
+    private IdamService idamService;
+
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(SYSTEM_UPDATE_AUTH_TOKEN, UserDetails.builder().build());
+        when(idamService.retrieveSystemUpdateUserDetails()).thenReturn(user);
+        when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION);
+    }
+
     @Test
     void shouldTriggerAwaitingConditionalOrderOnEachCaseAndSendNotificationWhenCaseHasFinishedHoldingPeriod() {
         final CaseDetails caseDetails1 = mock(CaseDetails.class);
@@ -82,14 +104,14 @@ class SystemProgressHeldCasesTaskTest {
         when(holdingPeriodService.isHoldingPeriodFinished(issueDate2)).thenReturn(true);
         when(holdingPeriodService.isHoldingPeriodFinished(issueDate3)).thenReturn(false);
         when(holdingPeriodService.getHoldingPeriodInWeeks()).thenReturn(14);
-        when(ccdSearchService.searchForAllCasesWithStateOf(Holding)).thenReturn(caseDetailsList);
+        when(ccdSearchService.searchForAllCasesWithStateOf(Holding, user, SERVICE_AUTHORIZATION)).thenReturn(caseDetailsList);
 
         doNothing().when(conditionalOrderNotification).send(any(CaseData.class), anyLong());
 
         awaitingConditionalOrderTask.run();
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_HELD_CASE);
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_PROGRESS_HELD_CASE);
+        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_HELD_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_PROGRESS_HELD_CASE, user, SERVICE_AUTHORIZATION);
 
         verify(conditionalOrderNotification, times(2)).send(any(CaseData.class), anyLong());
         verifyNoMoreInteractions(ccdUpdateService, conditionalOrderNotification);
@@ -103,11 +125,11 @@ class SystemProgressHeldCasesTaskTest {
 
         mockInteractions(caseDetails, null, caseDataMap(caseDetails, null));
 
-        when(ccdSearchService.searchForAllCasesWithStateOf(Holding)).thenReturn(caseDetailsList);
+        when(ccdSearchService.searchForAllCasesWithStateOf(Holding, user, SERVICE_AUTHORIZATION)).thenReturn(caseDetailsList);
 
         awaitingConditionalOrderTask.run();
 
-        verify(ccdUpdateService, never()).submitEvent(caseDetails, SYSTEM_PROGRESS_HELD_CASE);
+        verify(ccdUpdateService, never()).submitEvent(caseDetails, SYSTEM_PROGRESS_HELD_CASE, user, SERVICE_AUTHORIZATION);
     }
 
     @Test
@@ -117,7 +139,7 @@ class SystemProgressHeldCasesTaskTest {
         final LocalDate issueDate = LocalDate.now();
         mockInteractions(caseDetails1, issueDate, caseDataMap(caseDetails1, issueDate));
 
-        when(ccdSearchService.searchForAllCasesWithStateOf(Holding)).thenReturn(singletonList(caseDetails1));
+        when(ccdSearchService.searchForAllCasesWithStateOf(Holding, user, SERVICE_AUTHORIZATION)).thenReturn(singletonList(caseDetails1));
 
         awaitingConditionalOrderTask.run();
 
@@ -126,7 +148,7 @@ class SystemProgressHeldCasesTaskTest {
 
     @Test
     void shouldNotSubmitEventIfSearchFails() {
-        when(ccdSearchService.searchForAllCasesWithStateOf(Holding))
+        when(ccdSearchService.searchForAllCasesWithStateOf(Holding, user, SERVICE_AUTHORIZATION))
             .thenThrow(new CcdSearchCaseException("Failed to search cases", mock(FeignException.class)));
 
         awaitingConditionalOrderTask.run();
@@ -145,15 +167,15 @@ class SystemProgressHeldCasesTaskTest {
 
         when(holdingPeriodService.isHoldingPeriodFinished(issueDate)).thenReturn(true);
         when(holdingPeriodService.getHoldingPeriodInWeeks()).thenReturn(14);
-        when(ccdSearchService.searchForAllCasesWithStateOf(Holding)).thenReturn(caseDetailsList);
+        when(ccdSearchService.searchForAllCasesWithStateOf(Holding, user, SERVICE_AUTHORIZATION)).thenReturn(caseDetailsList);
 
         doThrow(new CcdConflictException("Case is modified by another transaction", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_HELD_CASE);
+            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_HELD_CASE, user, SERVICE_AUTHORIZATION);
 
         awaitingConditionalOrderTask.run();
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_HELD_CASE);
-        verify(ccdUpdateService, never()).submitEvent(caseDetails2, SYSTEM_PROGRESS_HELD_CASE);
+        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_HELD_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService, never()).submitEvent(caseDetails2, SYSTEM_PROGRESS_HELD_CASE, user, SERVICE_AUTHORIZATION);
     }
 
     @Test
@@ -168,10 +190,10 @@ class SystemProgressHeldCasesTaskTest {
         when(holdingPeriodService.isHoldingPeriodFinished(issueDate1)).thenReturn(true);
         when(holdingPeriodService.isHoldingPeriodFinished(issueDate2)).thenReturn(true);
         when(holdingPeriodService.getHoldingPeriodInWeeks()).thenReturn(14);
-        when(ccdSearchService.searchForAllCasesWithStateOf(Holding)).thenReturn(caseDetailsList);
+        when(ccdSearchService.searchForAllCasesWithStateOf(Holding, user, SERVICE_AUTHORIZATION)).thenReturn(caseDetailsList);
 
         doThrow(new CcdManagementException("Failed processing of case", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_HELD_CASE);
+            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_HELD_CASE, user, SERVICE_AUTHORIZATION);
 
         doNothing().when(conditionalOrderNotification).send(any(CaseData.class), anyLong());
 
@@ -180,8 +202,8 @@ class SystemProgressHeldCasesTaskTest {
 
         awaitingConditionalOrderTask.run();
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_HELD_CASE);
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_PROGRESS_HELD_CASE);
+        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_PROGRESS_HELD_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_PROGRESS_HELD_CASE, user, SERVICE_AUTHORIZATION);
         verify(conditionalOrderNotification, times(1)).send(any(CaseData.class), anyLong());
     }
 


### PR DESCRIPTION
Reduce the number of calls made to idam and service auth provider by getting the tokens at the start of executing a cron, rather than on every CCD API call