### PR TITLE
Add solicitor statement of truth page with disputed/undisputed events

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitAos.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitAos.java
@@ -13,14 +13,10 @@ import uk.gov.hmcts.divorce.common.event.page.Applicant2SolStatementOfTruth;
 import uk.gov.hmcts.divorce.common.event.page.SolicitorDetailsWithStatementOfTruth;
 import uk.gov.hmcts.divorce.common.service.SubmitAosService;
 import uk.gov.hmcts.divorce.divorcecase.model.AcknowledgementOfService;
-import uk.gov.hmcts.divorce.divorcecase.model.Application;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
-import uk.gov.hmcts.divorce.divorcecase.model.HowToRespondApplication;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.idam.IdamService;
-import uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosDisputed;
-import uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosUnDisputed;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
@@ -42,7 +38,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_R
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosDisputed.SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosUnDisputed.SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED;
-import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorServicePack.SYSTEM_ISSUE_SOLICITOR_SERVICE_PACK;
 
 @Component
 @Slf4j
@@ -141,7 +136,6 @@ public class SubmitAos implements CCDConfig<CaseData, State, UserRole> {
         String eventId;
         if (DISPUTE_DIVORCE.equals(acknowledgementOfService.getHowToRespondApplication())) {
             eventId = SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED;
-
         } else {
             eventId = SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED;
         }
@@ -149,7 +143,7 @@ public class SubmitAos implements CCDConfig<CaseData, State, UserRole> {
         final User user = idamService.retrieveSystemUpdateUserDetails();
         final String serviceAuthorization = authTokenGenerator.generate();
 
-        log.info("Submitting solicitor event id {} for case id {}", eventId, details.getId());
+        log.info("Submitting event id {} for case id {}", eventId, details.getId());
         ccdUpdateService.submitEvent(details, eventId, user, serviceAuthorization);
 
         return SubmittedCallbackResponse.builder().build();

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitAos.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitAos.java
@@ -133,12 +133,9 @@ public class SubmitAos implements CCDConfig<CaseData, State, UserRole> {
 
         final AcknowledgementOfService acknowledgementOfService = details.getData().getAcknowledgementOfService();
 
-        String eventId;
-        if (DISPUTE_DIVORCE.equals(acknowledgementOfService.getHowToRespondApplication())) {
-            eventId = SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED;
-        } else {
-            eventId = SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED;
-        }
+        String eventId = DISPUTE_DIVORCE.equals(acknowledgementOfService.getHowToRespondApplication())
+            ? SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED
+            : SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED;
 
         final User user = idamService.retrieveSystemUpdateUserDetails();
         final String serviceAuthorization = authTokenGenerator.generate();

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitAos.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitAos.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.divorce.common.event;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
@@ -9,16 +10,27 @@ import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.divorce.common.ccd.CcdPageConfiguration;
 import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
 import uk.gov.hmcts.divorce.common.event.page.Applicant2SolStatementOfTruth;
+import uk.gov.hmcts.divorce.common.event.page.SolicitorDetailsWithStatementOfTruth;
 import uk.gov.hmcts.divorce.common.service.SubmitAosService;
 import uk.gov.hmcts.divorce.divorcecase.model.AcknowledgementOfService;
+import uk.gov.hmcts.divorce.divorcecase.model.Application;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.HowToRespondApplication;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.divorce.idam.IdamService;
+import uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosDisputed;
+import uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosUnDisputed;
+import uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
+import uk.gov.hmcts.reform.idam.client.models.User;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+import static uk.gov.hmcts.divorce.divorcecase.model.HowToRespondApplication.DISPUTE_DIVORCE;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AosDrafted;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Holding;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2;
@@ -28,8 +40,12 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosDisputed.SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED;
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosUnDisputed.SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED;
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorServicePack.SYSTEM_ISSUE_SOLICITOR_SERVICE_PACK;
 
 @Component
+@Slf4j
 public class SubmitAos implements CCDConfig<CaseData, State, UserRole> {
 
     public static final String SUBMIT_AOS = "submit-aos";
@@ -37,8 +53,18 @@ public class SubmitAos implements CCDConfig<CaseData, State, UserRole> {
     @Autowired
     private SubmitAosService submitAosService;
 
+    @Autowired
+    private CcdUpdateService ccdUpdateService;
+
+    @Autowired
+    private IdamService idamService;
+
+    @Autowired
+    private AuthTokenGenerator authTokenGenerator;
+
     private final List<CcdPageConfiguration> pages = List.of(
-        new Applicant2SolStatementOfTruth()
+        new Applicant2SolStatementOfTruth(),
+        new SolicitorDetailsWithStatementOfTruth()
     );
 
     @Override
@@ -96,11 +122,36 @@ public class SubmitAos implements CCDConfig<CaseData, State, UserRole> {
             .description("Submit AoS")
             .showSummary()
             .aboutToSubmitCallback(this::aboutToSubmit)
+            .submittedCallback(this::submitted)
             .explicitGrants()
             .grant(CREATE_READ_UPDATE, APPLICANT_2_SOLICITOR, APPLICANT_2)
             .grant(READ,
                 CASE_WORKER,
                 LEGAL_ADVISOR,
                 SUPER_USER));
+    }
+
+    public SubmittedCallbackResponse submitted(final CaseDetails<CaseData, State> details,
+                                               final CaseDetails<CaseData, State> beforeDetails) {
+
+        log.info("Caseworker submit aos submitted callback invoked for case id: {}", details.getId());
+
+        final AcknowledgementOfService acknowledgementOfService = details.getData().getAcknowledgementOfService();
+
+        String eventId;
+        if (DISPUTE_DIVORCE.equals(acknowledgementOfService.getHowToRespondApplication())) {
+            eventId = SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED;
+
+        } else {
+            eventId = SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED;
+        }
+
+        final User user = idamService.retrieveSystemUpdateUserDetails();
+        final String serviceAuthorization = authTokenGenerator.generate();
+
+        log.info("Submitting solicitor event id {} for case id {}", eventId, details.getId());
+        ccdUpdateService.submitEvent(details, eventId, user, serviceAuthorization);
+
+        return SubmittedCallbackResponse.builder().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/page/Applicant2SolStatementOfTruth.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/page/Applicant2SolStatementOfTruth.java
@@ -26,12 +26,6 @@ public class Applicant2SolStatementOfTruth implements CcdPageConfiguration {
             .complex(CaseData::getApplicant2)
                 .readonlyNoSummary(Applicant::getLegalProceedings)
                 .readonlyNoSummary(Applicant::getLegalProceedingsDetails)
-            .done()
-            .complex(CaseData::getAcknowledgementOfService)
-                .label("LabelApplicant2SolStatementOfTruth-SOT", "## Statement of truth")
-                .mandatory(AcknowledgementOfService::getStatementOfTruth)
-                .label("LabelApplicant2SolStatementOfTruth-Prayer", "## Prayer")
-                .mandatory(AcknowledgementOfService::getPrayerHasBeenGiven)
-                .done();
+            .done();
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/page/SolicitorDetailsWithStatementOfTruth.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/page/SolicitorDetailsWithStatementOfTruth.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.divorce.common.event.page;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.type.Organisation;
+import uk.gov.hmcts.ccd.sdk.type.OrganisationPolicy;
+import uk.gov.hmcts.divorce.common.ccd.CcdPageConfiguration;
+import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
+import uk.gov.hmcts.divorce.divorcecase.model.AcknowledgementOfService;
+import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_1_SOLICITOR;
+
+@Component
+public class SolicitorDetailsWithStatementOfTruth implements CcdPageConfiguration {
+
+    @Override
+    public void addTo(final PageBuilder pageBuilder) {
+
+        pageBuilder
+            .page("SubmitAos")
+            .pageLabel("Statement of Truth - Solicitor")
+            .complex(CaseData::getAcknowledgementOfService)
+                .label("labelApplicant2SolStatementOfTruth-SOT", "## Statement of truth")
+                .mandatory(AcknowledgementOfService::getStatementOfTruth)
+                .done()
+            .complex(CaseData::getApplicant2)
+                .complex(Applicant::getSolicitor)
+                    .complex(Solicitor::getOrganisationPolicy, null, "Your firm's address or DX number")
+                        .complex(OrganisationPolicy::getOrganisation)
+                            .mandatory(Organisation::getOrganisationId)
+                            .done()
+                    .done()
+                .done()
+            .done()
+            .complex(CaseData::getAcknowledgementOfService)
+                .optional(AcknowledgementOfService::getAdditionalComments)
+            .done()
+            .label("warning-ProceedingForContent",
+                "*Proceedings for contempt of court may be brought against anyone who makes, or causes to be made, "
+                    + "a false statement verified by a statement of truth without an honest belief in its truth *");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/page/SolicitorDetailsWithStatementOfTruth.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/page/SolicitorDetailsWithStatementOfTruth.java
@@ -1,16 +1,12 @@
 package uk.gov.hmcts.divorce.common.event.page;
 
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.ccd.sdk.type.Organisation;
-import uk.gov.hmcts.ccd.sdk.type.OrganisationPolicy;
 import uk.gov.hmcts.divorce.common.ccd.CcdPageConfiguration;
 import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
 import uk.gov.hmcts.divorce.divorcecase.model.AcknowledgementOfService;
 import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
-
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_1_SOLICITOR;
 
 @Component
 public class SolicitorDetailsWithStatementOfTruth implements CcdPageConfiguration {
@@ -27,13 +23,7 @@ public class SolicitorDetailsWithStatementOfTruth implements CcdPageConfiguratio
                 .done()
             .complex(CaseData::getApplicant2)
                 .complex(Applicant::getSolicitor)
-                    .complex(Solicitor::getOrganisationPolicy, null, "Your firm's address or DX number")
-                        .complex(OrganisationPolicy::getOrganisation)
-                            .mandatory(Organisation::getOrganisationId)
-                            .done()
-                    .optional(OrganisationPolicy::getOrgPolicyCaseAssignedRole, NEVER_SHOW, APPLICANT_1_SOLICITOR)
-                    .optional(OrganisationPolicy::getOrgPolicyReference, NEVER_SHOW)
-                    .done()
+                    .mandatory(Solicitor::getAddress)
                 .done()
             .done()
             .complex(CaseData::getAcknowledgementOfService)

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/page/SolicitorDetailsWithStatementOfTruth.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/page/SolicitorDetailsWithStatementOfTruth.java
@@ -31,6 +31,8 @@ public class SolicitorDetailsWithStatementOfTruth implements CcdPageConfiguratio
                         .complex(OrganisationPolicy::getOrganisation)
                             .mandatory(Organisation::getOrganisationId)
                             .done()
+                    .optional(OrganisationPolicy::getOrgPolicyCaseAssignedRole, NEVER_SHOW, APPLICANT_1_SOLICITOR)
+                    .optional(OrganisationPolicy::getOrgPolicyReference, NEVER_SHOW)
                     .done()
                 .done()
             .done()
@@ -39,6 +41,6 @@ public class SolicitorDetailsWithStatementOfTruth implements CcdPageConfiguratio
             .done()
             .label("warning-ProceedingForContent",
                 "*Proceedings for contempt of court may be brought against anyone who makes, or causes to be made, "
-                    + "a false statement verified by a statement of truth without an honest belief in its truth *");
+                    + "a false statement verified by a statement of truth without an honest belief in its truth*");
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/AcknowledgementOfService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/AcknowledgementOfService.java
@@ -115,6 +115,7 @@ public class AcknowledgementOfService {
     @CCD(
         label = "Additional Comments",
         hint = "For the attention of court staff. These comments will not form part of the AOS",
+        typeOverride = TextArea,
         access = {AosAccess.class}
     )
     private String additionalComments;

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/AcknowledgementOfService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/AcknowledgementOfService.java
@@ -112,6 +112,12 @@ public class AcknowledgementOfService {
     )
     private HowToRespondApplication howToRespondApplication;
 
+    @CCD(
+        label = "Additional Comments",
+        hint = "For the attention of court staff. These comments will not form part of the AOS",
+        access = {AosAccess.class}
+    )
+    private String additionalComments;
 
     @JsonIgnore
     public void setNoticeOfProceedings(final Solicitor solicitor) {

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueSolicitorAosDisputed.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueSolicitorAosDisputed.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.divorce.systemupdate.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingService;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
+
+@Component
+@Slf4j
+public class SystemIssueSolicitorAosDisputed implements CCDConfig<CaseData, State, UserRole> {
+
+    public static final String SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED = "system-issue-solicitor-aos-disputed";
+
+    @Override
+    public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
+
+        new PageBuilder(configBuilder
+            .event(SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED)
+            .forState(AwaitingService)
+            .name("Aos disputed")
+            .description("Aos disputed")
+            .explicitGrants()
+            .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
+            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
+            .retries(120, 120));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueSolicitorAosUnDisputed.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueSolicitorAosUnDisputed.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.divorce.systemupdate.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingService;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
+
+@Component
+@Slf4j
+public class SystemIssueSolicitorAosUnDisputed implements CCDConfig<CaseData, State, UserRole> {
+
+    public static final String SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED = "system-issue-solicitor-aos-undisputed";
+
+    @Override
+    public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
+
+        new PageBuilder(configBuilder
+            .event(SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED)
+            .forState(AwaitingService)
+            .name("Aos undisputed")
+            .description("Aos undisputed")
+            .explicitGrants()
+            .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
+            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
+            .retries(120, 120));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-1345

### Change description ###

- Removed Prayer and statement of truth from `Applicant2SolStatementOfTruth` page as SOT is moved to new page and prayer is removed.
- Added new page `SolicitorDetailsWithStatementOfTruth` as below.
- As part of submitted event created disputed/undisputed event based on how solicitor has chosen to respond.

![image (31)](https://user-images.githubusercontent.com/13840402/142255958-92deeb4a-6828-4ace-8dfc-a12e3a79e5b9.png)

