### PR TITLE
remove state change for SystemLinkApplicant2

### DIFF
--- a/src/integrationTest/resources/wiremock/responses/about-to-submit-link-applicant-2.json
+++ b/src/integrationTest/resources/wiremock/responses/about-to-submit-link-applicant-2.json
@@ -65,5 +65,5 @@
   },
   "errors": null,
   "warnings": null,
-  "state": "AwaitingApplicant2Response"
+  "state": null
 }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemLinkApplicant2.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemLinkApplicant2.java
@@ -60,7 +60,6 @@ public class SystemLinkApplicant2 implements CCDConfig<CaseData, State, UserRole
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(data)
-            .state(AwaitingApplicant2Response)
             .build();
     }
 }


### PR DESCRIPTION
### Change description ###
Remove state change for SystemLinkApplicant2 
Currently case in AwaitingAos state is being set to AwaitingApplicant2Response when a respondent links to the case

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
