### PR TITLE
Revert changes to the Bailiff and Divorce service keywords

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/testutil/FeesWireMock.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/testutil/FeesWireMock.java
@@ -35,7 +35,7 @@ public final class FeesWireMock {
 
     public static void stubForFeesLookup(final String feeResponse) {
         FEES_SERVER.stubFor(get("/fees-register/fees/lookup"
-            + "?channel=default&event=issue&jurisdiction1=family&jurisdiction2=family+court&service=divorce&keyword=DivorceCivPart")
+            + "?channel=default&event=issue&jurisdiction1=family&jurisdiction2=family+court&service=divorce")
             .willReturn(aResponse()
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
                 .withBody(feeResponse)));
@@ -44,7 +44,7 @@ public final class FeesWireMock {
     public static void stubForFeesNotFound() {
         FEES_SERVER.stubFor(get(urlEqualTo(
             "/fees-register/fees/lookup"
-                + "?channel=default&event=issue&jurisdiction1=family&jurisdiction2=family+court&service=divorce&keyword=DivorceCivPart"))
+                + "?channel=default&event=issue&jurisdiction1=family&jurisdiction2=family+court&service=divorce"))
             .willReturn(aResponse()
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
                 .withStatus(HttpStatus.NOT_FOUND.value())

--- a/src/main/java/uk/gov/hmcts/divorce/payment/PaymentService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/PaymentService.java
@@ -49,9 +49,9 @@ public class PaymentService {
     public static final String EVENT_ISSUE = "issue";
     public static final String SERVICE_DIVORCE = "divorce";
     public static final String SERVICE_OTHER = "other";
-    public static final String KEYWORD_BAILIFF = "BailiffServeDoc";
+    public static final String KEYWORD_BAILIFF = "HIJ";
     public static final String KEYWORD_DEEMED = "GeneralAppWithoutNotice";
-    public static final String KEYWORD_DIVORCE = "DivorceCivPart";
+    public static final String KEYWORD_DIVORCE = null;
 
     private static final String FAMILY = "family";
     private static final String FAMILY_COURT = "family court";

--- a/src/test/java/uk/gov/hmcts/divorce/payment/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/payment/PaymentServiceTest.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -107,7 +108,7 @@ public class PaymentServiceTest {
                 anyString(),
                 anyString(),
                 anyString(),
-                anyString()
+                isNull()
             );
 
         OrderSummary orderSummary = paymentService.getOrderSummaryByServiceEvent(SERVICE_DIVORCE, EVENT_ISSUE, KEYWORD_DIVORCE);
@@ -126,7 +127,7 @@ public class PaymentServiceTest {
                 anyString(),
                 anyString(),
                 anyString(),
-                anyString()
+                isNull()
             );
 
         verifyNoMoreInteractions(feesAndPaymentsClient);


### PR DESCRIPTION
### JIRA link (if applicable) ###

no ticket

### Change description ###

Fee and Payment team have reverted a change to the keyword for fee lookups on Bailiff Enforcement and Divorce petition fees

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
