### PR TITLE
nfdiv-1183: move content back to template

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant1ResubmitNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant1ResubmitNotification.java
@@ -4,20 +4,32 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.divorce.common.config.EmailTemplatesConfig;
+import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.notification.CommonContent;
 import uk.gov.hmcts.divorce.notification.NotificationService;
 
+import java.util.HashMap;
 import java.util.Map;
 
+import static uk.gov.hmcts.divorce.notification.CommonContent.isDivorce;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.JOINT_APPLICANT1_APPLICANT1_CHANGES_MADE;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.JOINT_APPLICANT2_APPLICANT1_CHANGES_MADE;
 import static uk.gov.hmcts.divorce.notification.FormatUtil.DATE_TIME_FORMATTER;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.COURT_EMAIL;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.DISSOLUTION_COURT_EMAIL;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.DIVORCE_COURT_EMAIL;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.FIRST_NAME;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.IS_DISSOLUTION;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.IS_DIVORCE;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.LAST_NAME;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.NO;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.PARTNER;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.SIGN_IN_DISSOLUTION_URL;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.SIGN_IN_DIVORCE_URL;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.SIGN_IN_URL_NOTIFY_KEY;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.SUBMISSION_RESPONSE_DATE;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.THEIR_EMAIL_ADDRESS;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.YES;
 
 @Component
 @Slf4j
@@ -30,42 +42,49 @@ public class Applicant1ResubmitNotification {
     private CommonContent commonContent;
 
     @Autowired
-    private EmailTemplatesConfig emailTemplatesConfig;
+    private EmailTemplatesConfig configVars;
 
     public void sendToApplicant1(CaseData caseData, Long id) {
-        Map<String, String> templateVars = commonContent.templateVarsForApplicant(
-            caseData, caseData.getApplicant1(), caseData.getApplicant2());
-
-        templateVars.put(SUBMISSION_RESPONSE_DATE, caseData.getDueDate().format(DATE_TIME_FORMATTER));
-        templateVars.put(THEIR_EMAIL_ADDRESS, caseData.getCaseInvite().getApplicant2InviteEmailAddress());
-
         log.info("Sending applicant 1 made changes notification to applicant 1 for case : {}", id);
 
         notificationService.sendEmail(
             caseData.getApplicant1().getEmail(),
             JOINT_APPLICANT1_APPLICANT1_CHANGES_MADE,
-            templateVars,
+            resubmitTemplateVars(caseData, caseData.getApplicant1(), caseData.getApplicant2()),
             caseData.getApplicant1().getLanguagePreference()
         );
     }
 
     public void sendToApplicant2(CaseData caseData, Long id) {
-        Map<String, String> templateVars = commonContent.templateVarsForApplicant(
-            caseData, caseData.getApplicant2(), caseData.getApplicant1());
-
-        templateVars.put(SUBMISSION_RESPONSE_DATE, caseData.getDueDate().format(DATE_TIME_FORMATTER));
-
-        Map<String, String> configTemplateVars = emailTemplatesConfig.getTemplateVars();
-        String signInLink = caseData.getDivorceOrDissolution().isDivorce() ? SIGN_IN_DIVORCE_URL : SIGN_IN_DISSOLUTION_URL;
-        templateVars.put(SIGN_IN_URL_NOTIFY_KEY, configTemplateVars.get(signInLink) + "/applicant2/check-your-joint-application");
-
         log.info("Sending applicant 1 made changes notification to applicant 2 for case : {}", id);
 
         notificationService.sendEmail(
             caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
             JOINT_APPLICANT2_APPLICANT1_CHANGES_MADE,
-            templateVars,
+            applicant2TemplateVars(caseData),
             caseData.getApplicant2().getLanguagePreference()
         );
+    }
+
+    private Map<String, String> applicant2TemplateVars(CaseData caseData) {
+        Map<String, String> templateVars = resubmitTemplateVars(caseData, caseData.getApplicant2(), caseData.getApplicant1());
+        String signInLink = configVars.getTemplateVars().get(isDivorce(caseData) ? SIGN_IN_DIVORCE_URL : SIGN_IN_DISSOLUTION_URL);
+        templateVars.put(SIGN_IN_URL_NOTIFY_KEY, signInLink + "/applicant2/check-your-joint-application");
+        return templateVars;
+    }
+
+    private Map<String, String> resubmitTemplateVars(CaseData caseData, Applicant applicant, Applicant partner) {
+        Map<String, String> templateVars = new HashMap<>();
+        templateVars.put(IS_DIVORCE, isDivorce(caseData) ? YES : NO);
+        templateVars.put(IS_DISSOLUTION, !isDivorce(caseData) ? YES : NO);
+        templateVars.put(FIRST_NAME, applicant.getFirstName());
+        templateVars.put(LAST_NAME, applicant.getLastName());
+        templateVars.put(PARTNER, commonContent.getPartner(caseData, partner));
+        templateVars.put(SUBMISSION_RESPONSE_DATE, caseData.getDueDate().format(DATE_TIME_FORMATTER));
+        templateVars.put(SIGN_IN_URL_NOTIFY_KEY,
+            configVars.getTemplateVars().get(isDivorce(caseData) ? SIGN_IN_DIVORCE_URL : SIGN_IN_DISSOLUTION_URL));
+        templateVars.put(COURT_EMAIL,
+            configVars.getTemplateVars().get(isDivorce(caseData) ? DIVORCE_COURT_EMAIL : DISSOLUTION_COURT_EMAIL));
+        return templateVars;
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant1ResubmitNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant1ResubmitNotification.java
@@ -29,6 +29,7 @@ import static uk.gov.hmcts.divorce.notification.NotificationConstants.SIGN_IN_DI
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.SIGN_IN_DIVORCE_URL;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.SIGN_IN_URL_NOTIFY_KEY;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.SUBMISSION_RESPONSE_DATE;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.THEIR_EMAIL_ADDRESS;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.YES;
 
 @Component
@@ -50,7 +51,7 @@ public class Applicant1ResubmitNotification {
         notificationService.sendEmail(
             caseData.getApplicant1().getEmail(),
             JOINT_APPLICANT1_APPLICANT1_CHANGES_MADE,
-            resubmitTemplateVars(caseData, caseData.getApplicant1(), caseData.getApplicant2()),
+            applicant1TemplateVars(caseData),
             caseData.getApplicant1().getLanguagePreference()
         );
     }
@@ -64,6 +65,12 @@ public class Applicant1ResubmitNotification {
             applicant2TemplateVars(caseData),
             caseData.getApplicant2().getLanguagePreference()
         );
+    }
+
+    private Map<String, String> applicant1TemplateVars(CaseData caseData) {
+        Map<String, String> templateVars = resubmitTemplateVars(caseData, caseData.getApplicant1(), caseData.getApplicant2());
+        templateVars.put(THEIR_EMAIL_ADDRESS, caseData.getCaseInvite().getApplicant2InviteEmailAddress());
+        return templateVars;
     }
 
     private Map<String, String> applicant2TemplateVars(CaseData caseData) {

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant1ResubmitNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant1ResubmitNotificationTest.java
@@ -25,6 +25,7 @@ import static uk.gov.hmcts.divorce.notification.EmailTemplateName.JOINT_APPLICAN
 import static uk.gov.hmcts.divorce.notification.FormatUtil.DATE_TIME_FORMATTER;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.SIGN_IN_URL_NOTIFY_KEY;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.SUBMISSION_RESPONSE_DATE;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.THEIR_EMAIL_ADDRESS;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SIGN_IN_DISSOLUTION_TEST_URL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SIGN_IN_DIVORCE_TEST_URL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_APPLICANT_2_USER_EMAIL;
@@ -65,6 +66,7 @@ class Applicant1ResubmitNotificationTest {
             eq(TEST_USER_EMAIL),
             eq(JOINT_APPLICANT1_APPLICANT1_CHANGES_MADE),
             argThat(allOf(
+                hasEntry(THEIR_EMAIL_ADDRESS, TEST_APPLICANT_2_USER_EMAIL),
                 hasEntry(SUBMISSION_RESPONSE_DATE, LOCAL_DATE.format(DATE_TIME_FORMATTER))
             )),
             eq(ENGLISH)
@@ -83,6 +85,7 @@ class Applicant1ResubmitNotificationTest {
             eq(TEST_USER_EMAIL),
             eq(JOINT_APPLICANT1_APPLICANT1_CHANGES_MADE),
             argThat(allOf(
+                hasEntry(THEIR_EMAIL_ADDRESS, TEST_APPLICANT_2_USER_EMAIL),
                 hasEntry(SUBMISSION_RESPONSE_DATE, LOCAL_DATE.format(DATE_TIME_FORMATTER))
             )),
             eq(ENGLISH)

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant1ResubmitNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant1ResubmitNotificationTest.java
@@ -25,7 +25,6 @@ import static uk.gov.hmcts.divorce.notification.EmailTemplateName.JOINT_APPLICAN
 import static uk.gov.hmcts.divorce.notification.FormatUtil.DATE_TIME_FORMATTER;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.SIGN_IN_URL_NOTIFY_KEY;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.SUBMISSION_RESPONSE_DATE;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.THEIR_EMAIL_ADDRESS;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SIGN_IN_DISSOLUTION_TEST_URL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SIGN_IN_DIVORCE_TEST_URL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_APPLICANT_2_USER_EMAIL;
@@ -66,13 +65,10 @@ class Applicant1ResubmitNotificationTest {
             eq(TEST_USER_EMAIL),
             eq(JOINT_APPLICANT1_APPLICANT1_CHANGES_MADE),
             argThat(allOf(
-                hasEntry(SUBMISSION_RESPONSE_DATE, LOCAL_DATE.format(DATE_TIME_FORMATTER)),
-                hasEntry(THEIR_EMAIL_ADDRESS, TEST_APPLICANT_2_USER_EMAIL)
+                hasEntry(SUBMISSION_RESPONSE_DATE, LOCAL_DATE.format(DATE_TIME_FORMATTER))
             )),
             eq(ENGLISH)
         );
-
-        verify(commonContent).templateVarsForApplicant(data, data.getApplicant1(), data.getApplicant2());
     }
 
     @Test
@@ -81,33 +77,22 @@ class Applicant1ResubmitNotificationTest {
         data.setDivorceOrDissolution(DivorceOrDissolution.DISSOLUTION);
         data.setDueDate(LOCAL_DATE);
 
-        final HashMap<String, String> templateVars = new HashMap<>();
-
-        when(commonContent.templateVarsForApplicant(data, data.getApplicant1(), data.getApplicant2())).thenReturn(templateVars);
-
         notification.sendToApplicant1(data, 1234567890123456L);
 
         verify(notificationService).sendEmail(
             eq(TEST_USER_EMAIL),
             eq(JOINT_APPLICANT1_APPLICANT1_CHANGES_MADE),
             argThat(allOf(
-                hasEntry(SUBMISSION_RESPONSE_DATE, LOCAL_DATE.format(DATE_TIME_FORMATTER)),
-                hasEntry(THEIR_EMAIL_ADDRESS, TEST_APPLICANT_2_USER_EMAIL)
+                hasEntry(SUBMISSION_RESPONSE_DATE, LOCAL_DATE.format(DATE_TIME_FORMATTER))
             )),
             eq(ENGLISH)
         );
-
-        verify(commonContent).templateVarsForApplicant(data, data.getApplicant1(), data.getApplicant2());
     }
 
     @Test
     void shouldSendEmailToApplicant2WithDivorceContent() {
         CaseData data = validApplicant2CaseData();
         data.setDueDate(LOCAL_DATE);
-
-        final HashMap<String, String> templateVars = new HashMap<>();
-
-        when(commonContent.templateVarsForApplicant(data, data.getApplicant2(), data.getApplicant1())).thenReturn(templateVars);
         when(emailTemplatesConfig.getTemplateVars()).thenReturn(getConfigTemplateVars());
 
         notification.sendToApplicant2(data, 1234567890123456L);
@@ -121,8 +106,6 @@ class Applicant1ResubmitNotificationTest {
             )),
             eq(ENGLISH)
         );
-
-        verify(commonContent).templateVarsForApplicant(data, data.getApplicant2(), data.getApplicant1());
     }
 
     @Test
@@ -130,10 +113,6 @@ class Applicant1ResubmitNotificationTest {
         CaseData data = validApplicant2CaseData();
         data.setDivorceOrDissolution(DivorceOrDissolution.DISSOLUTION);
         data.setDueDate(LOCAL_DATE);
-
-        final HashMap<String, String> templateVars = new HashMap<>();
-
-        when(commonContent.templateVarsForApplicant(data, data.getApplicant2(), data.getApplicant1())).thenReturn(templateVars);
         when(emailTemplatesConfig.getTemplateVars()).thenReturn(getConfigTemplateVars());
 
         notification.sendToApplicant2(data, 1234567890123456L);
@@ -147,6 +126,5 @@ class Applicant1ResubmitNotificationTest {
             )),
             eq(ENGLISH)
         );
-        verify(commonContent).templateVarsForApplicant(data, data.getApplicant2(), data.getApplicant1());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
- https://tools.hmcts.net/jira/browse/NFDIV-1183

### Change description ###
- move content back to template for resubmit notification
- affected template: https://www.notifications.service.gov.uk/services/56f68e5c-b51f-4bdf-a0ac-d70af335e1d1/templates/e0398a62-8900-48d0-baf8-5d73040089ae

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
