### PR TITLE
Use new object mapper for class conversion

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/common/config/jackson/JacksonConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/config/jackson/JacksonConfiguration.java
@@ -19,7 +19,7 @@ public class JacksonConfiguration {
     @Primary
     @Bean
     public ObjectMapper getMapper() {
-        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        ObjectMapper mapper = new ObjectMapper();
         mapper.configure(ACCEPT_CASE_INSENSITIVE_ENUMS, true);
         mapper.enable(INFER_BUILDER_TYPE_BINDINGS);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/CaseDetailsUpdater.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/CaseDetailsUpdater.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.divorce.systemupdate.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
@@ -15,11 +14,11 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 @Slf4j
 public class CaseDetailsUpdater {
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
     public CaseDetails<CaseData, State> updateCaseData(final CaseTask caseTask,
                                                        final StartEventResponse startEventResponse) {
+
+        //Use object mapper with all modules registered for conversion, rather than autowired Jackson version
+        final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
         final uk.gov.hmcts.reform.ccd.client.model.CaseDetails initCaseDetails = startEventResponse.getCaseDetails();
         final CaseDetails<CaseData, State> caseDetails = objectMapper

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/service/CaseDetailsUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/service/CaseDetailsUpdaterTest.java
@@ -1,11 +1,9 @@
 package uk.gov.hmcts.divorce.systemupdate.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.collections4.map.HashedMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
@@ -19,9 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 class CaseDetailsUpdaterTest {
-
-    @Spy
-    private ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
     @InjectMocks
     private CaseDetailsUpdater caseDetailsUpdater;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/NFDIV-1616


### Change description ###
Revert add findAndRegisterModules method to autowired Jackson ObjectMapper
Update CaseDetailsUpdater to use new ObjectMapper rather than autowired Jackson ObjectMapper