### PR TITLE
Display respondent contact details when keep confidential is not set

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/ApplicationTab.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/ApplicationTab.java
@@ -88,12 +88,12 @@ public class ApplicationTab implements CCDConfig<CaseData, State, UserRole> {
                 "applicant2KeepContactDetailsConfidential=\"Yes\"",
                 "#### ${labelContentTheApplicant2UC}'s contact details are confidential")
             .label("LabelApplicant2DetailsAreShareable-Heading",
-                "applicant2KeepContactDetailsConfidential=\"No\"",
+                "applicant2KeepContactDetailsConfidential!=\"Yes\"",
                 "#### ${labelContentTheApplicant2UC}'s contact details may be shared")
-            .field("applicant2PhoneNumber", "applicant2KeepContactDetailsConfidential=\"No\"")
-            .field("applicant2Email", "applicant2KeepContactDetailsConfidential=\"No\"")
-            .field("applicant2HomeAddress", "applicant2KeepContactDetailsConfidential=\"No\"")
-            .field("applicant2CorrespondenceAddress", "applicant2KeepContactDetailsConfidential=\"No\"")
+            .field("applicant2PhoneNumber", "applicant2KeepContactDetailsConfidential!=\"Yes\"")
+            .field("applicant2Email", "applicant2KeepContactDetailsConfidential!=\"Yes\"")
+            .field("applicant2HomeAddress", "applicant2KeepContactDetailsConfidential!=\"Yes\"")
+            .field("applicant2CorrespondenceAddress", "applicant2KeepContactDetailsConfidential!=\"Yes\"")
             .field("applicant2AgreedToReceiveEmails")
 
             //Applicant 2 Solicitor


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/NFDIV-1410


### Change description ###
Display respondent contact details in application tab when applicant2KeepContactDetailsConfidential is not set