### PR TITLE
Remove solicitor from disputed and undisputed event names

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitAos.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitAos.java
@@ -36,8 +36,8 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
-import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosDisputed.SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED;
-import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosUnDisputed.SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED;
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueAosDisputed.SYSTEM_ISSUE_AOS_DISPUTED;
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueAosUnDisputed.SYSTEM_ISSUE_AOS_UNDISPUTED;
 
 @Component
 @Slf4j
@@ -133,8 +133,8 @@ public class SubmitAos implements CCDConfig<CaseData, State, UserRole> {
         final AcknowledgementOfService acknowledgementOfService = details.getData().getAcknowledgementOfService();
 
         String eventId = DISPUTE_DIVORCE.equals(acknowledgementOfService.getHowToRespondApplication())
-            ? SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED
-            : SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED;
+            ? SYSTEM_ISSUE_AOS_DISPUTED
+            : SYSTEM_ISSUE_AOS_UNDISPUTED;
 
         final User user = idamService.retrieveSystemUpdateUserDetails();
         final String serviceAuthorization = authTokenGenerator.generate();

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueAosDisputed.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueAosDisputed.java
@@ -22,20 +22,19 @@ import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
-public class SystemIssueSolicitorAosDisputed implements CCDConfig<CaseData, State, UserRole> {
+public class SystemIssueAosDisputed implements CCDConfig<CaseData, State, UserRole> {
 
-    public static final String SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED = "system-issue-solicitor-aos-disputed";
+    public static final String SYSTEM_ISSUE_AOS_DISPUTED = "system-issue-aos-disputed";
 
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
 
         new PageBuilder(configBuilder
-            .event(SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED)
+            .event(SYSTEM_ISSUE_AOS_DISPUTED)
             .forStates(AwaitingAos, Holding, AosOverdue)
             .name("AoS disputed")
             .description("AoS disputed")
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
-            .retries(120, 120));
+            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueAosUnDisputed.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueAosUnDisputed.java
@@ -22,20 +22,19 @@ import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
-public class SystemIssueSolicitorAosUnDisputed implements CCDConfig<CaseData, State, UserRole> {
+public class SystemIssueAosUnDisputed implements CCDConfig<CaseData, State, UserRole> {
 
-    public static final String SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED = "system-issue-solicitor-aos-undisputed";
+    public static final String SYSTEM_ISSUE_AOS_UNDISPUTED = "system-issue-aos-undisputed";
 
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
 
         new PageBuilder(configBuilder
-            .event(SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED)
+            .event(SYSTEM_ISSUE_AOS_UNDISPUTED)
             .forStates(AwaitingAos, Holding, AosOverdue)
             .name("AoS undisputed")
             .description("AoS undisputed")
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
-            .retries(120, 120));
+            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/common/event/SubmitAosTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/event/SubmitAosTest.java
@@ -30,8 +30,8 @@ import static uk.gov.hmcts.divorce.common.event.SubmitAos.SUBMIT_AOS;
 import static uk.gov.hmcts.divorce.divorcecase.model.HowToRespondApplication.DISPUTE_DIVORCE;
 import static uk.gov.hmcts.divorce.divorcecase.model.HowToRespondApplication.WITHOUT_DISPUTE_DIVORCE;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Holding;
-import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosDisputed.SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED;
-import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosUnDisputed.SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED;
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueAosDisputed.SYSTEM_ISSUE_AOS_DISPUTED;
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueAosUnDisputed.SYSTEM_ISSUE_AOS_UNDISPUTED;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SERVICE_AUTH_TOKEN;
@@ -143,11 +143,11 @@ class SubmitAosTest {
 
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
 
-        doNothing().when(ccdUpdateService).submitEvent(caseDetails, SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED, user, TEST_SERVICE_AUTH_TOKEN);
+        doNothing().when(ccdUpdateService).submitEvent(caseDetails, SYSTEM_ISSUE_AOS_DISPUTED, user, TEST_SERVICE_AUTH_TOKEN);
 
         submitAos.submitted(caseDetails, beforeDetails);
 
-        verify(ccdUpdateService).submitEvent(caseDetails, SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED, user, TEST_SERVICE_AUTH_TOKEN);
+        verify(ccdUpdateService).submitEvent(caseDetails, SYSTEM_ISSUE_AOS_DISPUTED, user, TEST_SERVICE_AUTH_TOKEN);
     }
 
     @Test
@@ -172,10 +172,10 @@ class SubmitAosTest {
 
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
 
-        doNothing().when(ccdUpdateService).submitEvent(caseDetails, SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED, user, TEST_SERVICE_AUTH_TOKEN);
+        doNothing().when(ccdUpdateService).submitEvent(caseDetails, SYSTEM_ISSUE_AOS_UNDISPUTED, user, TEST_SERVICE_AUTH_TOKEN);
 
         submitAos.submitted(caseDetails, beforeDetails);
 
-        verify(ccdUpdateService).submitEvent(caseDetails, SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED, user, TEST_SERVICE_AUTH_TOKEN);
+        verify(ccdUpdateService).submitEvent(caseDetails, SYSTEM_ISSUE_AOS_UNDISPUTED, user, TEST_SERVICE_AUTH_TOKEN);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueAosDisputedTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueAosDisputedTest.java
@@ -11,24 +11,24 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosUnDisputed.SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED;
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueAosDisputed.SYSTEM_ISSUE_AOS_DISPUTED;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
 
 @ExtendWith(SpringExtension.class)
-public class SystemIssueSolicitorAosUnDisputedTest {
+public class SystemIssueAosDisputedTest {
 
     @InjectMocks
-    private SystemIssueSolicitorAosUnDisputed systemIssueSolicitorAosUnDisputed;
+    private SystemIssueAosDisputed systemIssueAosDisputed;
 
     @Test
     void shouldAddConfigurationToConfigBuilder() {
         final ConfigBuilderImpl<CaseData, State, UserRole> configBuilder = createCaseDataConfigBuilder();
 
-        systemIssueSolicitorAosUnDisputed.configure(configBuilder);
+        systemIssueAosDisputed.configure(configBuilder);
 
         assertThat(getEventsFrom(configBuilder).values())
             .extracting(Event::getId)
-            .contains(SYSTEM_ISSUE_SOLICITOR_AOS_UNDISPUTED);
+            .contains(SYSTEM_ISSUE_AOS_DISPUTED);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueAosUnDisputedTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueAosUnDisputedTest.java
@@ -11,24 +11,24 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorAosDisputed.SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED;
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueAosUnDisputed.SYSTEM_ISSUE_AOS_UNDISPUTED;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
 
 @ExtendWith(SpringExtension.class)
-public class SystemIssueSolicitorAosDisputedTest {
+public class SystemIssueAosUnDisputedTest {
 
     @InjectMocks
-    private SystemIssueSolicitorAosDisputed systemIssueSolicitorAosDisputed;
+    private SystemIssueAosUnDisputed systemIssueAosUnDisputed;
 
     @Test
     void shouldAddConfigurationToConfigBuilder() {
         final ConfigBuilderImpl<CaseData, State, UserRole> configBuilder = createCaseDataConfigBuilder();
 
-        systemIssueSolicitorAosDisputed.configure(configBuilder);
+        systemIssueAosUnDisputed.configure(configBuilder);
 
         assertThat(getEventsFrom(configBuilder).values())
             .extracting(Event::getId)
-            .contains(SYSTEM_ISSUE_SOLICITOR_AOS_DISPUTED);
+            .contains(SYSTEM_ISSUE_AOS_UNDISPUTED);
     }
 }


### PR DESCRIPTION
These events are triggered for citizen and solicitor cases so I've removed solicitor from the event ID