### PR TITLE
Share a case

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,7 +246,7 @@ dependencies {
   implementation group: 'uk.gov.hmcts.reform', name: 'logging-spring', version: versions.reformsJavaLogging
 
   implementation group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '2.0.0'
-  implementation group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.7.6'
+  implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.8.1'
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.jackson

--- a/charts/nfdiv-case-api/Chart.yaml
+++ b/charts/nfdiv-case-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for nfdiv-case-api App
 name: nfdiv-case-api
 home: https://github.com/hmcts/nfdiv-case-api
-version: 0.0.40
+version: 0.0.41
 maintainers:
   - name: HMCTS nfdiv team
 dependencies:

--- a/charts/nfdiv-case-api/values.preview.template.yaml
+++ b/charts/nfdiv-case-api/values.preview.template.yaml
@@ -75,6 +75,7 @@ ccd:
         DATA_STORE_IDAM_KEY: ${DATA_STORE_S2S_KEY}
         DATA_STORE_DEFAULT_LOG_LEVEL: info
         DATA_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_admin,ccd_ps,divorce_ccd_submission,divorce_frontend,nfdiv_case_api
+        CCD_S2S_AUTHORISED_SERVICES_CASE_USER_ROLES: nfdiv_case_api
         ELASTIC_SEARCH_ENABLED: false
         CCD_DM_DOMAIN: http://dm-store-aat.service.core-compute-aat.internal
         CCD_DOCUMENT_URL_PATTERN: ^https?://(((?:api-gateway\.preprod\.dm\.reform\.hmcts\.net|dm-store-aat\.service\.core-compute-aat\.internal(?::\d+)?)\/documents\/[A-Za-z0-9-]+(?:\/binary)?)|(em-hrs-api-aat\.service\.core-compute-aat\.internal(?::\d+)?\/hearing-recordings\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/segments\/[0-9]))

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorSubmitApplicationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorSubmitApplicationIT.java
@@ -30,10 +30,8 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -43,35 +41,19 @@ import static uk.gov.hmcts.divorce.divorcecase.model.SolicitorPaymentMethod.FEE_
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Draft;
 import static uk.gov.hmcts.divorce.payment.model.PaymentStatus.SUCCESS;
 import static uk.gov.hmcts.divorce.solicitor.event.SolicitorSubmitApplication.SOLICITOR_SUBMIT;
-import static uk.gov.hmcts.divorce.testutil.CaseDataWireMock.stubForCcdCaseRoles;
-import static uk.gov.hmcts.divorce.testutil.CaseDataWireMock.stubForCcdCaseRolesUpdateFailure;
-import static uk.gov.hmcts.divorce.testutil.FeesWireMock.stubForFeesLookup;
 import static uk.gov.hmcts.divorce.testutil.FeesWireMock.stubForFeesNotFound;
-import static uk.gov.hmcts.divorce.testutil.IdamWireMock.CASEWORKER_ROLE;
-import static uk.gov.hmcts.divorce.testutil.IdamWireMock.SOLICITOR_ROLE;
-import static uk.gov.hmcts.divorce.testutil.IdamWireMock.SYSTEM_USER_ROLE;
-import static uk.gov.hmcts.divorce.testutil.IdamWireMock.stubForIdamDetails;
-import static uk.gov.hmcts.divorce.testutil.IdamWireMock.stubForIdamFailure;
-import static uk.gov.hmcts.divorce.testutil.IdamWireMock.stubForIdamToken;
 import static uk.gov.hmcts.divorce.testutil.PaymentWireMock.stubCreditAccountPayment;
-import static uk.gov.hmcts.divorce.testutil.PaymentWireMock.stubPbaNumbersRetrieval;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.ABOUT_TO_START_URL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.ABOUT_TO_SUBMIT_URL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.AUTHORIZATION;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.AUTH_HEADER_VALUE;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.CASEWORKER_AUTH_TOKEN;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.CASEWORKER_USER_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.SOLICITOR_USER_ID;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_USER_USER_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_AUTHORIZATION_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SERVICE_AUTH_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.callbackRequest;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseDataWithOrderSummary;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseDataWithStatementOfTruth;
-import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getFeeResponseAsJson;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getPbaNumbersForAccount;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.orderSummaryWithFee;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.organisationPolicy;
@@ -119,37 +101,6 @@ public class SolicitorSubmitApplicationIT {
     }
 
     @Test
-    public void givenValidCaseDataWhenCallbackIsInvokedThenOrderSummaryAndSolicitorRolesAreSet()
-        throws Exception {
-
-        stubForFeesLookup(getFeeResponseAsJson());
-        stubForIdamDetails(TEST_AUTHORIZATION_TOKEN, SOLICITOR_USER_ID, SOLICITOR_ROLE);
-        stubForIdamDetails(SYSTEM_UPDATE_AUTH_TOKEN, SYSTEM_USER_USER_ID, SYSTEM_USER_ROLE);
-        stubForIdamToken(SYSTEM_UPDATE_AUTH_TOKEN);
-        stubPbaNumbersRetrieval();
-
-        when(serviceTokenGenerator.generate()).thenReturn(AUTH_HEADER_VALUE);
-
-        stubForCcdCaseRoles();
-
-        mockMvc.perform(post(ABOUT_TO_START_URL)
-                .contentType(APPLICATION_JSON)
-                .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
-                .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
-                .content(objectMapper.writeValueAsString(callbackRequest(caseDataWithOrderSummary(), SOLICITOR_SUBMIT)))
-                .accept(APPLICATION_JSON))
-            .andExpect(
-                status().isOk()
-            )
-            .andExpect(
-                content().json(expectedCcdCallbackResponse())
-            );
-
-        verify(serviceTokenGenerator).generate();
-        verifyNoMoreInteractions(serviceTokenGenerator);
-    }
-
-    @Test
     public void givenFeeEventIsNotAvailableWhenCallbackIsInvokedThenReturn404FeeEventNotFound()
         throws Exception {
         stubForFeesNotFound();
@@ -169,58 +120,6 @@ public class SolicitorSubmitApplicationIT {
             .andExpect(
                 result -> assertThat(requireNonNull(result.getResolvedException()).getMessage())
                     .contains("404 Fee event not found")
-            );
-    }
-
-    @Test
-    public void givenValidCaseDataWhenCallbackIsInvokedAndIdamUserRetrievalThrowsUnauthorizedThen401IsReturned()
-        throws Exception {
-
-        stubForFeesLookup(getFeeResponseAsJson());
-        stubForIdamFailure();
-
-        mockMvc.perform(post(ABOUT_TO_START_URL)
-                .contentType(APPLICATION_JSON)
-                .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
-                .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
-                .content(objectMapper.writeValueAsString(callbackRequest(caseDataWithOrderSummary(), SOLICITOR_SUBMIT)))
-                .accept(APPLICATION_JSON))
-            .andExpect(
-                status().isUnauthorized()
-            )
-            .andExpect(
-                result -> assertThat(result.getResolvedException()).isExactlyInstanceOf(FeignException.Unauthorized.class)
-            )
-            .andExpect(
-                result -> assertThat(requireNonNull(result.getResolvedException()).getMessage())
-                    .contains("Invalid idam credentials")
-            );
-    }
-
-    @Test
-    public void givenValidCaseDataWhenCallbackIsInvokedAndCcdCaseRolesUpdateThrowsForbiddenExceptionThen403IsReturned()
-        throws Exception {
-
-        stubForFeesLookup(getFeeResponseAsJson());
-        stubForIdamDetails(TEST_AUTHORIZATION_TOKEN, SOLICITOR_USER_ID, SOLICITOR_ROLE);
-        stubForIdamDetails(CASEWORKER_AUTH_TOKEN, CASEWORKER_USER_ID, CASEWORKER_ROLE);
-        stubForIdamToken(CASEWORKER_AUTH_TOKEN);
-
-        when(serviceTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION);
-
-        stubForCcdCaseRolesUpdateFailure();
-
-        mockMvc.perform(post(ABOUT_TO_START_URL)
-                .contentType(APPLICATION_JSON)
-                .header(SERVICE_AUTHORIZATION, AUTH_HEADER_VALUE)
-                .header(AUTHORIZATION, TEST_AUTHORIZATION_TOKEN)
-                .content(objectMapper.writeValueAsString(callbackRequest(caseDataWithOrderSummary(), SOLICITOR_SUBMIT)))
-                .accept(APPLICATION_JSON))
-            .andExpect(
-                status().isForbidden()
-            )
-            .andExpect(
-                result -> assertThat(result.getResolvedException()).isExactlyInstanceOf(FeignException.Forbidden.class)
             );
     }
 
@@ -289,10 +188,6 @@ public class SolicitorSubmitApplicationIT {
             );
 
         verifyNoInteractions(notificationService);
-    }
-
-    private String expectedCcdCallbackResponse() throws IOException {
-        return expectedResponse("classpath:wiremock/responses/issue-fees-response.json");
     }
 
     private String expectedCcdAboutToSubmitCallbackResponse() throws IOException {

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/testutil/CaseDataWireMock.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/testutil/CaseDataWireMock.java
@@ -9,12 +9,13 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.HttpHeaders;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.AUTH_HEADER_VALUE;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.BEARER;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.CASEWORKER_AUTH_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_AUTHORIZATION_TOKEN;
@@ -39,12 +40,24 @@ public final class CaseDataWireMock {
         }
     }
 
-    public static void stubForCcdCaseRoles() {
-        CASE_DATA_SERVER.stubFor(put(urlMatching("/cases/[0-9]+/users/[0-9]+"))
+    public static void stubForCaseAssignmentRoles() {
+        CASE_DATA_SERVER.stubFor(delete(urlMatching("/case-users"))
             .withHeader(HttpHeaders.AUTHORIZATION, new EqualToPattern(BEARER + SYSTEM_UPDATE_AUTH_TOKEN))
             .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern(AUTH_HEADER_VALUE))
             .withRequestBody(new EqualToJsonPattern(
-                "{\"user_id\" : \"1\", \"case_roles\":[\"[APPONESOLICITOR]\"]}",
+                "{\"case_users\":[{\"case_id\":\"1616591401473378\",\"case_role\":\"[CREATOR]\",\"organisation_id\":\"ABC123\","
+                    + "\"user_id\":\"1\"}]}",
+                true,
+                true))
+            .willReturn(aResponse().withStatus(200))
+        );
+
+        CASE_DATA_SERVER.stubFor(post(urlMatching("/case-users"))
+            .withHeader(HttpHeaders.AUTHORIZATION, new EqualToPattern(BEARER + SYSTEM_UPDATE_AUTH_TOKEN))
+            .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern(AUTH_HEADER_VALUE))
+            .withRequestBody(new EqualToJsonPattern(
+                "{\"case_users\":[{\"case_id\":\"1616591401473378\",\"case_role\":\"[APPONESOLICITOR]\",\"organisation_id\":\"ABC123\","
+                    + "\"user_id\":\"1\"}]}",
                 true,
                 true))
             .willReturn(aResponse().withStatus(200))
@@ -64,11 +77,12 @@ public final class CaseDataWireMock {
     }
 
     public static void stubForCcdCaseRolesUpdateFailure() {
-        CASE_DATA_SERVER.stubFor(put(urlMatching("/cases/[0-9]+/users/[0-9]+"))
-            .withHeader(HttpHeaders.AUTHORIZATION, new EqualToPattern(BEARER + CASEWORKER_AUTH_TOKEN))
-            .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern(SERVICE_AUTHORIZATION))
+        CASE_DATA_SERVER.stubFor(delete(urlMatching("/case-users"))
+            .withHeader(HttpHeaders.AUTHORIZATION, new EqualToPattern(BEARER + SYSTEM_UPDATE_AUTH_TOKEN))
+            .withHeader(SERVICE_AUTHORIZATION, new EqualToPattern(AUTH_HEADER_VALUE))
             .withRequestBody(new EqualToJsonPattern(
-                "{\"user_id\" : \"1\", \"case_roles\":[\"[APPONESOLICITOR]\"]}",
+                "{\"case_users\":[{\"case_id\":\"1616591401473378\",\"case_role\":\"[CREATOR]\",\"organisation_id\":\"ABC123\","
+                    + "\"user_id\":\"1\"}]}",
                 true,
                 true))
             .willReturn(aResponse().withStatus(403))

--- a/src/main/java/uk/gov/hmcts/divorce/CaseApiApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/CaseApiApplication.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationClient;
 import uk.gov.hmcts.divorce.solicitor.client.pba.PbaRefDataClient;
 import uk.gov.hmcts.divorce.systemupdate.service.ScheduledTaskRunner;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
+import uk.gov.hmcts.reform.ccd.client.CaseAssignmentApi;
 import uk.gov.hmcts.reform.ccd.client.CaseUserApi;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataClientAutoConfiguration;
@@ -36,6 +37,7 @@ import javax.annotation.PostConstruct;
         FeesAndPaymentsClient.class,
         DocAssemblyClient.class,
         CoreCaseDataApi.class,
+        CaseAssignmentApi.class,
         DocumentManagementClient.class,
         OrganisationClient.class,
         PbaRefDataClient.class,

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitApplication.java
@@ -24,7 +24,6 @@ import uk.gov.hmcts.divorce.solicitor.event.page.SolPayment;
 import uk.gov.hmcts.divorce.solicitor.event.page.SolPaymentSummary;
 import uk.gov.hmcts.divorce.solicitor.event.page.SolStatementOfTruth;
 import uk.gov.hmcts.divorce.solicitor.event.page.SolSummary;
-import uk.gov.hmcts.divorce.solicitor.service.CcdAccessService;
 import uk.gov.hmcts.divorce.solicitor.service.notification.SolicitorSubmittedNotification;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
@@ -33,12 +32,10 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import javax.servlet.http.HttpServletRequest;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.util.CollectionUtils.isEmpty;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
@@ -64,12 +61,6 @@ public class SolicitorSubmitApplication implements CCDConfig<CaseData, State, Us
 
     @Autowired
     private PaymentService paymentService;
-
-    @Autowired
-    private CcdAccessService ccdAccessService;
-
-    @Autowired
-    private HttpServletRequest httpServletRequest;
 
     @Autowired
     private SolPayment solPayment;
@@ -108,12 +99,6 @@ public class SolicitorSubmitApplication implements CCDConfig<CaseData, State, Us
             NumberFormat.getNumberInstance().format(
                 new BigDecimal(orderSummary.getPaymentTotal()).movePointLeft(2)
             )
-        );
-
-        log.info("Adding the applicant's solicitor case roles");
-        ccdAccessService.addApplicant1SolicitorRole(
-            httpServletRequest.getHeader(AUTHORIZATION),
-            details.getId()
         );
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitApplicationTest.java
@@ -24,14 +24,12 @@ import uk.gov.hmcts.divorce.payment.model.Payment;
 import uk.gov.hmcts.divorce.payment.model.PaymentStatus;
 import uk.gov.hmcts.divorce.payment.model.PbaResponse;
 import uk.gov.hmcts.divorce.solicitor.event.page.SolPayment;
-import uk.gov.hmcts.divorce.solicitor.service.CcdAccessService;
 import uk.gov.hmcts.divorce.solicitor.service.notification.SolicitorSubmittedNotification;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import javax.servlet.http.HttpServletRequest;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Collections.singletonList;
@@ -41,7 +39,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
@@ -74,12 +71,6 @@ public class SolicitorSubmitApplicationTest {
     private PaymentService paymentService;
 
     @Mock
-    private CcdAccessService ccdAccessService;
-
-    @Mock
-    private HttpServletRequest httpServletRequest;
-
-    @Mock
     private SubmissionService submissionService;
 
     @Mock
@@ -103,7 +94,6 @@ public class SolicitorSubmitApplicationTest {
         caseDetails.setId(caseId);
 
         when(paymentService.getOrderSummaryByServiceEvent(SERVICE_DIVORCE, EVENT_ISSUE, KEYWORD_DIVORCE)).thenReturn(orderSummary);
-        when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn(authorization);
         when(orderSummary.getPaymentTotal()).thenReturn("55000");
 
         var midEventCaseData = caseData();
@@ -119,11 +109,6 @@ public class SolicitorSubmitApplicationTest {
 
         assertThat(response.getData().getApplication().getApplicationFeeOrderSummary()).isEqualTo(orderSummary);
         assertThat(response.getData().getApplication().getSolApplicationFeeInPounds()).isEqualTo("550");
-
-        verify(ccdAccessService).addApplicant1SolicitorRole(
-            authorization,
-            caseId
-        );
     }
 
     @Test


### PR DESCRIPTION
- Remove [CREATOR] role when adding [APPONESOLICITOR] role
- Switch roles on submitted hook in solicitor-create-application event instead of aboutToStart of solicitor-submit-case
- Upgrade ccd-client library
- Use Case Assignment API to change user roles to ensure supplementary data for Share a case is set correctly by CCD

As noted on: https://tools.hmcts.net/confluence/display/RCCD/A+Guide+to+Assign+Access+to+cases+for+professional+users%3A+configuration?focusedCommentId=1475839441#comment-1475839441 you must remove the [CREATOR] role before adding the new role or the supplementary data does not get set.