### PR TITLE
nfdiv-1130: retire fields instead of deleting them

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/RetiredFields.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/RetiredFields.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.divorce.divorcecase.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
@@ -214,6 +215,24 @@ public class RetiredFields {
     )
     private YesOrNo applicant2KeepContactDetailsConfidential;
 
+    @CCD(
+        label = "Retired flag indicating notification to applicant 1 they can apply for a Conditional Order already sent",
+        access = {DefaultAccess.class}
+    )
+    private YesOrNo applicant1NotifiedCanApplyForConditionalOrder;
+
+    @CCD(
+        label = "Retired flag indicating notification to joint applicants they can apply for a Conditional Order already sent",
+        access = {DefaultAccess.class}
+    )
+    private YesOrNo jointApplicantsNotifiedCanApplyForConditionalOrder;
+
+    @CCD(
+        label = "Retired Date Conditional Order submitted to HMCTS, split into applicant1 and applicant2 submission dates"
+    )
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    private LocalDateTime coDateSubmitted;
+
     @JsonIgnore
     private static final Consumer<Map<String, Object>> DO_NOTHING = data -> {
     };
@@ -288,6 +307,8 @@ public class RetiredFields {
             data -> data.put("applicant2ContactDetailsType", transformContactDetails(data, "applicant2KeepContactDetailsConfidential")));
         init.put("marriageIsSameSexCouple",
             data -> data.put("marriageFormationType", transformSameSexToMarriageFormation(data)));
+        init.put("coDateSubmitted",
+            data -> data.put("coApplicant1SubmittedDate", data.get("coDateSubmitted")));
 
         migrations = unmodifiableMap(init);
     }

--- a/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/RetiredFieldsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/RetiredFieldsTest.java
@@ -36,6 +36,7 @@ class RetiredFieldsTest {
         data.put("applicant1FinancialOrderForRemoved", "value");
         data.put("applicant2FinancialOrderForRemoved", "value");
         data.put("dateConditionalOrderSubmitted", "2021-11-11");
+        data.put("coDateSubmitted", "2021-11-13");
         data.put("legalProceedingsExist", "YES");
         data.put("legalProceedingsDescription", "value");
         data.put("doYouAgreeCourtHasJurisdiction", "YES");
@@ -65,7 +66,7 @@ class RetiredFieldsTest {
             entry("applicant1FinancialOrderForRemoved", null),
             entry("applicant2FinancialOrderForRemoved", null),
             entry("dateConditionalOrderSubmitted", null),
-            entry("coApplicant1SubmittedDate", "2021-11-11"),
+            entry("coApplicant1SubmittedDate", "2021-11-13"),
             entry("legalProceedingsExist", null),
             entry("applicant2LegalProceedings", "YES"),
             entry("legalProceedingsDescription", null),


### PR DESCRIPTION
### JIRA link (if applicable) ###
- https://tools.hmcts.net/jira/browse/NFDIV-1128
- https://tools.hmcts.net/jira/browse/NFDIV-1129
- https://tools.hmcts.net/jira/browse/NFDIV-1130

### Change description ###
- reinstate fields deleted in previous commits into the RetiredFields class

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
