### PR TITLE
Fix dynamic content for notice of proceedings

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingContent.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingContent.java
@@ -67,6 +67,7 @@ public class NoticeOfProceedingContent {
     public static final String BEEN_MARRIED_TO = "been married to";
     public static final String MARRIAGE_OR_CIVIL_PARTNER = "marriageOrCivilPartner";
     public static final String MARRIAGE = "marriage";
+    public static final String CIVIL_PARTNERSHIP = "civil partnership";
 
     private static final int HOLDING_DUE_DATE_OFFSET_DAYS = 141;
     private static final int PAPER_SERVE_OFFSET_DAYS = 28;
@@ -149,7 +150,7 @@ public class NoticeOfProceedingContent {
 
             templateContent.put(DIVORCE_OR_END_YOUR_CIVIL_PARTNERSHIP, APPLICATION_TO_END_YOUR_CIVIL_PARTNERSHIP);
             templateContent.put(BEEN_MARRIED_OR_ENTERED_INTO_CIVIL_PARTNERSHIP, ENTERED_INTO_A_CIVIL_PARTNERSHIP_WITH);
-            templateContent.put(MARRIAGE_OR_CIVIL_PARTNER, CIVIL_PARTNER);
+            templateContent.put(MARRIAGE_OR_CIVIL_PARTNER, CIVIL_PARTNERSHIP);
         }
         final var ctscContactDetails = CtscContactDetails
             .builder()

--- a/src/test/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingContentTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingContentTest.java
@@ -26,6 +26,7 @@ import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.AP
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.BEEN_MARRIED_OR_ENTERED_INTO_CIVIL_PARTNERSHIP;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.BEEN_MARRIED_TO;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.CIVIL_PARTNER;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.CIVIL_PARTNERSHIP;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.CIVIL_PARTNERSHIP_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.CONTACT_DIVORCE_JUSTICE_GOV_UK;
@@ -180,7 +181,7 @@ public class NoticeOfProceedingContentTest {
         expectedEntries.put(SERVE_PAPERS_BEFORE_DATE, "16 July 2021");
         expectedEntries.put(DIVORCE_OR_END_YOUR_CIVIL_PARTNERSHIP, APPLICATION_TO_END_YOUR_CIVIL_PARTNERSHIP);
         expectedEntries.put(BEEN_MARRIED_OR_ENTERED_INTO_CIVIL_PARTNERSHIP, ENTERED_INTO_A_CIVIL_PARTNERSHIP_WITH);
-        expectedEntries.put(MARRIAGE_OR_CIVIL_PARTNER, CIVIL_PARTNER);
+        expectedEntries.put(MARRIAGE_OR_CIVIL_PARTNER, CIVIL_PARTNERSHIP);
         expectedEntries.put("ctscContactDetails", ctscContactDetails);
 
         Map<String, Object> templateContent = noticeOfProceedingContent.apply(caseData, TEST_CASE_ID);


### PR DESCRIPTION
<img width="935" alt="image" src="https://user-images.githubusercontent.com/13840402/143608973-15ff0dbf-449e-4685-9576-36e0020754b0.png">

should be: 'You must tell the court if you’ve [been married to / entered into a civil partnership with] more than one person during this [marriage / civil partnership].'