### PR TITLE
nfdiv-1183: move content to template

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2NotBrokenNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2NotBrokenNotification.java
@@ -7,22 +7,12 @@ import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.notification.CommonContent;
 import uk.gov.hmcts.divorce.notification.NotificationService;
 
-import java.util.Map;
-
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.JOINT_APPLICANT1_APPLICANT2_REJECTED;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.JOINT_APPLICANT2_APPLICANT2_REJECTED;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.DIVORCE_OR_END_CIVIL_PARTNERSHIP;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.FOR_A_APPLICATION;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.FOR_YOUR_APPLICATION;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.FOR_YOUR_DIVORCE;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.TO_DIVORCE;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.TO_END_CIVIL_PARTNERSHIP;
 
 @Component
 @Slf4j
 public class Applicant2NotBrokenNotification {
-
-    private static final String FOR_A_DIVORCE = "for a divorce";
 
     @Autowired
     private NotificationService notificationService;
@@ -31,45 +21,24 @@ public class Applicant2NotBrokenNotification {
     private CommonContent commonContent;
 
     public void sendToApplicant1(CaseData caseData, Long id) {
-        Map<String, String> templateVars = commonContent.templateVarsForApplicant(
-            caseData, caseData.getApplicant1(), caseData.getApplicant2());
-
-        if (caseData.getDivorceOrDissolution().isDivorce()) {
-            templateVars.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, TO_DIVORCE);
-        } else {
-            templateVars.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, TO_END_CIVIL_PARTNERSHIP);
-        }
-
         log.info("Sending applicant 2 reject notification to applicant 1 for case : {}", id);
 
         notificationService.sendEmail(
             caseData.getApplicant1().getEmail(),
             JOINT_APPLICANT1_APPLICANT2_REJECTED,
-            templateVars,
+            commonContent.commonTemplateVars(caseData, caseData.getApplicant1(), caseData.getApplicant2()),
             caseData.getApplicant1().getLanguagePreference()
         );
     }
 
     public void sendToApplicant2(CaseData caseData, Long id) {
-        Map<String, String> templateVars = commonContent.templateVarsForApplicant(
-            caseData, caseData.getApplicant2(), caseData.getApplicant1());
-
-        if (caseData.getDivorceOrDissolution().isDivorce()) {
-            templateVars.put(FOR_YOUR_APPLICATION, FOR_YOUR_DIVORCE);
-            templateVars.put(FOR_A_APPLICATION, FOR_A_DIVORCE);
-        } else {
-            templateVars.put(FOR_YOUR_APPLICATION, TO_END_CIVIL_PARTNERSHIP);
-            templateVars.put(FOR_A_APPLICATION, TO_END_CIVIL_PARTNERSHIP);
-        }
-
         log.info("Sending applicant 2 reject notification to applicant 1 for case : {}", id);
 
         notificationService.sendEmail(
             caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
             JOINT_APPLICANT2_APPLICANT2_REJECTED,
-            templateVars,
+            commonContent.commonTemplateVars(caseData, caseData.getApplicant2(), caseData.getApplicant1()),
             caseData.getApplicant1().getLanguagePreference()
         );
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/divorce/notification/CommonContent.java
+++ b/src/main/java/uk/gov/hmcts/divorce/notification/CommonContent.java
@@ -26,8 +26,11 @@ import static uk.gov.hmcts.divorce.notification.NotificationConstants.DIVORCE_AP
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.DIVORCE_COURT_EMAIL;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.FIRST_NAME;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.FOR_DIVORCE;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.IS_DISSOLUTION;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.IS_DIVORCE;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.LAST_NAME;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.MARRIAGE;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.NO;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.PARTNER;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.RELATIONSHIP;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.RELATIONSHIP_COURT_HEADER;
@@ -37,6 +40,7 @@ import static uk.gov.hmcts.divorce.notification.NotificationConstants.SIGN_IN_DI
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.SIGN_IN_URL_NOTIFY_KEY;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.TO_END_CIVIL_PARTNERSHIP;
 import static uk.gov.hmcts.divorce.notification.NotificationConstants.UNION;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.YES;
 
 @Component
 public class CommonContent {
@@ -45,7 +49,7 @@ public class CommonContent {
     private static final String END_CIVIL_PARTNERSHIP = "End a civil partnership service";
 
     @Autowired
-    private EmailTemplatesConfig emailTemplatesConfig;
+    private EmailTemplatesConfig config;
 
     public Map<String, String> templateVarsForApplicant(final CaseData caseData, Applicant applicant, Applicant partner) {
         Map<String, String> templateVars = templateVarsFor(caseData);
@@ -62,7 +66,7 @@ public class CommonContent {
 
         final HashMap<String, String> templateVars = new HashMap<>();
 
-        Map<String, String> configTemplateVars = emailTemplatesConfig.getTemplateVars();
+        Map<String, String> configTemplateVars = config.getTemplateVars();
 
         if (caseData.getDivorceOrDissolution().isDivorce()) {
             templateVars.put(RELATIONSHIP, DIVORCE_APPLICATION);
@@ -108,6 +112,20 @@ public class CommonContent {
         templateVars.put(RESPONDENT_NAME, join(" ", respondent.getFirstName(), respondent.getLastName()));
         templateVars.put(APPLICATION_REFERENCE, formatId(caseId));
 
+        return templateVars;
+    }
+
+    public Map<String, String> commonTemplateVars(CaseData caseData, Applicant applicant, Applicant partner) {
+        Map<String, String> templateVars = new HashMap<>();
+        templateVars.put(IS_DIVORCE, isDivorce(caseData) ? YES : NO);
+        templateVars.put(IS_DISSOLUTION, !isDivorce(caseData) ? YES : NO);
+        templateVars.put(FIRST_NAME, applicant.getFirstName());
+        templateVars.put(LAST_NAME, applicant.getLastName());
+        templateVars.put(PARTNER, getPartner(caseData, partner));
+        templateVars.put(COURT_EMAIL,
+            config.getTemplateVars().get(isDivorce(caseData) ? DIVORCE_COURT_EMAIL : DISSOLUTION_COURT_EMAIL));
+        templateVars.put(SIGN_IN_URL_NOTIFY_KEY,
+            config.getTemplateVars().get(isDivorce(caseData) ? SIGN_IN_DIVORCE_URL : SIGN_IN_DISSOLUTION_URL));
         return templateVars;
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2NotBrokenNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2NotBrokenNotificationTest.java
@@ -9,7 +9,7 @@ import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.notification.CommonContent;
 import uk.gov.hmcts.divorce.notification.NotificationService;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
@@ -21,11 +21,10 @@ import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DISSOL
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.JOINT_APPLICANT1_APPLICANT2_REJECTED;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.JOINT_APPLICANT2_APPLICANT2_REJECTED;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.DIVORCE_OR_END_CIVIL_PARTNERSHIP;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.FOR_A_APPLICATION;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.FOR_YOUR_APPLICATION;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.TO_DIVORCE;
-import static uk.gov.hmcts.divorce.notification.NotificationConstants.TO_END_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.IS_DISSOLUTION;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.IS_DIVORCE;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.NO;
+import static uk.gov.hmcts.divorce.notification.NotificationConstants.YES;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_APPLICANT_2_USER_EMAIL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_USER_EMAIL;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.validJointApplicant1CaseData;
@@ -45,10 +44,8 @@ class Applicant2NotBrokenNotificationTest {
     @Test
     void shouldSendEmailToApplicant1WithDivorceContent() {
         CaseData data = validJointApplicant1CaseData();
-
-        final HashMap<String, String> templateVars = new HashMap<>();
-
-        when(commonContent.templateVarsForApplicant(data, data.getApplicant1(), data.getApplicant2())).thenReturn(templateVars);
+        final Map<String, String> templateVars = Map.of(IS_DIVORCE, YES, IS_DISSOLUTION, NO);
+        when(commonContent.commonTemplateVars(data, data.getApplicant1(), data.getApplicant2())).thenReturn(templateVars);
 
         notification.sendToApplicant1(data, 1234567890123456L);
 
@@ -56,21 +53,19 @@ class Applicant2NotBrokenNotificationTest {
             eq(TEST_USER_EMAIL),
             eq(JOINT_APPLICANT1_APPLICANT2_REJECTED),
             argThat(allOf(
-                hasEntry(DIVORCE_OR_END_CIVIL_PARTNERSHIP, TO_DIVORCE)
+                hasEntry(IS_DIVORCE, YES),
+                hasEntry(IS_DISSOLUTION, NO)
             )),
             eq(ENGLISH)
         );
-
-        verify(commonContent).templateVarsForApplicant(data, data.getApplicant1(), data.getApplicant2());
+        verify(commonContent).commonTemplateVars(data, data.getApplicant1(), data.getApplicant2());
     }
 
     @Test
     void shouldSendEmailToApplicant2WithDivorceContent() {
         CaseData data = validJointApplicant1CaseData();
-
-        final HashMap<String, String> templateVars = new HashMap<>();
-
-        when(commonContent.templateVarsForApplicant(data, data.getApplicant2(), data.getApplicant1())).thenReturn(templateVars);
+        final Map<String, String> templateVars = Map.of(IS_DIVORCE, YES, IS_DISSOLUTION, NO);
+        when(commonContent.commonTemplateVars(data, data.getApplicant2(), data.getApplicant1())).thenReturn(templateVars);
 
         notification.sendToApplicant2(data, 1234567890123456L);
 
@@ -78,22 +73,20 @@ class Applicant2NotBrokenNotificationTest {
             eq(TEST_APPLICANT_2_USER_EMAIL),
             eq(JOINT_APPLICANT2_APPLICANT2_REJECTED),
             argThat(allOf(
-                hasEntry(FOR_A_APPLICATION, "for a divorce")
+                hasEntry(IS_DIVORCE, YES),
+                hasEntry(IS_DISSOLUTION, NO)
             )),
             eq(ENGLISH)
         );
-
-        verify(commonContent).templateVarsForApplicant(data, data.getApplicant2(), data.getApplicant1());
+        verify(commonContent).commonTemplateVars(data, data.getApplicant2(), data.getApplicant1());
     }
 
     @Test
     void shouldSendEmailToApplicant1WithDissolutionContent() {
         CaseData data = validJointApplicant1CaseData();
         data.setDivorceOrDissolution(DISSOLUTION);
-
-        final HashMap<String, String> templateVars = new HashMap<>();
-
-        when(commonContent.templateVarsForApplicant(data, data.getApplicant1(), data.getApplicant2())).thenReturn(templateVars);
+        final Map<String, String> templateVars = Map.of(IS_DIVORCE, NO, IS_DISSOLUTION, YES);
+        when(commonContent.commonTemplateVars(data, data.getApplicant1(), data.getApplicant2())).thenReturn(templateVars);
 
         notification.sendToApplicant1(data, 1234567890123456L);
 
@@ -101,22 +94,20 @@ class Applicant2NotBrokenNotificationTest {
             eq(TEST_USER_EMAIL),
             eq(JOINT_APPLICANT1_APPLICANT2_REJECTED),
             argThat(allOf(
-                hasEntry(DIVORCE_OR_END_CIVIL_PARTNERSHIP, TO_END_CIVIL_PARTNERSHIP)
+                hasEntry(IS_DIVORCE, NO),
+                hasEntry(IS_DISSOLUTION, YES)
             )),
             eq(ENGLISH)
         );
-
-        verify(commonContent).templateVarsForApplicant(data, data.getApplicant1(), data.getApplicant2());
+        verify(commonContent).commonTemplateVars(data, data.getApplicant1(), data.getApplicant2());
     }
 
     @Test
     void shouldSendEmailToApplicant2WithDissolutionContent() {
         CaseData data = validJointApplicant1CaseData();
         data.setDivorceOrDissolution(DISSOLUTION);
-
-        final HashMap<String, String> templateVars = new HashMap<>();
-
-        when(commonContent.templateVarsForApplicant(data, data.getApplicant1(), data.getApplicant2())).thenReturn(templateVars);
+        final Map<String, String> templateVars = Map.of(IS_DIVORCE, NO, IS_DISSOLUTION, YES);
+        when(commonContent.commonTemplateVars(data, data.getApplicant2(), data.getApplicant1())).thenReturn(templateVars);
 
         notification.sendToApplicant2(data, 1234567890123456L);
 
@@ -124,12 +115,11 @@ class Applicant2NotBrokenNotificationTest {
             eq(TEST_APPLICANT_2_USER_EMAIL),
             eq(JOINT_APPLICANT2_APPLICANT2_REJECTED),
             argThat(allOf(
-                hasEntry(FOR_YOUR_APPLICATION, TO_END_CIVIL_PARTNERSHIP),
-                hasEntry(FOR_A_APPLICATION, TO_END_CIVIL_PARTNERSHIP)
+                hasEntry(IS_DIVORCE, NO),
+                hasEntry(IS_DISSOLUTION, YES)
             )),
             eq(ENGLISH)
         );
-
-        verify(commonContent).templateVarsForApplicant(data, data.getApplicant2(), data.getApplicant1());
+        verify(commonContent).commonTemplateVars(data, data.getApplicant2(), data.getApplicant1());
     }
 }


### PR DESCRIPTION
### Change description ###
- move more of the content for marriageNotBroken notification to templates (below)
- https://www.notifications.service.gov.uk/services/56f68e5c-b51f-4bdf-a0ac-d70af335e1d1/templates/92440b46-66f9-4b15-bf28-047b5cc8202d
- https://www.notifications.service.gov.uk/services/56f68e5c-b51f-4bdf-a0ac-d70af335e1d1/templates/38d403a8-a3a2-4cbf-bfd6-de406583047c

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
