### PR TITLE
Nfdiv 1428 set applicant2 email on submit

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerIssueApplicationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerIssueApplicationIT.java
@@ -187,6 +187,7 @@ public class CaseworkerIssueApplicationIT {
         caseData.getApplication().setSolSignStatementOfTruth(null);
         caseData.getApplication().setDivorceWho(WIFE);
         caseData.getApplicant2().getHomeAddress().setCountry("UK");
+        caseData.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         when(serviceTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         when(documentIdProvider.documentId()).thenReturn("Divorce application").thenReturn("Notice of proceeding");
@@ -241,6 +242,7 @@ public class CaseworkerIssueApplicationIT {
         caseData.getApplication().setSolSignStatementOfTruth(null);
         caseData.getApplication().setDivorceWho(WIFE);
         caseData.getApplicant2().getHomeAddress().setCountry("France");
+        caseData.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         when(serviceTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         when(documentIdProvider.documentId()).thenReturn("Divorce application").thenReturn("Notice of proceeding");
@@ -302,6 +304,7 @@ public class CaseworkerIssueApplicationIT {
         caseData.setApplicationType(JOINT_APPLICATION);
         caseData.getApplication().getMarriageDetails().setPlaceOfMarriage("London");
         caseData.getApplication().setApplicant1KnowsApplicant2EmailAddress(YES);
+        caseData.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         when(serviceTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         when(documentIdProvider.documentId()).thenReturn("Respondent Invitation").thenReturn("Divorce application");

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerReIssueApplicationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerReIssueApplicationIT.java
@@ -127,8 +127,9 @@ public class CaseworkerReIssueApplicationIT {
         "classpath:caseworker-reissue-sole-citizen-application-about-to-submit-response.json";
     private static final String JOINT_CITIZEN_CASEWORKER_ABOUT_TO_SUBMIT =
         "classpath:caseworker-issue-joint-citizen-application-about-to-submit-response.json";
-    public static final String MINI_APPLICATION_ID = "5cd725e8-f053-4493-9cbe-bb69d1905ae3";
-    public static final String AOS_COVER_LETTER_ID = "c35b1868-e397-457a-aa67-ac1422bb8100";
+    private static final String MINI_APPLICATION_ID = "5cd725e8-f053-4493-9cbe-bb69d1905ae3";
+    private static final String AOS_COVER_LETTER_ID = "c35b1868-e397-457a-aa67-ac1422bb8100";
+    private static final String SOLE_APPLICATION_DOC_NAME = "NFD_CP_Application_Sole.docx";
 
     @Autowired
     private MockMvc mockMvc;
@@ -180,11 +181,12 @@ public class CaseworkerReIssueApplicationIT {
         caseData.getApplication().setSolSignStatementOfTruth(null);
         caseData.getApplication().setReissueOption(reissueOption);
         caseData.getApplication().setIssueDate(LocalDate.now());
+        caseData.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         when(serviceTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         when(documentIdProvider.documentId()).thenReturn("Respondent Invitation").thenReturn("Divorce application");
 
-        stubForDocAssemblyWith(MINI_APPLICATION_ID, "NFD_CP_Mini_Application_Sole_Joint.docx");
+        stubForDocAssemblyWith(MINI_APPLICATION_ID, "NFD_CP_Application_Sole.docx");
         stubForIdamDetails(TEST_AUTHORIZATION_TOKEN, CASEWORKER_USER_ID, CASEWORKER_ROLE);
         stubForIdamToken(TEST_AUTHORIZATION_TOKEN);
         stubForIdamDetails(TEST_SYSTEM_AUTHORISATION_TOKEN, SYSTEM_USER_USER_ID, SYSTEM_USER_ROLE);
@@ -237,11 +239,12 @@ public class CaseworkerReIssueApplicationIT {
         caseData.getApplication().setReissueOption(reissueOption);
         caseData.getApplication().setIssueDate(LocalDate.now());
         caseData.getApplication().setApplicant1KnowsApplicant2EmailAddress(YES);
+        caseData.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         when(serviceTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         when(documentIdProvider.documentId()).thenReturn("Respondent Invitation").thenReturn("Divorce application");
 
-        stubForDocAssemblyWith(MINI_APPLICATION_ID, "NFD_CP_Mini_Application_Sole_Joint.docx");
+        stubForDocAssemblyWith(MINI_APPLICATION_ID, SOLE_APPLICATION_DOC_NAME);
         stubForIdamDetails(TEST_AUTHORIZATION_TOKEN, CASEWORKER_USER_ID, CASEWORKER_ROLE);
         stubForIdamToken(TEST_AUTHORIZATION_TOKEN);
         stubForIdamDetails(TEST_SYSTEM_AUTHORISATION_TOKEN, SYSTEM_USER_USER_ID, SYSTEM_USER_ROLE);

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenAddPaymentIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenAddPaymentIT.java
@@ -185,6 +185,7 @@ public class CitizenAddPaymentIT {
         data.getApplication().getMarriageDetails().setMarriedInUk(NO);
         data.getApplication().setApplicant1CannotUploadSupportingDocument(Set.of(MARRIAGE_CERTIFICATE, MARRIAGE_CERTIFICATE_TRANSLATION));
         data.getApplication().setApplicant2CannotUploadSupportingDocument(Set.of(NAME_CHANGE_EVIDENCE));
+        data.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         OrderSummary orderSummary = OrderSummary.builder().paymentTotal("55000").build();
         data.getApplication().setApplicationFeeOrderSummary(orderSummary);

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant1ResubmitIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant1ResubmitIT.java
@@ -76,6 +76,7 @@ public class CitizenApplicant1ResubmitIT {
         var marriageDetails = data.getApplication().getMarriageDetails();
         marriageDetails.setDate(LocalDate.of(2020, 1, 1));
         data.setNote("Marriage date incorrect, correct date: 1/1/2020");
+        data.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         String actualResponse = mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
             .contentType(APPLICATION_JSON)

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant2ApproveIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant2ApproveIT.java
@@ -76,6 +76,7 @@ public class CitizenApplicant2ApproveIT {
     @Test
     public void givenValidCaseDataWhenCallbackIsInvokedThenSendEmailToApplicant1AndApplicant2() throws Exception {
         CaseData data = validApplicant2CaseData();
+        data.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         String actualResponse = mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
             .contentType(APPLICATION_JSON)
@@ -105,6 +106,7 @@ public class CitizenApplicant2ApproveIT {
         CaseData data = validApplicant2CaseData();
         data.getApplication().setApplicant1HelpWithFees(HelpWithFees.builder().needHelp(YES).build());
         data.getApplication().setApplicant2HelpWithFees(HelpWithFees.builder().needHelp(NO).build());
+        data.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         String actualResponse = mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
             .contentType(APPLICATION_JSON)

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenSwitchToSoleApplicationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenSwitchToSoleApplicationIT.java
@@ -106,6 +106,7 @@ public class CitizenSwitchToSoleApplicationIT {
     @Test
     public void givenValidCaseDataWhenCallbackIsInvokedForApplicant2SwitchToSoleThenCaseIsWithdrawnAndNotificationsSent() throws Exception {
         CaseData data = validApplicant2CaseData();
+        data.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         String actualResponse = mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
             .contentType(APPLICATION_JSON)

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/common/SubmitAosIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/common/SubmitAosIT.java
@@ -148,6 +148,7 @@ public class SubmitAosIT {
         data.getApplication().setIssueDate(LOCAL_DATE);
         data.getAcknowledgementOfService().setHowToRespondApplication(WITHOUT_DISPUTE_DIVORCE);
         data.getApplicant1().setSolicitor(null);
+        data.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         when(serviceTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         stubForIdamDetails(TEST_SYSTEM_AUTHORISATION_TOKEN, SYSTEM_USER_USER_ID, SYSTEM_USER_ROLE);
@@ -185,6 +186,7 @@ public class SubmitAosIT {
         data.getApplication().setIssueDate(LOCAL_DATE);
         data.getAcknowledgementOfService().setHowToRespondApplication(DISPUTE_DIVORCE);
         data.getApplicant1().setSolicitor(null);
+        data.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         when(serviceTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         stubForIdamDetails(TEST_SYSTEM_AUTHORISATION_TOKEN, SYSTEM_USER_USER_ID, SYSTEM_USER_ROLE);

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressCaseToAosOverdueIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressCaseToAosOverdueIT.java
@@ -78,6 +78,7 @@ public class SystemProgressCaseToAosOverdueIT {
         data.setDueDate(LOCAL_DATE);
         data.getApplication().setIssueDate(LOCAL_DATE);
         data.getCaseInvite().setAccessCode("1234-1234-1234-1234");
+        data.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         String actualResponse = mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
             .contentType(APPLICATION_JSON)

--- a/src/integrationTest/resources/caseworker-issue-joint-citizen-application-about-to-submit-response.json
+++ b/src/integrationTest/resources/caseworker-issue-joint-citizen-application-about-to-submit-response.json
@@ -11,7 +11,7 @@
     "applicant2FirstName": "test_first_name",
     "applicant2MiddleName": "test_middle_name",
     "applicant2LastName": "test_last_name",
-    "applicant2Email": "test@test.com",
+    "applicant2Email": "applicant2@test.com",
     "applicant2LanguagePreferenceWelsh": "No",
     "applicant2Gender": "male",
     "marriageApplicant1Name": "test_first_name test_last_name",

--- a/src/integrationTest/resources/caseworker-issue-sole-citizen-application-about-to-submit-response.json
+++ b/src/integrationTest/resources/caseworker-issue-sole-citizen-application-about-to-submit-response.json
@@ -15,7 +15,7 @@
     "applicant2FirstName": "test_first_name",
     "applicant2MiddleName": "test_middle_name",
     "applicant2LastName": "test_last_name",
-    "applicant2Email": "test@test.com",
+    "applicant2Email": "applicant2@test.com",
     "applicant2LanguagePreferenceWelsh": "No",
     "applicant2HomeAddress": {
       "AddressLine1": "line 1",

--- a/src/integrationTest/resources/caseworker-reissue-sole-citizen-application-about-to-submit-response.json
+++ b/src/integrationTest/resources/caseworker-reissue-sole-citizen-application-about-to-submit-response.json
@@ -11,7 +11,7 @@
     "applicant2FirstName": "test_first_name",
     "applicant2MiddleName": "test_middle_name",
     "applicant2LastName": "test_last_name",
-    "applicant2Email": "test@test.com",
+    "applicant2Email": "applicant2@test.com",
     "applicant2LanguagePreferenceWelsh": "No",
     "applicant2Gender": "male",
     "marriageApplicant1Name": "test_first_name test_last_name",

--- a/src/integrationTest/resources/wiremock/responses/about-to-submit-applicant-2-approved.json
+++ b/src/integrationTest/resources/wiremock/responses/about-to-submit-applicant-2-approved.json
@@ -8,7 +8,7 @@
     "applicant1LanguagePreferenceWelsh": "No",
     "applicant1LastName": "test_last_name",
     "applicant1MiddleName": "test_middle_name",
-    "applicant2Email": "test@test.com",
+    "applicant2Email": "applicant2@test.com",
     "applicant2FirstName": "test_first_name",
     "applicant2Gender": "male",
     "applicant2InviteEmailAddress": "applicant2@test.com",

--- a/src/integrationTest/resources/wiremock/responses/about-to-submit-citizen-submit-aos-with-dispute.json
+++ b/src/integrationTest/resources/wiremock/responses/about-to-submit-citizen-submit-aos-with-dispute.json
@@ -11,7 +11,7 @@
     "applicant1MiddleName": "test_middle_name",
     "applicant1PrayerHasBeenGivenCheckbox": ["Yes"],
     "applicant1StatementOfTruth": "Yes",
-    "applicant2Email": "test@test.com",
+    "applicant2Email": "applicant2@test.com",
     "applicant2FinancialOrder": "No",
     "applicant2FirstName": "test_first_name",
     "applicant2Gender": "male",

--- a/src/integrationTest/resources/wiremock/responses/about-to-submit-citizen-submit-aos-without-dispute.json
+++ b/src/integrationTest/resources/wiremock/responses/about-to-submit-citizen-submit-aos-without-dispute.json
@@ -11,7 +11,7 @@
     "applicant1MiddleName": "test_middle_name",
     "applicant1PrayerHasBeenGivenCheckbox": ["Yes"],
     "applicant1StatementOfTruth": "Yes",
-    "applicant2Email": "test@test.com",
+    "applicant2Email": "applicant2@test.com",
     "applicant2FinancialOrder": "No",
     "applicant2FirstName": "test_first_name",
     "applicant2Gender": "male",

--- a/src/integrationTest/resources/wiremock/responses/about-to-submit-system-progress-case-to-aos-overdue.json
+++ b/src/integrationTest/resources/wiremock/responses/about-to-submit-system-progress-case-to-aos-overdue.json
@@ -11,7 +11,7 @@
     "applicant1MiddleName": "test_middle_name",
     "applicant1PrayerHasBeenGivenCheckbox": ["Yes"],
     "applicant1StatementOfTruth": "Yes",
-    "applicant2Email": "test@test.com",
+    "applicant2Email": "applicant2@test.com",
     "applicant2FinancialOrder": "No",
     "applicant2FirstName": "test_first_name",
     "applicant2Gender": "male",

--- a/src/integrationTest/resources/wiremock/responses/applicant-1-resubmit-application.json
+++ b/src/integrationTest/resources/wiremock/responses/applicant-1-resubmit-application.json
@@ -8,7 +8,7 @@
   "applicant1LanguagePreferenceWelsh": "No",
   "applicant1LastName": "test_last_name",
   "applicant1MiddleName": "test_middle_name",
-  "applicant2Email": "test@test.com",
+  "applicant2Email": "applicant2@test.com",
   "applicant2FirstName": "test_first_name",
   "applicant2Gender": "male",
   "applicant2InviteEmailAddress": "applicant2@test.com",

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/service/task/SendApplicationIssueNotifications.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/service/task/SendApplicationIssueNotifications.java
@@ -27,7 +27,7 @@ public class SendApplicationIssueNotifications implements CaseTask {
 
             if (caseData.getApplicationType().isSole()) {
                 applicationIssuedNotification.sendToSoleApplicant1(caseData, caseId);
-                if (isNotBlank(caseData.getCaseInvite().getApplicant2InviteEmailAddress())) {
+                if (isNotBlank(caseData.getApplicant2EmailAddress())) {
                     applicationIssuedNotification.sendToSoleRespondent(caseData, caseId);
                 }
                 if (caseDetails.getState() == AwaitingAos && caseData.getApplicant2().isBasedOverseas()) {
@@ -35,7 +35,7 @@ public class SendApplicationIssueNotifications implements CaseTask {
                 }
             } else {
                 applicationIssuedNotification.sendToJointApplicant1(caseData, caseId);
-                if (isNotBlank(caseData.getCaseInvite().getApplicant2InviteEmailAddress())) {
+                if (isNotBlank(caseData.getApplicant2EmailAddress())) {
                     applicationIssuedNotification.sendToJointApplicant2(caseData, caseId);
                 }
             }

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant1ResubmitNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant1ResubmitNotification.java
@@ -50,7 +50,7 @@ public class Applicant1ResubmitNotification {
         log.info("Sending applicant 1 made changes notification to applicant 2 for case : {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             JOINT_APPLICANT2_APPLICANT1_CHANGES_MADE,
             applicant2TemplateVars(caseData, id),
             caseData.getApplicant2().getLanguagePreference()
@@ -59,7 +59,7 @@ public class Applicant1ResubmitNotification {
 
     private Map<String, String> applicant1TemplateVars(CaseData caseData, Long id) {
         Map<String, String> templateVars = resubmitTemplateVars(caseData, id, caseData.getApplicant1(), caseData.getApplicant2());
-        templateVars.put(THEIR_EMAIL_ADDRESS, caseData.getCaseInvite().getApplicant2InviteEmailAddress());
+        templateVars.put(THEIR_EMAIL_ADDRESS, caseData.getApplicant2EmailAddress());
         return templateVars;
     }
 

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2ApprovedNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2ApprovedNotification.java
@@ -59,7 +59,7 @@ public class Applicant2ApprovedNotification {
         log.info("Sending applicant 2 approved notification to applicant 2 for case : {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             JOINT_APPLICANT2_APPLICANT2_APPROVED,
             applicant2TemplateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1()),
             caseData.getApplicant2().getLanguagePreference()

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2NotBrokenNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2NotBrokenNotification.java
@@ -35,7 +35,7 @@ public class Applicant2NotBrokenNotification {
         log.info("Sending applicant 2 reject notification to applicant 1 for case : {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             JOINT_APPLICANT2_APPLICANT2_REJECTED,
             commonContent.mainTemplateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1()),
             caseData.getApplicant1().getLanguagePreference()

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2RequestChangesNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2RequestChangesNotification.java
@@ -44,7 +44,7 @@ public class Applicant2RequestChangesNotification {
         log.info("Sending notification to applicant 2 to confirm their request for changes: {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             JOINT_APPLICANT2_REQUEST_CHANGES,
             commonContent.mainTemplateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1()),
             caseData.getApplicant2().getLanguagePreference()

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationIssuedNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationIssuedNotification.java
@@ -59,7 +59,7 @@ public class ApplicationIssuedNotification {
         log.info("Sending sole application issued notification to respondent for case : {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             SOLE_RESPONDENT_APPLICATION_ACCEPTED,
             soleRespondentTemplateVars(caseData, id),
             caseData.getApplicant1().getLanguagePreference()
@@ -70,7 +70,7 @@ public class ApplicationIssuedNotification {
         log.info("Sending reminder to respondent to register for case : {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             SOLE_RESPONDENT_APPLICATION_ACCEPTED,
             reminderToSoleRespondentTemplateVars(caseData, id),
             caseData.getApplicant1().getLanguagePreference()
@@ -103,7 +103,7 @@ public class ApplicationIssuedNotification {
         log.info("Sending joint application issued notification to applicant 2 for case : {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             JOINT_APPLICATION_ACCEPTED,
             commonTemplateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1()),
             caseData.getApplicant1().getLanguagePreference()
@@ -113,8 +113,8 @@ public class ApplicationIssuedNotification {
     public void notifyApplicantOfServiceToOverseasRespondent(CaseData caseData, Long id) {
         log.info("Notifying sole applicant of application issue (case {}) to overseas respondent", id);
 
-        final boolean hasEmail = caseData.getCaseInvite().getApplicant2InviteEmailAddress() != null
-            && !caseData.getCaseInvite().getApplicant2InviteEmailAddress().isEmpty();
+        final boolean hasEmail = caseData.getApplicant2EmailAddress() != null
+            && !caseData.getApplicant2EmailAddress().isEmpty();
         notificationService.sendEmail(
             caseData.getApplicant1().getEmail(),
             hasEmail ? OVERSEAS_RESPONDENT_HAS_EMAIL_APPLICATION_ISSUED : OVERSEAS_RESPONDENT_NO_EMAIL_APPLICATION_ISSUED,

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationOutstandingActionNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationOutstandingActionNotification.java
@@ -61,7 +61,7 @@ public class ApplicationOutstandingActionNotification {
         log.info("Sending application outstanding actions notification to applicant 2 for case : {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             OUTSTANDING_ACTIONS,
             this.applicant2TemplateVars(caseData, id),
             caseData.getApplicant1().getLanguagePreference()

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationSentForReviewApplicant2Notification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationSentForReviewApplicant2Notification.java
@@ -42,7 +42,7 @@ public class ApplicationSentForReviewApplicant2Notification {
         log.info("Sending application sent for review notification to applicant 2 for case : {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             JOINT_APPLICANT2_ANSWERS_SENT_FOR_REVIEW,
             templateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1(), false),
             caseData.getApplicant1().getLanguagePreference()
@@ -53,7 +53,7 @@ public class ApplicationSentForReviewApplicant2Notification {
         log.info("Sending reminder to applicant 2 to review case : {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             JOINT_APPLICANT2_ANSWERS_SENT_FOR_REVIEW,
             templateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1(), true),
             caseData.getApplicant1().getLanguagePreference()

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationSubmittedNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationSubmittedNotification.java
@@ -39,7 +39,7 @@ public class ApplicationSubmittedNotification {
         log.info("Sending application submitted notification to applicant 2 for case : {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             APPLICATION_SUBMITTED,
             templateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1()),
             caseData.getApplicant1().getLanguagePreference()

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/SoleAosSubmittedNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/SoleAosSubmittedNotification.java
@@ -44,7 +44,7 @@ public class SoleAosSubmittedNotification {
         log.info("Sending Aos submitted without dispute notification to respondent");
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             SOLE_RESPONDENT_AOS_SUBMITTED,
             nonDdisputedTemplateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1()),
             caseData.getApplicant2().getLanguagePreference()
@@ -66,7 +66,7 @@ public class SoleAosSubmittedNotification {
         log.info("Sending Aos submitted disputed notification to respondent");
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             SOLE_RESPONDENT_DISPUTED_AOS_SUBMITTED,
             disputedTemplateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1()),
             caseData.getApplicant2().getLanguagePreference()

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/SwitchToSoleNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/SwitchToSoleNotification.java
@@ -35,7 +35,7 @@ public class SwitchToSoleNotification {
         log.info("Sending applicant 1 switch to sole notification to applicant 2 for case : {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             JOINT_APPLICATION_ENDED,
             commonContent.mainTemplateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1()),
             caseData.getApplicant1().getLanguagePreference()
@@ -57,7 +57,7 @@ public class SwitchToSoleNotification {
         log.info("Sending applicant 2 switch to sole notification to applicant 2 for case : {}", id);
 
         notificationService.sendEmail(
-            caseData.getCaseInvite().getApplicant2InviteEmailAddress(),
+            caseData.getApplicant2EmailAddress(),
             APPLICANT_SWITCH_TO_SOLE,
             commonContent.mainTemplateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1()),
             caseData.getApplicant1().getLanguagePreference()

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/SubmissionService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/SubmissionService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.divorce.common.service.task.SendCitizenSubmissionNotifications;
+import uk.gov.hmcts.divorce.common.service.task.SetApplicant2Email;
 import uk.gov.hmcts.divorce.common.service.task.SetDateSubmitted;
 import uk.gov.hmcts.divorce.common.service.task.SetStateAfterSubmission;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
@@ -20,6 +21,9 @@ public class SubmissionService {
     private SetDateSubmitted setDateSubmitted;
 
     @Autowired
+    private SetApplicant2Email setApplicant2Email;
+
+    @Autowired
     private SendCitizenSubmissionNotifications sendCitizenSubmissionNotifications;
 
     public CaseDetails<CaseData, State> submitApplication(final CaseDetails<CaseData, State> caseDetails) {
@@ -27,6 +31,7 @@ public class SubmissionService {
         return CaseTaskRunner.caseTasks(
             setStateAfterSubmission,
             setDateSubmitted,
+            setApplicant2Email,
             sendCitizenSubmissionNotifications
         ).run(caseDetails);
     }

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/SetApplicant2Email.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/SetApplicant2Email.java
@@ -5,9 +5,11 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseInvite;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
 
+import static java.util.Objects.nonNull;
 import static org.apache.groovy.parser.antlr4.util.StringUtils.isEmpty;
 
 @Component
@@ -18,13 +20,16 @@ public class SetApplicant2Email implements CaseTask {
     public CaseDetails<CaseData, State> apply(final CaseDetails<CaseData, State> caseDetails) {
 
         final CaseData caseData = caseDetails.getData();
-        final String applicant2InviteEmailAddress = caseData.getCaseInvite().getApplicant2InviteEmailAddress();
-        final Applicant applicant2 = caseData.getApplicant2();
+        final CaseInvite caseInvite = caseData.getCaseInvite();
 
-        if (!isEmpty(applicant2InviteEmailAddress) && isEmpty(applicant2.getEmail())) {
-            applicant2.setEmail(applicant2InviteEmailAddress);
+        if (nonNull(caseInvite)) {
+            final String applicant2InviteEmailAddress = caseInvite.getApplicant2InviteEmailAddress();
+            final Applicant applicant2 = caseData.getApplicant2();
+
+            if (!isEmpty(applicant2InviteEmailAddress) && isEmpty(applicant2.getEmail())) {
+                applicant2.setEmail(applicant2InviteEmailAddress);
+            }
         }
-
         return caseDetails;
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/SetApplicant2Email.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/SetApplicant2Email.java
@@ -27,9 +27,15 @@ public class SetApplicant2Email implements CaseTask {
             final Applicant applicant2 = caseData.getApplicant2();
 
             if (!isEmpty(applicant2InviteEmailAddress) && isEmpty(applicant2.getEmail())) {
+                log.info("Setting applicant2 email to the same as applicant2 invite email for Case ID: {}", caseDetails.getId());
                 applicant2.setEmail(applicant2InviteEmailAddress);
+            } else {
+                log.info("Not setting applicant2 email, it is already set or invite email is not set for Case ID: {}", caseDetails.getId());
             }
+        } else {
+            log.info("Not setting applicant2 email, there is no case invite for Case ID: {}", caseDetails.getId());
         }
+
         return caseDetails;
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/SetApplicant2Email.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/SetApplicant2Email.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.divorce.common.service.task;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import static org.apache.groovy.parser.antlr4.util.StringUtils.isEmpty;
+
+@Component
+@Slf4j
+public class SetApplicant2Email implements CaseTask {
+
+    @Override
+    public CaseDetails<CaseData, State> apply(final CaseDetails<CaseData, State> caseDetails) {
+
+        final CaseData caseData = caseDetails.getData();
+        final String applicant2InviteEmailAddress = caseData.getCaseInvite().getApplicant2InviteEmailAddress();
+        final Applicant applicant2 = caseData.getApplicant2();
+
+        if (!isEmpty(applicant2InviteEmailAddress) && isEmpty(applicant2.getEmail())) {
+            applicant2.setEmail(applicant2InviteEmailAddress);
+        }
+
+        return caseDetails;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/CaseData.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.groovy.parser.antlr4.util.StringUtils;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
 import uk.gov.hmcts.ccd.sdk.type.CaseLink;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
@@ -29,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toCollection;
 import static org.springframework.util.CollectionUtils.isEmpty;
@@ -239,6 +241,21 @@ public class CaseData {
         } else {
             documents.add(0, listValue); // always add to start top of list
         }
+    }
+
+    @JsonIgnore
+    public String getApplicant2EmailAddress() {
+        final String applicant2Email = applicant2.getEmail();
+
+        if (StringUtils.isEmpty(applicant2Email)) {
+            if (nonNull(caseInvite)) {
+                return caseInvite.getApplicant2InviteEmailAddress();
+            } else {
+                return null;
+            }
+        }
+
+        return applicant2Email;
     }
 
     public void sortUploadedDocuments(List<ListValue<DivorceDocument>> previousDocuments) {

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressCaseToAosOverdue.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressCaseToAosOverdue.java
@@ -51,7 +51,7 @@ public class SystemProgressCaseToAosOverdue implements CCDConfig<CaseData, State
                                                                        CaseDetails<CaseData, State> beforeDetails) {
 
         CaseData data = details.getData();
-        if (!Objects.isNull(data.getCaseInvite().getApplicant2InviteEmailAddress())
+        if (!Objects.isNull(data.getApplicant2EmailAddress())
             && !Objects.isNull(data.getCaseInvite().getAccessCode())) {
             applicationIssuedNotification.sendReminderToSoleRespondent(data, details.getId());
         }

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant1ResubmitNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant1ResubmitNotificationTest.java
@@ -56,6 +56,7 @@ class Applicant1ResubmitNotificationTest {
     void shouldSendEmailToApplicant1WithDivorceContent() {
         CaseData data = validApplicant2CaseData();
         data.setDueDate(LOCAL_DATE);
+        data.getApplicant2().setEmail(null);
         final Map<String, String> templateVars = new HashMap<>();
         templateVars.putAll(getConfigTemplateVars());
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant1(), data.getApplicant2()))
@@ -79,6 +80,7 @@ class Applicant1ResubmitNotificationTest {
         CaseData data = validApplicant2CaseData();
         data.setDivorceOrDissolution(DivorceOrDissolution.DISSOLUTION);
         data.setDueDate(LOCAL_DATE);
+        data.getApplicant2().setEmail(null);
 
         notification.sendToApplicant1(data, 1234567890123456L);
 
@@ -97,6 +99,7 @@ class Applicant1ResubmitNotificationTest {
     void shouldSendEmailToApplicant2WithDivorceContent() {
         CaseData data = validApplicant2CaseData();
         data.setDueDate(LOCAL_DATE);
+        data.getApplicant2().setEmail(null);
         when(emailTemplatesConfig.getTemplateVars()).thenReturn(getConfigTemplateVars());
 
         notification.sendToApplicant2(data, 1234567890123456L);
@@ -117,6 +120,7 @@ class Applicant1ResubmitNotificationTest {
         CaseData data = validApplicant2CaseData();
         data.setDivorceOrDissolution(DivorceOrDissolution.DISSOLUTION);
         data.setDueDate(LOCAL_DATE);
+        data.getApplicant2().setEmail(null);
         when(emailTemplatesConfig.getTemplateVars()).thenReturn(getConfigTemplateVars());
 
         notification.sendToApplicant2(data, 1234567890123456L);

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2ApprovedNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2ApprovedNotificationTest.java
@@ -85,6 +85,7 @@ class Applicant2ApprovedNotificationTest {
         CaseData data = validApplicant2CaseData();
         data.getApplication().getApplicant1HelpWithFees().setNeedHelp(YesOrNo.NO);
         data.setDueDate(LOCAL_DATE);
+        data.getApplicant2().setEmail(null);
 
         notification.sendToApplicant2(data, 1234567890123456L);
 
@@ -105,6 +106,7 @@ class Applicant2ApprovedNotificationTest {
         data.getApplication().getApplicant1HelpWithFees().setNeedHelp(YesOrNo.YES);
         data.getApplication().getApplicant2HelpWithFees().setNeedHelp(YesOrNo.YES);
         data.setDueDate(LOCAL_DATE);
+        data.getApplicant2().setEmail(null);
 
         notification.sendToApplicant2(data, 1234567890123456L);
 
@@ -144,6 +146,7 @@ class Applicant2ApprovedNotificationTest {
         data.getApplication().getApplicant1HelpWithFees().setNeedHelp(YesOrNo.YES);
         data.getApplication().getApplicant2HelpWithFees().setNeedHelp(YesOrNo.NO);
         data.setDueDate(LOCAL_DATE);
+        data.getApplicant2().setEmail(null);
 
         notification.sendToApplicant2(data, 1234567890123456L);
 

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationIssuedNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationIssuedNotificationTest.java
@@ -126,6 +126,8 @@ public class ApplicationIssuedNotificationTest {
         CaseData data = validCaseDataForIssueApplication();
         data.setDueDate(LocalDate.now().plusDays(141));
         data.getApplication().setIssueDate(LocalDate.now());
+        data.getApplicant2().setEmail(null);
+
         Map<String, String> divorceTemplateVars = new HashMap<>();
         divorceTemplateVars.putAll(getCommonTemplateVars());
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
@@ -154,6 +156,8 @@ public class ApplicationIssuedNotificationTest {
         data.setDivorceOrDissolution(DISSOLUTION);
         data.setDueDate(LocalDate.now().plusDays(141));
         data.getApplication().setIssueDate(LocalDate.now());
+        data.getApplicant2().setEmail(null);
+
         Map<String, String> dissolutionTemplateVars = new HashMap<>();
         dissolutionTemplateVars.putAll(getCommonTemplateVars());
         dissolutionTemplateVars.putAll(Map.of(IS_DIVORCE, NO, IS_DISSOLUTION, YES));
@@ -182,6 +186,8 @@ public class ApplicationIssuedNotificationTest {
         CaseData data = validCaseDataForIssueApplication();
         data.setDueDate(LocalDate.now().plusDays(141));
         data.getApplication().setIssueDate(LocalDate.now());
+        data.getApplicant2().setEmail(null);
+
         Map<String, String> divorceTemplateVars = new HashMap<>();
         divorceTemplateVars.putAll(getCommonTemplateVars());
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
@@ -211,6 +217,8 @@ public class ApplicationIssuedNotificationTest {
         data.setDivorceOrDissolution(DISSOLUTION);
         data.setDueDate(LocalDate.now().plusDays(141));
         data.getApplication().setIssueDate(LocalDate.now());
+        data.getApplicant2().setEmail(null);
+
         Map<String, String> dissolutionTemplateVars = new HashMap<>();
         dissolutionTemplateVars.putAll(getCommonTemplateVars());
         dissolutionTemplateVars.putAll(Map.of(IS_DIVORCE, NO, IS_DISSOLUTION, YES));
@@ -409,6 +417,8 @@ public class ApplicationIssuedNotificationTest {
         data.setDueDate(LocalDate.now().plusDays(141));
         data.getApplication().setIssueDate(LocalDate.now());
         data.getCaseInvite().setApplicant2InviteEmailAddress(null);
+        data.getApplicant2().setEmail(null);
+
         Map<String, String> divorceTemplateVars = new HashMap<>();
         divorceTemplateVars.putAll(getCommonTemplateVars());
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant1(), data.getApplicant2()))

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationOutstandingActionNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationOutstandingActionNotificationTest.java
@@ -90,6 +90,8 @@ class ApplicationOutstandingActionNotificationTest {
         CaseData data = validApplicant2CaseData();
         data.getApplication().getMarriageDetails().setMarriedInUk(YesOrNo.NO);
         data.getApplication().setApplicant2CannotUploadSupportingDocument(Set.of(NAME_CHANGE_EVIDENCE));
+        data.getApplicant2().setEmail(null);
+
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
             .thenReturn(getCommonTemplateVars());
 

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationSubmittedNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/ApplicationSubmittedNotificationTest.java
@@ -64,6 +64,8 @@ class ApplicationSubmittedNotificationTest {
     void shouldSendEmailToApplicant2WithSubmissionResponseDate() {
         CaseData data = jointCaseDataWithOrderSummary();
         data.setDueDate(LocalDate.of(2021, 4, 21));
+        data.getApplicant2().setEmail(null);
+
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
             .thenReturn(getCommonTemplateVars());
 

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/SoleAosSubmittedNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/SoleAosSubmittedNotificationTest.java
@@ -101,6 +101,8 @@ public class SoleAosSubmittedNotificationTest {
     void shouldSendAosNotDisputedEmailToSoleRespondentWithDivorceContent() {
         CaseData data = validCaseDataForAosSubmitted();
         data.setDueDate(LocalDate.now().plusDays(141));
+        data.getApplicant2().setEmail(null);
+
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
             .thenReturn(getCommonTemplateVars());
 
@@ -125,6 +127,8 @@ public class SoleAosSubmittedNotificationTest {
         CaseData data = validCaseDataForAosSubmitted();
         data.setDivorceOrDissolution(DISSOLUTION);
         data.setDueDate(LocalDate.now().plusDays(141));
+        data.getApplicant2().setEmail(null);
+
         final Map<String, String> templateVars = getCommonTemplateVars();
         templateVars.putAll(Map.of(IS_DISSOLUTION, YES, IS_DIVORCE, NO));
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1())).thenReturn(templateVars);
@@ -200,6 +204,8 @@ public class SoleAosSubmittedNotificationTest {
         CaseData data = validCaseDataForAosSubmitted();
         data.setDueDate(LocalDate.now().plusDays(141));
         data.getApplication().setIssueDate(LocalDate.now());
+        data.getApplicant2().setEmail(null);
+
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
             .thenReturn(getCommonTemplateVars());
 
@@ -225,6 +231,8 @@ public class SoleAosSubmittedNotificationTest {
         data.setDivorceOrDissolution(DISSOLUTION);
         data.setDueDate(LocalDate.now().plusDays(141));
         data.getApplication().setIssueDate(LocalDate.now());
+        data.getApplicant2().setEmail(null);
+
         final Map<String, String> templateVars = getCommonTemplateVars();
         templateVars.putAll(Map.of(IS_DISSOLUTION, YES, IS_DIVORCE, NO));
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1())).thenReturn(templateVars);

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/SwitchToSoleNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/SwitchToSoleNotificationTest.java
@@ -87,6 +87,8 @@ class SwitchToSoleNotificationTest {
     @Test
     void shouldSendApplicant1SwitchToSoleEmailToApplicant2WithDivorceContent() {
         CaseData data = validApplicant2CaseData();
+        data.getApplicant2().setEmail(null);
+
         final Map<String, String> templateVars = Map.of(IS_DIVORCE, YES, IS_DISSOLUTION, NO);
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
             .thenReturn(templateVars);
@@ -109,6 +111,8 @@ class SwitchToSoleNotificationTest {
     void shouldSendApplicant1SwitchToSoleEmailToApplicant2WithDissolutionContent() {
         CaseData data = validApplicant2CaseData();
         data.setDivorceOrDissolution(DISSOLUTION);
+        data.getApplicant2().setEmail(null);
+
         final Map<String, String> templateVars = Map.of(IS_DIVORCE, NO, IS_DISSOLUTION, YES);
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
             .thenReturn(templateVars);
@@ -171,6 +175,8 @@ class SwitchToSoleNotificationTest {
     @Test
     void shouldSendApplicant2SwitchToSoleEmailToApplicant2WithDivorceContent() {
         CaseData data = validApplicant2CaseData();
+        data.getApplicant2().setEmail(null);
+
         final Map<String, String> templateVars = Map.of(IS_DIVORCE, YES, IS_DISSOLUTION, NO);
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1())).thenReturn(templateVars);
 
@@ -192,6 +198,8 @@ class SwitchToSoleNotificationTest {
     void shouldSendApplicant2SwitchToSoleEmailToApplicant2WithDissolutionContent() {
         CaseData data = validApplicant2CaseData();
         data.setDivorceOrDissolution(DISSOLUTION);
+        data.getApplicant2().setEmail(null);
+
         final Map<String, String> templateVars = Map.of(IS_DIVORCE, NO, IS_DISSOLUTION, YES);
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1())).thenReturn(templateVars);
 

--- a/src/test/java/uk/gov/hmcts/divorce/common/service/SubmissionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/service/SubmissionServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.divorce.common.service.task.SendCitizenSubmissionNotifications;
+import uk.gov.hmcts.divorce.common.service.task.SetApplicant2Email;
 import uk.gov.hmcts.divorce.common.service.task.SetDateSubmitted;
 import uk.gov.hmcts.divorce.common.service.task.SetStateAfterSubmission;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
@@ -26,6 +27,9 @@ class SubmissionServiceTest {
     private SetDateSubmitted setDateSubmitted;
 
     @Mock
+    private SetApplicant2Email setApplicant2Email;
+
+    @Mock
     private SendCitizenSubmissionNotifications sendCitizenSubmissionNotifications;
 
     @InjectMocks
@@ -39,6 +43,7 @@ class SubmissionServiceTest {
 
         when(setStateAfterSubmission.apply(caseDetails)).thenReturn(caseDetails);
         when(setDateSubmitted.apply(caseDetails)).thenReturn(caseDetails);
+        when(setApplicant2Email.apply(caseDetails)).thenReturn(caseDetails);
         when(sendCitizenSubmissionNotifications.apply(caseDetails)).thenReturn(expectedCaseDetails);
 
         final CaseDetails<CaseData, State> result = submissionService.submitApplication(caseDetails);
@@ -47,6 +52,7 @@ class SubmissionServiceTest {
 
         verify(setStateAfterSubmission).apply(caseDetails);
         verify(setDateSubmitted).apply(caseDetails);
+        verify(setApplicant2Email).apply(caseDetails);
         verify(sendCitizenSubmissionNotifications).apply(caseDetails);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/common/service/task/SetApplicant2EmailTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/service/task/SetApplicant2EmailTest.java
@@ -1,0 +1,117 @@
+package uk.gov.hmcts.divorce.common.service.task;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseInvite;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_USER_EMAIL;
+
+@ExtendWith(MockitoExtension.class)
+class SetApplicant2EmailTest {
+
+    @InjectMocks
+    private SetApplicant2Email setApplicant2Email;
+
+    @Test
+    void shouldSetApplicant2EmailIfApplicant2InviteEmailAddressIsSetAndApplicant2EmailIsNotSet() {
+
+        final CaseData caseData = CaseData.builder()
+            .applicant2(Applicant.builder().build())
+            .caseInvite(CaseInvite.builder()
+                .applicant2InviteEmailAddress(TEST_USER_EMAIL)
+                .build())
+            .build();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> result = setApplicant2Email.apply(caseDetails);
+
+        assertThat(result.getData().getApplicant2().getEmail()).isEqualTo(TEST_USER_EMAIL);
+    }
+
+    @Test
+    void shouldSetApplicant2EmailIfApplicant2InviteEmailAddressIsSetAndApplicant2EmailIsBlank() {
+
+        final CaseData caseData = CaseData.builder()
+            .applicant2(Applicant.builder()
+                .email("")
+                .build())
+            .caseInvite(CaseInvite.builder()
+                .applicant2InviteEmailAddress(TEST_USER_EMAIL)
+                .build())
+            .build();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> result = setApplicant2Email.apply(caseDetails);
+
+        assertThat(result.getData().getApplicant2().getEmail()).isEqualTo(TEST_USER_EMAIL);
+    }
+
+    @Test
+    void shouldNotSetApplicant2EmailIfApplicant2InviteEmailAddressIsNotSet() {
+
+        final CaseData caseData = CaseData.builder()
+            .applicant2(Applicant.builder().build())
+            .caseInvite(CaseInvite.builder()
+                .build())
+            .build();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> result = setApplicant2Email.apply(caseDetails);
+
+        assertThat(result.getData().getApplicant2().getEmail()).isNull();
+    }
+
+    @Test
+    void shouldNotSetApplicant2EmailIfApplicant2InviteEmailAddressIsBlank() {
+
+        final CaseData caseData = CaseData.builder()
+            .applicant2(Applicant.builder()
+                .build())
+            .caseInvite(CaseInvite.builder()
+                .applicant2InviteEmailAddress("")
+                .build())
+            .build();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> result = setApplicant2Email.apply(caseDetails);
+
+        assertThat(result.getData().getApplicant2().getEmail()).isNull();
+    }
+
+    @Test
+    void shouldNotSetApplicant2EmailIfApplicant2EmailIsSet() {
+
+        final String email = "app2@email";
+
+        final CaseData caseData = CaseData.builder()
+            .applicant2(Applicant.builder()
+                .email(email)
+                .build())
+            .caseInvite(CaseInvite.builder()
+                .applicant2InviteEmailAddress(TEST_USER_EMAIL)
+                .build())
+            .build();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> result = setApplicant2Email.apply(caseDetails);
+
+        assertThat(result.getData().getApplicant2().getEmail()).isEqualTo(email);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/common/service/task/SetApplicant2EmailTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/service/task/SetApplicant2EmailTest.java
@@ -114,4 +114,23 @@ class SetApplicant2EmailTest {
 
         assertThat(result.getData().getApplicant2().getEmail()).isEqualTo(email);
     }
+
+    @Test
+    void shouldNotSetApplicant2EmailIfCaseInviteIsNull() {
+
+        final String email = "app2@email";
+
+        final CaseData caseData = CaseData.builder()
+            .applicant2(Applicant.builder()
+                .email("")
+                .build())
+            .build();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> result = setApplicant2Email.apply(caseDetails);
+
+        assertThat(result.getData().getApplicant2().getEmail()).isEqualTo("");
+    }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDataTest.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.divorce.divorcecase.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_APPLICANT_2_USER_EMAIL;
+
+class CaseDataTest {
+
+    @Test
+    void shouldReturnApplicant2EmailIfApplicant2EmailIsSet() {
+
+        final CaseData caseData = CaseData.builder()
+            .applicant2(Applicant.builder()
+                .email(TEST_APPLICANT_2_USER_EMAIL)
+                .build())
+            .build();
+
+        assertThat(caseData.getApplicant2EmailAddress()).isEqualTo(TEST_APPLICANT_2_USER_EMAIL);
+    }
+
+    @Test
+    void shouldReturnApplicant2InviteEmailIfApplicant2EmailIsNullAndApplicant2InviteEmailAddressIsSet() {
+
+        final CaseData caseData = CaseData.builder()
+            .applicant2(Applicant.builder()
+                .email("")
+                .build())
+            .caseInvite(CaseInvite.builder()
+                .applicant2InviteEmailAddress(TEST_APPLICANT_2_USER_EMAIL)
+                .build())
+            .build();
+
+        assertThat(caseData.getApplicant2EmailAddress()).isEqualTo(TEST_APPLICANT_2_USER_EMAIL);
+    }
+
+    @Test
+    void shouldReturnApplicant2InviteEmailIfApplicant2EmailIsBlankAndApplicant2InviteEmailAddressIsSet() {
+
+        final CaseData caseData = CaseData.builder()
+            .caseInvite(CaseInvite.builder()
+                .applicant2InviteEmailAddress(TEST_APPLICANT_2_USER_EMAIL)
+                .build())
+            .build();
+
+        assertThat(caseData.getApplicant2EmailAddress()).isEqualTo(TEST_APPLICANT_2_USER_EMAIL);
+    }
+
+    @Test
+    void shouldReturnNullIfApplicant2EmailIsNullAndCaseInviteIsNull() {
+
+        final CaseData caseData = CaseData.builder()
+            .build();
+
+        assertThat(caseData.getApplicant2EmailAddress()).isNull();
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/NFDIV-1428


### Change description ###
Add task to set applicant2 email from the applicant2 invitaion email if present, in submission service
Add method to retrieve applicant2EmailAddress from the CaseData, that will return either the applicant2 email address if present or applicant2 invitation email