### PR TITLE
Fix Aos reminder issues

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressCaseToAosOverdue.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressCaseToAosOverdue.java
@@ -12,9 +12,8 @@ import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 
-import java.util.Objects;
-
 import static java.util.EnumSet.of;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AosDrafted;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AosOverdue;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingAos;
@@ -51,12 +50,11 @@ public class SystemProgressCaseToAosOverdue implements CCDConfig<CaseData, State
                                                                        CaseDetails<CaseData, State> beforeDetails) {
 
         CaseData data = details.getData();
-        if (!Objects.isNull(data.getApplicant2EmailAddress())
-            && !Objects.isNull(data.getCaseInvite().getAccessCode())) {
+        if (isNotBlank(data.getApplicant2EmailAddress()) && isNotBlank(data.getCaseInvite().getAccessCode())) {
             applicationIssuedNotification.sendReminderToSoleRespondent(data, details.getId());
         }
 
-        if (!data.getApplication().isSolicitorApplication()) {
+        if (!data.getApplicant1().isRepresented()) {
             applicationIssuedNotification.sendPartnerNotRespondedToSoleApplicant(data, details.getId());
         }
 

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressCaseToAosOverdueTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressCaseToAosOverdueTest.java
@@ -8,9 +8,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.Event;
-import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.citizen.notification.ApplicationIssuedNotification;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 
@@ -90,7 +90,7 @@ public class SystemProgressCaseToAosOverdueTest {
     @Test
     void shouldNotSendEmailToApplicantForSolicitorApplication() {
         final CaseData caseData = caseData();
-        caseData.getApplication().setSolSignStatementOfTruth(YesOrNo.YES);
+        caseData.getApplicant1().setSolicitor(Solicitor.builder().email("test@test.com").build());
         final CaseDetails<CaseData, State> details = new CaseDetails<>();
         details.setId(1L);
         details.setData(caseData);


### PR DESCRIPTION
Fix an issue where AoS reminder email fails if applicant2 email is an empty string. 

Correct logic on when to send applicant1 a reminder that the respondent has not completed the AoS
