### PR TITLE
Use system user to trigger async event and remove financial order hidden field

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/common/event/Applicant2Approve.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/Applicant2Approve.java
@@ -20,7 +20,7 @@ import java.util.List;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Applicant2Approved;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingApplicant2Response;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2_SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ValidationUtil.validateApplicant2BasicCase;
 
@@ -44,7 +44,7 @@ public class Applicant2Approve implements CCDConfig<CaseData, State, UserRole> {
             .forStateTransition(AwaitingApplicant2Response, Applicant2Approved)
             .name("Applicant 2 approve")
             .description("Applicant 2 has approved")
-            .grant(CREATE_READ_UPDATE, APPLICANT_2, APPLICANT_2_SOLICITOR)
+            .grant(CREATE_READ_UPDATE, APPLICANT_2, SYSTEMUPDATE)
             .retries(120, 120)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/Applicant2RequestChanges.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/Applicant2RequestChanges.java
@@ -18,7 +18,7 @@ import java.util.List;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingApplicant1Response;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingApplicant2Response;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2_SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ValidationUtil.validateApplicant2RequestChanges;
 
@@ -42,7 +42,7 @@ public class Applicant2RequestChanges implements CCDConfig<CaseData, State, User
             .forStateTransition(AwaitingApplicant2Response, AwaitingApplicant1Response)
             .name("Applicant 2 Request Changes")
             .description("Applicant 2 Requests changes to be made by Applicant 1")
-            .grant(CREATE_READ_UPDATE, APPLICANT_2, APPLICANT_2_SOLICITOR)
+            .grant(CREATE_READ_UPDATE, APPLICANT_2, SYSTEMUPDATE)
             .retries(120, 120)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Application.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Application.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.ccd.sdk.type.OrderSummary;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.divorcecase.model.access.Applicant2Access;
-import uk.gov.hmcts.divorce.divorcecase.model.access.Applicant2ReadAccess;
 import uk.gov.hmcts.divorce.divorcecase.model.access.CaseworkerAccess;
 import uk.gov.hmcts.divorce.divorcecase.model.access.DefaultAccess;
 import uk.gov.hmcts.divorce.document.model.DocumentType;
@@ -408,7 +407,7 @@ public class Application {
 
     @CCD(
         label = "Link to applicant 1 solicitors answers",
-        access = {Applicant2ReadAccess.class}
+        access = {CaseworkerAccess.class}
     )
     private Document applicant1SolicitorAnswersLink;
 

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplication.java
@@ -20,10 +20,8 @@ import uk.gov.hmcts.divorce.solicitor.service.SolicitorSubmitJointApplicationSer
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
 import java.util.List;
-import javax.servlet.http.HttpServletRequest;
 
 import static java.util.Arrays.asList;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingApplicant2Response;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Draft;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_1_SOLICITOR;
@@ -48,9 +46,6 @@ public class SolicitorSubmitJointApplication implements CCDConfig<CaseData, Stat
 
     @Autowired
     private SolicitorSubmitJointApplicationService solicitorSubmitJointApplicationService;
-
-    @Autowired
-    private HttpServletRequest httpServletRequest;
 
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
@@ -89,10 +84,7 @@ public class SolicitorSubmitJointApplication implements CCDConfig<CaseData, Stat
 
         log.info("Solicitor submit joint application submitted callback invoked for case id: {}", details.getId());
 
-        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(
-            details,
-            httpServletRequest.getHeader(AUTHORIZATION)
-        );
+        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(details);
 
         return SubmittedCallbackResponse.builder().build();
     }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/SolStatementOfTruthApplicant2.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/page/SolStatementOfTruthApplicant2.java
@@ -2,13 +2,10 @@ package uk.gov.hmcts.divorce.solicitor.event.page;
 
 import uk.gov.hmcts.divorce.common.ccd.CcdPageConfiguration;
 import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
-import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.Application;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 
 public class SolStatementOfTruthApplicant2 implements CcdPageConfiguration {
-
-    private static final String ALWAYS_HIDE = "applicant2StatementOfTruth=\"ALWAYS_HIDE\"";
 
     @Override
     public void addTo(final PageBuilder pageBuilder) {
@@ -17,10 +14,6 @@ public class SolStatementOfTruthApplicant2 implements CcdPageConfiguration {
             .page("SolStatementOfTruthApplicant2")
             .showCondition("applicant2ConfirmApplicant1Information=\"Yes\"")
             .pageLabel("Statement of truth and reconciliation")
-            .readonlyNoSummary(CaseData::getDivorceOrDissolution, ALWAYS_HIDE)
-            .complex(CaseData::getApplicant2)
-                .readonlyNoSummary(Applicant::getFinancialOrder, ALWAYS_HIDE)
-                .done()
             .complex(CaseData::getApplication)
                 .label("LabelPrayer", "## The prayer ##")
                 .mandatory(Application::getApplicant2PrayerHasBeenGivenCheckbox)

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitJointApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitJointApplicationService.java
@@ -31,15 +31,14 @@ public class SolicitorSubmitJointApplicationService {
     private AuthTokenGenerator authTokenGenerator;
 
     @Async
-    public void submitEventForApprovalOrRequestingChanges(final CaseDetails<CaseData, State> details,
-                                                          final String authToken) {
+    public void submitEventForApprovalOrRequestingChanges(final CaseDetails<CaseData, State> details) {
         final Application application = details.getData().getApplication();
 
         String eventId = YES.equals(application.getApplicant2ConfirmApplicant1Information())
             ? APPLICANT_2_REQUEST_CHANGES
             : APPLICANT_2_APPROVE;
 
-        User solUser = idamService.retrieveUser(authToken);
+        User solUser = idamService.retrieveSystemUpdateUserDetails();
 
         final String serviceAuthorization = authTokenGenerator.generate();
 

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplicationTest.java
@@ -15,17 +15,12 @@ import uk.gov.hmcts.divorce.solicitor.event.page.HelpWithFeesPageForApplicant2;
 import uk.gov.hmcts.divorce.solicitor.event.page.MarriageIrretrievablyBrokenForApplicant2;
 import uk.gov.hmcts.divorce.solicitor.service.SolicitorSubmitJointApplicationService;
 
-import javax.servlet.http.HttpServletRequest;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.solicitor.event.SolicitorSubmitJointApplication.SOLICITOR_SUBMIT_JOINT_APPLICATION;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_AUTHORIZATION_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,9 +34,6 @@ class SolicitorSubmitJointApplicationTest {
 
     @Mock
     private SolicitorSubmitJointApplicationService solicitorSubmitJointApplicationService;
-
-    @Mock
-    private HttpServletRequest httpServletRequest;
 
     @InjectMocks
     private SolicitorSubmitJointApplication solicitorSubmitJointApplication;
@@ -59,8 +51,6 @@ class SolicitorSubmitJointApplicationTest {
 
     @Test
     void shouldInvokeSubmitEventForApprovalOrRequestingChangesOnSubmittedCallback() {
-        when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn(TEST_AUTHORIZATION_TOKEN);
-
         final var caseData = caseData();
         caseData.getApplication().setApplicant2ConfirmApplicant1Information(YES);
 
@@ -69,6 +59,6 @@ class SolicitorSubmitJointApplicationTest {
 
         solicitorSubmitJointApplication.submitted(caseDetails, caseDetails);
 
-        verify(solicitorSubmitJointApplicationService).submitEventForApprovalOrRequestingChanges(caseDetails, TEST_AUTHORIZATION_TOKEN);
+        verify(solicitorSubmitJointApplicationService).submitEventForApprovalOrRequestingChanges(caseDetails);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitJointApplicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitJointApplicationServiceTest.java
@@ -42,7 +42,7 @@ public class SolicitorSubmitJointApplicationServiceTest {
     @Test
     void shouldSubmitCcdApplicant2RequestChangesEventOnSubmittedCallbackIfApp2SolicitorHasRequestedChanges() {
         final User user = new User(TEST_AUTHORIZATION_TOKEN, UserDetails.builder().build());
-        when(idamService.retrieveUser(TEST_AUTHORIZATION_TOKEN)).thenReturn(user);
+        when(idamService.retrieveSystemUpdateUserDetails()).thenReturn(user);
 
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION);
 
@@ -52,7 +52,7 @@ public class SolicitorSubmitJointApplicationServiceTest {
         final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
         caseDetails.setData(caseData);
 
-        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(caseDetails, TEST_AUTHORIZATION_TOKEN);
+        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(caseDetails);
 
         verify(ccdUpdateService).submitEvent(caseDetails, APPLICANT_2_REQUEST_CHANGES, user, SERVICE_AUTHORIZATION);
     }
@@ -60,7 +60,7 @@ public class SolicitorSubmitJointApplicationServiceTest {
     @Test
     void shouldSubmitCcdApplicant2ApproveEventOnSubmittedCallbackIfApp2SolicitorHasNotRequestedChanges() {
         final User user = new User(TEST_AUTHORIZATION_TOKEN, UserDetails.builder().build());
-        when(idamService.retrieveUser(TEST_AUTHORIZATION_TOKEN)).thenReturn(user);
+        when(idamService.retrieveSystemUpdateUserDetails()).thenReturn(user);
 
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION);
 
@@ -70,7 +70,7 @@ public class SolicitorSubmitJointApplicationServiceTest {
         final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
         caseDetails.setData(caseData);
 
-        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(caseDetails, TEST_AUTHORIZATION_TOKEN);
+        solicitorSubmitJointApplicationService.submitEventForApprovalOrRequestingChanges(caseDetails);
 
         verify(ccdUpdateService).submitEvent(caseDetails, APPLICANT_2_APPROVE, user, SERVICE_AUTHORIZATION);
     }


### PR DESCRIPTION
- If we configure applicant 2 solicitor  access for `APPLICANT_2_APPROVE` or  `APPLICANT_2_REQUEST_CHANGES` then app2 solicitor will see those in drop down and trigger. Hence configure system user and trigger those asynchronously using system user.
- Remove hidden field financial order as it needs to be shown on Financial order page.