### PR TITLE
WhoDivorcing and gender fixes for solicitor cases

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Applicant.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Applicant.java
@@ -152,13 +152,6 @@ public class Applicant {
     private String pcqId;
 
     @CCD(
-        label = "Spouse Type",
-        typeOverride = FixedRadioList,
-        typeParameterOverride = "WhoDivorcing"
-    )
-    private WhoDivorcing divorceWho;
-
-    @CCD(
         label = "The applicant wants to continue with their application."
     )
     private YesOrNo continueApplication;

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/MarriageDetails.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/MarriageDetails.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
@@ -18,6 +19,7 @@ import static uk.gov.hmcts.ccd.sdk.type.FieldType.FixedRadioList;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
+@Builder
 public class MarriageDetails {
 
     @CCD(

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/MarriageFormation.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/MarriageFormation.java
@@ -5,6 +5,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import uk.gov.hmcts.ccd.sdk.api.HasLabel;
 
+import static uk.gov.hmcts.divorce.divorcecase.model.Gender.FEMALE;
+import static uk.gov.hmcts.divorce.divorcecase.model.Gender.MALE;
+
 @Getter
 @AllArgsConstructor
 public enum MarriageFormation implements HasLabel {
@@ -15,6 +18,14 @@ public enum MarriageFormation implements HasLabel {
     @JsonProperty("oppositeSexCouple")
     OPPOSITE_SEX_COUPLE("oppositeSexCouple", "Opposite-sex couple");
 
-    private String type;
+    private final String type;
     private final String label;
+
+    public Gender getPartnerGender(Gender gender) {
+        return this == SAME_SEX_COUPLE
+            ? gender
+            : gender == MALE
+               ? FEMALE
+                : MALE;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/RetiredFields.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/RetiredFields.java
@@ -283,6 +283,20 @@ public class RetiredFields {
     )
     private String generalOrderLegalAdvisorName;
 
+    @CCD(
+        label = "Spouse Type",
+        typeOverride = FixedRadioList,
+        typeParameterOverride = "WhoDivorcing"
+    )
+    private WhoDivorcing applicant1DivorceWho;
+
+    @CCD(
+        label = "Spouse Type",
+        typeOverride = FixedRadioList,
+        typeParameterOverride = "WhoDivorcing"
+    )
+    private WhoDivorcing applicant2DivorceWho;
+
     @JsonIgnore
     private static final Consumer<Map<String, Object>> DO_NOTHING = data -> {
     };

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/SolAboutApplicant1.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/SolAboutApplicant1.java
@@ -1,12 +1,24 @@
 package uk.gov.hmcts.divorce.solicitor.event.page;
 
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.divorce.common.ccd.CcdPageConfiguration;
 import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
 import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.Application;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.Gender;
 import uk.gov.hmcts.divorce.divorcecase.model.MarriageDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.WhoDivorcing;
 
+import static uk.gov.hmcts.divorce.divorcecase.model.Gender.FEMALE;
+import static uk.gov.hmcts.divorce.divorcecase.model.Gender.MALE;
+import static uk.gov.hmcts.divorce.divorcecase.model.WhoDivorcing.HUSBAND;
+import static uk.gov.hmcts.divorce.divorcecase.model.WhoDivorcing.WIFE;
+
+@Slf4j
 public class SolAboutApplicant1 implements CcdPageConfiguration {
 
     private static final String DARK_HORIZONTAL_RULE =
@@ -16,7 +28,7 @@ public class SolAboutApplicant1 implements CcdPageConfiguration {
     public void addTo(final PageBuilder pageBuilder) {
 
         pageBuilder
-            .page("SolAboutApplicant1")
+            .page("SolAboutApplicant1", this::midEvent)
             .pageLabel("About the applicant")
             .complex(CaseData::getApplicant1)
                 .mandatoryWithLabel(Applicant::getFirstName,
@@ -34,10 +46,12 @@ public class SolAboutApplicant1 implements CcdPageConfiguration {
                 .mandatoryWithoutDefaultValue(Applicant::getNameChangedHowOtherDetails,
                 "applicant1NameChangedHow=\"other\"",
                 "If not through marriage or deed poll, please provide details of how they legally changed they name")
-                .optionalWithLabel(Applicant::getGender,
+                .mandatoryWithoutDefaultValue(Applicant::getGender, "divorceOrDissolution=\"dissolution\"",
                 "Is ${labelContentTheApplicantOrApplicant1} male or female?")
                 .done()
             .complex(CaseData::getApplication)
+                .mandatory(Application::getDivorceWho, "divorceOrDissolution=\"divorce\"", null,
+                "Who is ${labelContentTheApplicantOrApplicant1} divorcing?")
                 .complex(Application::getMarriageDetails)
                     .mandatory(MarriageDetails::getFormationType)
                     .done()
@@ -54,4 +68,39 @@ public class SolAboutApplicant1 implements CcdPageConfiguration {
                 .mandatory(Applicant::getContactDetailsType)
                 .done();
     }
+
+    public AboutToStartOrSubmitResponse<CaseData, State> midEvent(
+        CaseDetails<CaseData, State> details,
+        CaseDetails<CaseData, State> detailsBefore
+    ) {
+        log.info("Mid-event callback triggered for SolAboutTheSolicitor");
+
+        var data = details.getData();
+        Gender app1Gender;
+        Gender app2Gender;
+        WhoDivorcing whoDivorcing;
+
+        if (data.getDivorceOrDissolution().isDivorce()) {
+            // for a divorce we ask who is applicant1 divorcing to infer applicant2's gender, then use the marriage
+            // formation to infer applicant 1's gender
+            whoDivorcing = data.getApplication().getDivorceWho();
+            app2Gender = whoDivorcing == HUSBAND ? MALE : FEMALE;
+            app1Gender = data.getApplication().getMarriageDetails().getFormationType().getPartnerGender(app2Gender);
+        } else {
+            // for a dissolution we ask for applicant1's gender and use the marriage formation to infer applicant 2's
+            // gender and who they are divorcing
+            app1Gender = data.getApplicant1().getGender();
+            app2Gender = data.getApplication().getMarriageDetails().getFormationType().getPartnerGender(app1Gender);
+            whoDivorcing = app2Gender == MALE ? HUSBAND : WIFE;
+        }
+
+        data.getApplicant1().setGender(app1Gender);
+        data.getApplicant2().setGender(app2Gender);
+        data.getApplication().setDivorceWho(whoDivorcing);
+
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(data)
+            .build();
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/SolAboutApplicant1.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/SolAboutApplicant1.java
@@ -73,7 +73,7 @@ public class SolAboutApplicant1 implements CcdPageConfiguration {
         CaseDetails<CaseData, State> details,
         CaseDetails<CaseData, State> detailsBefore
     ) {
-        log.info("Mid-event callback triggered for SolAboutTheSolicitor");
+        log.info("Mid-event callback triggered for SolAboutApplicant1");
 
         var data = details.getData();
         Gender app1Gender;

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/SolAboutApplicant2.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/SolAboutApplicant2.java
@@ -38,14 +38,6 @@ public class SolAboutApplicant2 implements CcdPageConfiguration {
                     Applicant::getNameChangedHowOtherDetails,
                     "applicant2NameChangedHow=\"other\"",
                     "If not through marriage or deed poll, please provide details of how they legally changed they name")
-                .optionalWithLabel(Applicant::getGender,
-                        "Is ${labelContentTheApplicant2} male or female?")
-                .mandatory(
-                    Applicant::getDivorceWho,
-                    "divorceOrDissolution=\"divorce\"",
-                    null,
-                    "What is ${labelContentTheApplicant2}?"
-                )
                 .done();
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/page/SolAboutApplicant1Test.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/page/SolAboutApplicant1Test.java
@@ -1,0 +1,95 @@
+package uk.gov.hmcts.divorce.solicitor.event.page;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
+import uk.gov.hmcts.divorce.divorcecase.model.Application;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution;
+import uk.gov.hmcts.divorce.divorcecase.model.Gender;
+import uk.gov.hmcts.divorce.divorcecase.model.MarriageDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.MarriageFormation;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.WhoDivorcing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DISSOLUTION;
+import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DIVORCE;
+import static uk.gov.hmcts.divorce.divorcecase.model.Gender.FEMALE;
+import static uk.gov.hmcts.divorce.divorcecase.model.Gender.MALE;
+import static uk.gov.hmcts.divorce.divorcecase.model.MarriageFormation.OPPOSITE_SEX_COUPLE;
+import static uk.gov.hmcts.divorce.divorcecase.model.MarriageFormation.SAME_SEX_COUPLE;
+import static uk.gov.hmcts.divorce.divorcecase.model.WhoDivorcing.HUSBAND;
+import static uk.gov.hmcts.divorce.divorcecase.model.WhoDivorcing.WIFE;
+
+@ExtendWith(MockitoExtension.class)
+class SolAboutApplicant1Test {
+    private final SolAboutApplicant1 page = new SolAboutApplicant1();
+
+    @Test
+    void shouldSetGenderForADivorce() {
+        var data = createCaseData(DIVORCE, null, WIFE, OPPOSITE_SEX_COUPLE);
+        var details = CaseDetails.<CaseData, State>builder().data(data).build();
+        var result = page.midEvent(details, details).getData();
+
+        assertEquals(result.getApplicant1().getGender(), MALE);
+        assertEquals(result.getApplicant2().getGender(), FEMALE);
+        assertEquals(result.getApplication().getDivorceWho(), WIFE);
+    }
+
+    @Test
+    void shouldSetGenderForASameSexDivorce() {
+        var data = createCaseData(DIVORCE, null, HUSBAND, SAME_SEX_COUPLE);
+        var details = CaseDetails.<CaseData, State>builder().data(data).build();
+        var result = page.midEvent(details, details).getData();
+
+        assertEquals(result.getApplicant1().getGender(), MALE);
+        assertEquals(result.getApplicant2().getGender(), MALE);
+        assertEquals(result.getApplication().getDivorceWho(), HUSBAND);
+    }
+
+    @Test
+    void shouldSetGenderForADissolution() {
+        var data = createCaseData(DISSOLUTION, MALE, null, OPPOSITE_SEX_COUPLE);
+        var details = CaseDetails.<CaseData, State>builder().data(data).build();
+        var result = page.midEvent(details, details).getData();
+
+        assertEquals(result.getApplicant1().getGender(), MALE);
+        assertEquals(result.getApplicant2().getGender(), FEMALE);
+        assertEquals(result.getApplication().getDivorceWho(), WIFE);
+    }
+
+    @Test
+    void shouldSetGenderForASameSexDissolution() {
+        var data = createCaseData(DISSOLUTION, FEMALE, null, SAME_SEX_COUPLE);
+        var details = CaseDetails.<CaseData, State>builder().data(data).build();
+        var result = page.midEvent(details, details).getData();
+
+        assertEquals(result.getApplicant1().getGender(), FEMALE);
+        assertEquals(result.getApplicant2().getGender(), FEMALE);
+        assertEquals(result.getApplication().getDivorceWho(), WIFE);
+    }
+
+    private CaseData createCaseData(final DivorceOrDissolution type,
+                                    final Gender app1Gender,
+                                    final WhoDivorcing whoDivorcing,
+                                    final MarriageFormation formation) {
+        return CaseData.builder()
+            .divorceOrDissolution(type)
+            .applicant1(
+                Applicant.builder()
+                    .gender(app1Gender)
+                    .build()
+            )
+            .application(Application.builder()
+                .divorceWho(whoDivorcing)
+                .marriageDetails(
+                    MarriageDetails.builder()
+                        .formationType(formation)
+                        .build())
+                .build())
+            .build();
+    }
+}


### PR DESCRIPTION
- Remove whoDivorcing fields from Applicant
- Make whoDivorcing and gender questions consistent with how they are set by the citizen side
- Fix an issue where Application.whoDivorcing is not set in the CoE for solicitor cases
