### PR TITLE
Remove setting of default access class for solicitor

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -158,6 +158,7 @@ withPipeline(type, product, component) {
       env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-nfdiv-case-api-pr-${CHANGE_ID}.service.core-compute-preview.internal"
       env.CASE_DATA_STORE_BASEURL = "http://ccd-data-store-api-nfdiv-case-api-pr-${CHANGE_ID}.service.core-compute-preview.internal"
       env.TEST_S2S_URL = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
+      env.CITIZEN_UPDATE_CASE_STATE_ENABLED=true
 
       setCommonEnvVariables()
     }

--- a/charts/nfdiv-case-api/values.preview.template.yaml
+++ b/charts/nfdiv-case-api/values.preview.template.yaml
@@ -7,6 +7,7 @@ java:
   ingressHost: ${SERVICE_FQDN}
   environment:
     CASE_DATA_STORE_BASEURL: "http://ccd-data-store-api-nfdiv-case-api-pr-${CHANGE_ID}.service.core-compute-preview.internal"
+    CITIZEN_UPDATE_CASE_STATE_ENABLED: true
   keyVaults:
     nfdiv:
       secrets:
@@ -89,7 +90,7 @@ ccd:
       ingressHost: ccd-data-store-api-${SERVICE_FQDN}
   am-role-assignment-service:
     java:
-      keyVaults: 
+      keyVaults:
         am:
           secrets:
             - role-assignment-service-LD-SDK-KEY

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAat.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAat.java
@@ -43,8 +43,8 @@ public class CitizenUpdateCaseStateAat implements CCDConfig<CaseData, State, Use
 
         CaseData data = details.getData();
 
-        State state = State.valueOf(data.getApplicant2().getSolicitor().getAddress());
-        data.getApplicant2().getSolicitor().setAddress(null);
+        State state = State.valueOf(data.getApplicant2().getLegalProceedingsDetails());
+        data.getApplicant2().setLegalProceedingsDetails(null);
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(data)

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAat.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAat.java
@@ -43,8 +43,8 @@ public class CitizenUpdateCaseStateAat implements CCDConfig<CaseData, State, Use
 
         CaseData data = details.getData();
 
-        State state = State.valueOf(data.getApplicant2().getLegalProceedingsDetails());
-        data.getApplicant2().setLegalProceedingsDetails(null);
+        State state = State.valueOf(data.getApplicant2().getMiddleName());
+        data.getApplicant2().setMiddleName(null);
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(data)

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Applicant.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Applicant.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
 import uk.gov.hmcts.ccd.sdk.type.AddressGlobalUK;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
-import uk.gov.hmcts.divorce.divorcecase.model.access.DefaultAccess;
 
 import java.util.Set;
 
@@ -129,7 +128,6 @@ public class Applicant {
     private YesOrNo solicitorRepresented;
 
     @JsonUnwrapped(prefix = "Solicitor")
-    @CCD(access = {DefaultAccess.class})
     private Solicitor solicitor;
 
     @CCD(

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAatTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAatTest.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
-import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAatTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAatTest.java
@@ -44,8 +44,7 @@ public class CitizenUpdateCaseStateAatTest {
         final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
         final CaseData caseData = CaseData.builder().build();
         caseData.setApplicant2(new Applicant());
-        caseData.getApplicant2().setSolicitor(new Solicitor());
-        caseData.getApplicant2().getSolicitor().setAddress("Holding");
+        caseData.getApplicant2().setLegalProceedingsDetails("Holding");
 
         caseDetails.setData(caseData);
         caseDetails.setId(caseId);
@@ -53,6 +52,6 @@ public class CitizenUpdateCaseStateAatTest {
         final AboutToStartOrSubmitResponse<CaseData, State> response = citizenUpdateCaseStateAat.aboutToSubmit(caseDetails, caseDetails);
 
         assertThat(response.getState()).isEqualTo(State.Holding);
-        assertThat(response.getData().getApplicant2().getSolicitor().getAddress()).isNull();
+        assertThat(response.getData().getApplicant2().getLegalProceedingsDetails()).isNull();
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAatTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAatTest.java
@@ -43,7 +43,7 @@ public class CitizenUpdateCaseStateAatTest {
         final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
         final CaseData caseData = CaseData.builder().build();
         caseData.setApplicant2(new Applicant());
-        caseData.getApplicant2().setLegalProceedingsDetails("Holding");
+        caseData.getApplicant2().setMiddleName("Holding");
 
         caseDetails.setData(caseData);
         caseDetails.setId(caseId);
@@ -51,6 +51,6 @@ public class CitizenUpdateCaseStateAatTest {
         final AboutToStartOrSubmitResponse<CaseData, State> response = citizenUpdateCaseStateAat.aboutToSubmit(caseDetails, caseDetails);
 
         assertThat(response.getState()).isEqualTo(State.Holding);
-        assertThat(response.getData().getApplicant2().getLegalProceedingsDetails()).isNull();
+        assertThat(response.getData().getApplicant2().getMiddleName()).isNull();
     }
 }


### PR DESCRIPTION
### Change description ###
Remove setting of default access class for solicitor
the access class should already be inherited from the access to the Applicant fields


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
