### PR TITLE
Update bulk cases with processed and failed cases

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/tab/BulkActionCaseTypeTab.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/tab/BulkActionCaseTypeTab.java
@@ -1,8 +1,9 @@
-package uk.gov.hmcts.divorce.bulkaction.ccd;
+package uk.gov.hmcts.divorce.bulkaction.ccd.tab;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState;
 import uk.gov.hmcts.divorce.bulkaction.data.BulkActionCaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 
@@ -20,5 +21,8 @@ public class BulkActionCaseTypeTab implements CCDConfig<BulkActionCaseData, Bulk
             .field(BulkActionCaseData::getPronouncedDate)
             .field(BulkActionCaseData::getDateFinalOrderEligibleFrom)
             .field(BulkActionCaseData::getBulkListCaseDetails);
+
+        configBuilder.tab("unprocessedBulkCaseList", "Unprocessed bulk case list")
+            .field(BulkActionCaseData::getErroredCaseDetails);
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/bulkaction/data/BulkActionCaseData.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkaction/data/BulkActionCaseData.java
@@ -81,10 +81,19 @@ public class BulkActionCaseData {
     private List<ListValue<BulkListCaseDetails>> bulkListCaseDetails;
 
     @CCD(
+        label = "Cases that have successfully processed",
+        typeOverride = Collection,
+        typeParameterOverride = "BulkListCaseDetails",
+        access = {CaseworkerAccess.class}
+    )
+    private List<ListValue<BulkListCaseDetails>> processedCaseDetails;
+
+    @CCD(
         label = "Cases that have errored",
         typeOverride = Collection,
         typeParameterOverride = "BulkListCaseDetails",
         access = {CaseworkerAccess.class}
     )
     private List<ListValue<BulkListCaseDetails>> erroredCaseDetails;
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-1223

### Change description ###

- Once we update cases ion bulk case details we will now update bulk case with both processed and failed cases information.
- This will allow the cron job to reprocess them in case processed list is empty or if the error list is populated.
- Adds a tab to display failed cases.

