### PR TITLE
Use different field for citizen update case state

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAat.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAat.java
@@ -43,8 +43,8 @@ public class CitizenUpdateCaseStateAat implements CCDConfig<CaseData, State, Use
 
         CaseData data = details.getData();
 
-        State state = State.valueOf(data.getApplicant2().getSolicitor().getAddress());
-        data.getApplicant2().getSolicitor().setAddress(null);
+        State state = State.valueOf(data.getApplicant2().getMiddleName());
+        data.getApplicant2().setMiddleName(null);
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(data)

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAatTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAatTest.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
-import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 
@@ -44,8 +43,7 @@ public class CitizenUpdateCaseStateAatTest {
         final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
         final CaseData caseData = CaseData.builder().build();
         caseData.setApplicant2(new Applicant());
-        caseData.getApplicant2().setSolicitor(new Solicitor());
-        caseData.getApplicant2().getSolicitor().setAddress("Holding");
+        caseData.getApplicant2().setMiddleName("Holding");
 
         caseDetails.setData(caseData);
         caseDetails.setId(caseId);
@@ -53,6 +51,6 @@ public class CitizenUpdateCaseStateAatTest {
         final AboutToStartOrSubmitResponse<CaseData, State> response = citizenUpdateCaseStateAat.aboutToSubmit(caseDetails, caseDetails);
 
         assertThat(response.getState()).isEqualTo(State.Holding);
-        assertThat(response.getData().getApplicant2().getSolicitor().getAddress()).isNull();
+        assertThat(response.getData().getApplicant2().getMiddleName()).isNull();
     }
 }


### PR DESCRIPTION
### Change description ###
Use different field for citizen update case state
The previous field applicant2SolicitorAddress was only accessible for applicant 1 users


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
