### PR TITLE
Move HttpServletRequest to SolicitorSubmitJointApplication as we cannot autowire it in service

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplication.java
@@ -19,8 +19,8 @@ import uk.gov.hmcts.divorce.solicitor.event.page.SolStatementOfTruthApplicant2;
 import uk.gov.hmcts.divorce.solicitor.service.SolicitorSubmitJointApplicationService;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 
 import static java.util.Arrays.asList;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -89,7 +89,10 @@ public class SolicitorSubmitJointApplication implements CCDConfig<CaseData, Stat
 
         log.info("Solicitor submit joint application submitted callback invoked for case id: {}", details.getId());
 
-        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(details,httpServletRequest.getHeader(AUTHORIZATION));
+        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(
+            details,
+            httpServletRequest.getHeader(AUTHORIZATION)
+        );
 
         return SubmittedCallbackResponse.builder().build();
     }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplication.java
@@ -19,9 +19,11 @@ import uk.gov.hmcts.divorce.solicitor.event.page.SolStatementOfTruthApplicant2;
 import uk.gov.hmcts.divorce.solicitor.service.SolicitorSubmitJointApplicationService;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingApplicant2Response;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Draft;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_1_SOLICITOR;
@@ -42,10 +44,13 @@ public class SolicitorSubmitJointApplication implements CCDConfig<CaseData, Stat
     private MarriageIrretrievablyBrokenForApplicant2 marriageIrretrievablyBrokenForApplicant2;
 
     @Autowired
-    private HelpWithFeesPageForApplicant2  helpWithFeesPageForApplicant2;
+    private HelpWithFeesPageForApplicant2 helpWithFeesPageForApplicant2;
 
     @Autowired
     private SolicitorSubmitJointApplicationService solicitorSubmitJointApplicationService;
+
+    @Autowired
+    private HttpServletRequest httpServletRequest;
 
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
@@ -84,7 +89,7 @@ public class SolicitorSubmitJointApplication implements CCDConfig<CaseData, Stat
 
         log.info("Solicitor submit joint application submitted callback invoked for case id: {}", details.getId());
 
-        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(details);
+        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(details,httpServletRequest.getHeader(AUTHORIZATION));
 
         return SubmittedCallbackResponse.builder().build();
     }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitJointApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitJointApplicationService.java
@@ -33,19 +33,16 @@ public class SolicitorSubmitJointApplicationService {
     @Autowired
     private AuthTokenGenerator authTokenGenerator;
 
-    @Autowired
-    private HttpServletRequest httpServletRequest;
-
     @Async
-    public void submitEventForApprovalOrRequestingChanges(CaseDetails<CaseData, State> details) {
+    public void submitEventForApprovalOrRequestingChanges(final CaseDetails<CaseData, State> details,
+                                                          final String authToken) {
         final Application application = details.getData().getApplication();
 
         String eventId = YES.equals(application.getApplicant2ConfirmApplicant1Information())
             ? APPLICANT_2_REQUEST_CHANGES
             : APPLICANT_2_APPROVE;
 
-        String solicitorAuthToken = httpServletRequest.getHeader(AUTHORIZATION);
-        User solUser = idamService.retrieveUser(solicitorAuthToken);
+        User solUser = idamService.retrieveUser(authToken);
 
         final String serviceAuthorization = authTokenGenerator.generate();
 

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitJointApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitJointApplicationService.java
@@ -13,9 +13,6 @@ import uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.idam.client.models.User;
 
-import javax.servlet.http.HttpServletRequest;
-
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.common.event.Applicant2Approve.APPLICANT_2_APPROVE;
 import static uk.gov.hmcts.divorce.common.event.Applicant2RequestChanges.APPLICANT_2_REQUEST_CHANGES;

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplicationTest.java
@@ -11,29 +11,29 @@ import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
-import uk.gov.hmcts.divorce.solicitor.event.page.HelpWithFeesPageForApplicant2;
-import uk.gov.hmcts.divorce.solicitor.event.page.MarriageIrretrievablyBrokenForApplicant2;
 import uk.gov.hmcts.divorce.solicitor.service.SolicitorSubmitJointApplicationService;
+
+import javax.servlet.http.HttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.solicitor.event.SolicitorSubmitJointApplication.SOLICITOR_SUBMIT_JOINT_APPLICATION;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_AUTHORIZATION_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
 
 @ExtendWith(MockitoExtension.class)
 class SolicitorSubmitJointApplicationTest {
 
     @Mock
-    private MarriageIrretrievablyBrokenForApplicant2 marriageIrretrievablyBrokenForApplicant2;
-
-    @Mock
-    private HelpWithFeesPageForApplicant2 helpWithFeesPageForApplicant2;
-
-    @Mock
     private SolicitorSubmitJointApplicationService solicitorSubmitJointApplicationService;
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
 
     @InjectMocks
     private SolicitorSubmitJointApplication solicitorSubmitJointApplication;
@@ -51,6 +51,8 @@ class SolicitorSubmitJointApplicationTest {
 
     @Test
     void shouldInvokeSubmitEventForApprovalOrRequestingChangesOnSubmittedCallback() {
+        when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn(TEST_AUTHORIZATION_TOKEN);
+
         final var caseData = caseData();
         caseData.getApplication().setApplicant2ConfirmApplicant1Information(YES);
 
@@ -59,6 +61,6 @@ class SolicitorSubmitJointApplicationTest {
 
         solicitorSubmitJointApplication.submitted(caseDetails, caseDetails);
 
-        verify(solicitorSubmitJointApplicationService).submitEventForApprovalOrRequestingChanges(caseDetails);
+        verify(solicitorSubmitJointApplicationService).submitEventForApprovalOrRequestingChanges(caseDetails, TEST_AUTHORIZATION_TOKEN);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplicationTest.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.divorce.solicitor.event.page.HelpWithFeesPageForApplicant2;
+import uk.gov.hmcts.divorce.solicitor.event.page.MarriageIrretrievablyBrokenForApplicant2;
 import uk.gov.hmcts.divorce.solicitor.service.SolicitorSubmitJointApplicationService;
 
 import javax.servlet.http.HttpServletRequest;
@@ -28,6 +30,12 @@ import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
 
 @ExtendWith(MockitoExtension.class)
 class SolicitorSubmitJointApplicationTest {
+
+    @Mock
+    private MarriageIrretrievablyBrokenForApplicant2 marriageIrretrievablyBrokenForApplicant2;
+
+    @Mock
+    private HelpWithFeesPageForApplicant2 helpWithFeesPageForApplicant2;
 
     @Mock
     private SolicitorSubmitJointApplicationService solicitorSubmitJointApplicationService;

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitJointApplicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitJointApplicationServiceTest.java
@@ -14,11 +14,8 @@ import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.idam.client.models.User;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
-import javax.servlet.http.HttpServletRequest;
-
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.common.event.Applicant2Approve.APPLICANT_2_APPROVE;
@@ -39,16 +36,11 @@ public class SolicitorSubmitJointApplicationServiceTest {
     @Mock
     private AuthTokenGenerator authTokenGenerator;
 
-    @Mock
-    private HttpServletRequest httpServletRequest;
-
     @InjectMocks
     private SolicitorSubmitJointApplicationService solicitorSubmitJointApplicationService;
 
     @Test
     void shouldSubmitCcdApplicant2RequestChangesEventOnSubmittedCallbackIfApp2SolicitorHasRequestedChanges() {
-        when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn(TEST_AUTHORIZATION_TOKEN);
-
         final User user = new User(TEST_AUTHORIZATION_TOKEN, UserDetails.builder().build());
         when(idamService.retrieveUser(TEST_AUTHORIZATION_TOKEN)).thenReturn(user);
 
@@ -60,15 +52,13 @@ public class SolicitorSubmitJointApplicationServiceTest {
         final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
         caseDetails.setData(caseData);
 
-        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(caseDetails);
+        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(caseDetails, TEST_AUTHORIZATION_TOKEN);
 
         verify(ccdUpdateService).submitEvent(caseDetails, APPLICANT_2_REQUEST_CHANGES, user, SERVICE_AUTHORIZATION);
     }
 
     @Test
     void shouldSubmitCcdApplicant2ApproveEventOnSubmittedCallbackIfApp2SolicitorHasNotRequestedChanges() {
-        when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn(TEST_AUTHORIZATION_TOKEN);
-
         final User user = new User(TEST_AUTHORIZATION_TOKEN, UserDetails.builder().build());
         when(idamService.retrieveUser(TEST_AUTHORIZATION_TOKEN)).thenReturn(user);
 
@@ -80,7 +70,7 @@ public class SolicitorSubmitJointApplicationServiceTest {
         final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
         caseDetails.setData(caseData);
 
-        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(caseDetails);
+        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(caseDetails, TEST_AUTHORIZATION_TOKEN);
 
         verify(ccdUpdateService).submitEvent(caseDetails, APPLICANT_2_APPROVE, user, SERVICE_AUTHORIZATION);
     }


### PR DESCRIPTION
- We cannot autowire a HttpServletRequest in service class where we are using Async aspect as this will tie our aspect to be only runnable for classes that are called from within an executing HttpServletRequest.
