### PR TITLE
Added exception record ccd definitions for bulk scan

### DIFF
--- a/bin/process-and-import-ccd-definition.sh
+++ b/bin/process-and-import-ccd-definition.sh
@@ -12,5 +12,9 @@ build_dir=${root_dir}/build/ccd-config
 for dir in $(find ${root_dir}/build/definitions/ -maxdepth 1 -mindepth  1 -type d -exec basename {} \;)
 do
   definitionOutputFile=${build_dir}/ccd-$dir-${CCD_DEF_NAME:-dev}.xlsx
-  ${scriptPath}/ccd-import-definition.sh $definitionOutputFile
+  # skip uploading of exception record as it is managed separately
+  if [[ ${definitionOutputFile} != *"ExceptionRecord"* ]];
+  then
+     ${scriptPath}/ccd-import-definition.sh $definitionOutputFile
+  fi
 done

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -185,7 +185,7 @@
     </module>
     <module name="AbbreviationAsWordInName">
       <property name="ignoreFinal" value="false"/>
-      <property name="allowedAbbreviationLength" value="1"/>
+      <property name="allowedAbbreviationLength" value="3"/>
     </module>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="VariableDeclarationUsageDistance"/>

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/ExceptionRecordCaseTypeConfig.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/ExceptionRecordCaseTypeConfig.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+@Component
+public class ExceptionRecordCaseTypeConfig implements CCDConfig<ExceptionRecord, ExceptionRecordState, UserRole> {
+
+    public static final String CASE_TYPE = "NO_FAULT_DIVORCE_ExceptionRecord";
+    public static final String JURISDICTION = "DIVORCE";
+
+    @Override
+    public void configure(final ConfigBuilder<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder) {
+        configBuilder.caseType(CASE_TYPE, "Exception record", "Exception record for new law case");
+        configBuilder.jurisdiction(JURISDICTION, "Family Divorce", "Manage new law case exception records");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/ExceptionRecordPageBuilder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/ExceptionRecordPageBuilder.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd;
+
+import uk.gov.hmcts.ccd.sdk.api.Event.EventBuilder;
+import uk.gov.hmcts.ccd.sdk.api.FieldCollection.FieldCollectionBuilder;
+import uk.gov.hmcts.ccd.sdk.api.callback.MidEvent;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+public class ExceptionRecordPageBuilder {
+
+    private final EventBuilder<ExceptionRecord, UserRole, ExceptionRecordState> eventBuilder;
+
+    public ExceptionRecordPageBuilder(final EventBuilder<ExceptionRecord, UserRole, ExceptionRecordState> eventBuilder) {
+        this.eventBuilder = eventBuilder;
+    }
+
+    public FieldCollectionBuilder<
+        ExceptionRecord,
+        ExceptionRecordState,
+        EventBuilder<ExceptionRecord, UserRole, ExceptionRecordState>
+        > page(final String id) {
+        return eventBuilder.fields().page(id);
+    }
+
+    public FieldCollectionBuilder<
+        ExceptionRecord, ExceptionRecordState,
+        EventBuilder<ExceptionRecord, UserRole, ExceptionRecordState>
+        > page(
+        final String id,
+        final MidEvent<ExceptionRecord, ExceptionRecordState> callback) {
+
+        return eventBuilder.fields().page(id, callback);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/ExceptionRecordState.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/ExceptionRecordState.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import uk.gov.hmcts.ccd.sdk.api.CCD;
+
+@RequiredArgsConstructor
+@Getter
+public enum ExceptionRecordState {
+
+    @CCD(
+        name = "A scanned record has been received"
+    )
+    ScannedRecordReceived("ScannedRecordReceived"),
+
+    @CCD(
+        name = "The scanned record has been attached to existing case"
+    )
+    ScannedRecordAttachedToCase("ScannedRecordAttachedToCase"),
+
+    @CCD(
+        name = "A new case is created from scanned record"
+    )
+    ScannedRecordCaseCreated("ScannedRecordCaseCreated"),
+
+    @CCD(
+        name = "The scanned record has been rejected"
+    )
+    ScannedRecordRejected("ScannedRecordRejected"),
+
+    @CCD(
+        name = "The scanned record has been handled by CW manually"
+    )
+    ScannedRecordManuallyHandled("ScannedRecordManuallyHandled");
+
+    private final String name;
+}
+

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/AttachExceptionRecordToCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/AttachExceptionRecordToCase.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.event;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordPageBuilder;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState.ScannedRecordAttachedToCase;
+import static uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState.ScannedRecordReceived;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER_BULK_SCAN;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+
+@Component
+public class AttachExceptionRecordToCase implements CCDConfig<ExceptionRecord, ExceptionRecordState, UserRole> {
+
+    public static final String ATTACH_TO_EXISTING_CASE = "attachToExistingCase";
+
+    @Override
+    public void configure(final ConfigBuilder<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder) {
+        new ExceptionRecordPageBuilder(configBuilder
+            .event(ATTACH_TO_EXISTING_CASE)
+            .forStateTransition(ScannedRecordReceived, ScannedRecordAttachedToCase)
+            .name("Attach record to existing case")
+            .description("Attach record to existing case")
+            .showEventNotes()
+            .grant(CREATE_READ_UPDATE, CASE_WORKER_BULK_SCAN, CASE_WORKER, SYSTEMUPDATE))
+            .page("attachToExistingCase")
+            .pageLabel("Correspondence")
+            .readonlyNoSummary(ExceptionRecord::getShowEnvelopeCaseReference,"envelopeCaseReference=\"ALWAYS_HIDE\"")
+            .readonlyNoSummary(ExceptionRecord::getShowEnvelopeLegacyCaseReference,"envelopeLegacyCaseReference=\"ALWAYS_HIDE\"")
+            .readonly(ExceptionRecord::getEnvelopeCaseReference,"showEnvelopeCaseReference=\"Yes\"")
+            .readonly(ExceptionRecord::getShowEnvelopeLegacyCaseReference,"showEnvelopeLegacyCaseReference=\"Yes\"")
+            .mandatory(ExceptionRecord::getSearchCaseReference)
+            .mandatory(ExceptionRecord::getScannedDocuments);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/CompleteAwaitingPaymentDcnProcessing.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/CompleteAwaitingPaymentDcnProcessing.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.event;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordPageBuilder;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER_BULK_SCAN;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+
+@Component
+public class CompleteAwaitingPaymentDcnProcessing implements CCDConfig<ExceptionRecord, ExceptionRecordState, UserRole> {
+
+    public static final String COMPLETE_AWAITING_PAYMENT_DCNPROCESSING = "completeAwaitingPaymentDCNProcessing";
+
+    @Override
+    public void configure(final ConfigBuilder<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder) {
+        new ExceptionRecordPageBuilder(configBuilder
+            .event(COMPLETE_AWAITING_PAYMENT_DCNPROCESSING)
+            .forAllStates()
+            .name("Complete DCN processing")
+            .description("Complete the processing of payment document control numbers")
+            .showEventNotes()
+            .grant(CREATE_READ_UPDATE, CASE_WORKER_BULK_SCAN, CASE_WORKER, SYSTEMUPDATE));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/CreateCaseFromExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/CreateCaseFromExceptionRecord.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.event;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordPageBuilder;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState.ScannedRecordCaseCreated;
+import static uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState.ScannedRecordReceived;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER_BULK_SCAN;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+
+@Component
+public class CreateCaseFromExceptionRecord implements CCDConfig<ExceptionRecord, ExceptionRecordState, UserRole> {
+
+    public static final String CREATE_NEW_CASE = "createNewCase";
+
+    @Override
+    public void configure(final ConfigBuilder<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder) {
+        new ExceptionRecordPageBuilder(configBuilder
+            .event(CREATE_NEW_CASE)
+            .forStateTransition(ScannedRecordReceived, ScannedRecordCaseCreated)
+            .name("Create new case from exception")
+            .description("Create new case from exception")
+            .showEventNotes()
+            .grant(CREATE_READ_UPDATE, CASE_WORKER_BULK_SCAN, CASE_WORKER, SYSTEMUPDATE))
+            .page("createNewCase")
+            .pageLabel("Correspondence")
+            .mandatory(ExceptionRecord::getScannedDocuments)
+            .mandatory(ExceptionRecord::getScanOCRData);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/CreateExceptionRecord.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.event;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordPageBuilder;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState.ScannedRecordReceived;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER_BULK_SCAN;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+
+@Component
+public class CreateExceptionRecord implements CCDConfig<ExceptionRecord, ExceptionRecordState, UserRole> {
+
+    public static final String CREATE_EXCEPTION = "createException";
+
+    @Override
+    public void configure(final ConfigBuilder<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder) {
+        new ExceptionRecordPageBuilder(configBuilder
+            .event(CREATE_EXCEPTION)
+            .initialState(ScannedRecordReceived)
+            .name("Create an exception record")
+            .description("Create an exception record")
+            .showEventNotes()
+            .grant(CREATE_READ_UPDATE, CASE_WORKER_BULK_SCAN, CASE_WORKER, SYSTEMUPDATE))
+            .page("createException")
+            .pageLabel("Correspondence")
+            .readonly(ExceptionRecord::getEnvelopeLabel)
+            .optional(ExceptionRecord::getJourneyClassification)
+            .optional(ExceptionRecord::getPoBox)
+            .optional(ExceptionRecord::getPoBoxJurisdiction)
+            .optional(ExceptionRecord::getDeliveryDate)
+            .optional(ExceptionRecord::getOpeningDate)
+            .optional(ExceptionRecord::getScannedDocuments)
+            .optional(ExceptionRecord::getScanOCRData)
+            .optional(ExceptionRecord::getFormType)
+            .optional(ExceptionRecord::getEnvelopeCaseReference)
+            .optional(ExceptionRecord::getEnvelopeLegacyCaseReference)
+            .optional(ExceptionRecord::getShowEnvelopeCaseReference)
+            .optional(ExceptionRecord::getShowEnvelopeLegacyCaseReference);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/ManuallyHandleExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/ManuallyHandleExceptionRecord.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.event;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordPageBuilder;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState.ScannedRecordManuallyHandled;
+import static uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState.ScannedRecordReceived;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER_BULK_SCAN;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+
+@Component
+public class ManuallyHandleExceptionRecord implements CCDConfig<ExceptionRecord, ExceptionRecordState, UserRole> {
+
+    public static final String UPDATE_MANUALLY = "updateManually";
+
+    @Override
+    public void configure(final ConfigBuilder<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder) {
+        new ExceptionRecordPageBuilder(configBuilder
+            .event(UPDATE_MANUALLY)
+            .forStateTransition(ScannedRecordReceived, ScannedRecordManuallyHandled)
+            .name("Manually handle record")
+            .description("Manually handle record")
+            .showEventNotes()
+            .grant(CREATE_READ_UPDATE, CASE_WORKER_BULK_SCAN, CASE_WORKER, SYSTEMUPDATE))
+            .page("updateManually")
+            .pageLabel("Correspondence")
+            .mandatory(ExceptionRecord::getScannedDocuments)
+            .mandatory(ExceptionRecord::getScanOCRData);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/RejectExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/RejectExceptionRecord.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.event;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordPageBuilder;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState.ScannedRecordReceived;
+import static uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState.ScannedRecordRejected;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER_BULK_SCAN;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+
+@Component
+public class RejectExceptionRecord implements CCDConfig<ExceptionRecord, ExceptionRecordState, UserRole> {
+
+    public static final String REJECT_RECORD = "rejectRecord";
+
+    @Override
+    public void configure(final ConfigBuilder<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder) {
+        new ExceptionRecordPageBuilder(configBuilder
+            .event(REJECT_RECORD)
+            .forStateTransition(ScannedRecordReceived, ScannedRecordRejected)
+            .name("Reject record")
+            .description("Reject record")
+            .showEventNotes()
+            .grant(CREATE_READ_UPDATE, CASE_WORKER_BULK_SCAN, CASE_WORKER, SYSTEMUPDATE))
+            .page("createNewCase")
+            .pageLabel("Correspondence")
+            .mandatory(ExceptionRecord::getScannedDocuments);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/data/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/data/ExceptionRecord.java
@@ -1,0 +1,158 @@
+package uk.gov.hmcts.divorce.bulkscan.data;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.ccd.sdk.api.CCD;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static uk.gov.hmcts.ccd.sdk.type.FieldType.Collection;
+import static uk.gov.hmcts.ccd.sdk.type.FieldType.Label;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class ExceptionRecord {
+
+    @CCD(
+        label = "# Envelope meta data",
+        hint = "From scan envelope header",
+        typeOverride = Label
+    )
+    private String envelopeLabel;
+
+    @CCD(
+        label = "Journey classification",
+        hint = "Was this a supplementary evidence / new case or exception"
+    )
+    private String journeyClassification;
+
+    @CCD(
+        label = "PO box"
+    )
+    private String poBox;
+
+    @CCD(
+        label = "Jurisdiction"
+    )
+    private String poBoxJurisdiction;
+
+    @CCD(
+        label = "Delivery date"
+    )
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    private LocalDateTime deliveryDate;
+
+    @CCD(
+        label = "Opening date"
+    )
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    private LocalDateTime openingDate;
+
+    @CCD(
+        label = "Scanned documents",
+        typeOverride = Collection,
+        typeParameterOverride = "ScannedDocument"
+    )
+    private List<ListValue<ScannedDocument>> scannedDocuments;
+
+    @CCD(
+        label = "Form OCR data",
+        typeOverride = Collection,
+        typeParameterOverride = "KeyValue"
+    )
+    private List<ListValue<KeyValue>> scanOCRData;
+
+    @CCD(
+        label = "Attach to case reference",
+        hint = "The number of the case to attach the envelop to"
+    )
+    private String attachToCaseReference;
+
+    @CCD(
+        label = "Case reference",
+        hint = "Reference number of the new case created from exception record"
+    )
+    private String caseReference;
+
+    @CCD(
+        label = "OCR data validation warnings",
+        typeOverride = Collection,
+        typeParameterOverride = "TextArea"
+    )
+    private List<String> ocrDataValidationWarnings;
+
+    @CCD(
+        label = "Display warnings",
+        hint = "Indicates if warnings tab should be displayed"
+    )
+    private YesOrNo displayWarnings;
+
+    @CCD(
+        label = "Form type"
+    )
+    private String formType;
+
+    @CCD(
+        label = "Envelope Id",
+        hint = "Id of the envelope the exception record was created from"
+    )
+    private String envelopeId;
+
+    @CCD(
+        label = "Awaiting Payment DCN processing",
+        hint = "Indicates if the payment document control numbers are being processed"
+    )
+    private YesOrNo awaitingPaymentDCNProcessing;
+
+    @CCD(
+        label = "Contains payments",
+        hint = "Indicates if the exception record contains payments"
+    )
+    private YesOrNo containsPayments;
+
+    @CCD(
+        label = "Envelope Id",
+        hint = "Id of the envelope the exception record was created from"
+    )
+    private String envelopeCaseReference;
+
+    @CCD(
+        label = "Envelope legacy case reference",
+        hint = "The legacy case reference number received in the envelope"
+    )
+    private String envelopeLegacyCaseReference;
+
+    @CCD(
+        label = "Display envelope case reference",
+        hint = "Indicates if the envelope case reference field should be displayed"
+    )
+    private YesOrNo showEnvelopeCaseReference;
+
+    @CCD(
+        label = "Display envelope legacy case reference",
+        hint = "Indicates if the envelope case reference field should be displayed"
+    )
+    private YesOrNo showEnvelopeLegacyCaseReference;
+
+    @CCD(
+        label = "Surname",
+        hint = "Surname"
+    )
+    private String surname;
+
+    @CCD(
+        label = "Case Reference",
+        hint = "The case reference to attach the envelope to"
+    )
+    private String searchCaseReference;
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/data/KeyValue.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/data/KeyValue.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.divorce.bulkscan.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class KeyValue {
+
+    private String key;
+
+    private String value;
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/data/ScannedDocument.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/data/ScannedDocument.java
@@ -1,0 +1,66 @@
+package uk.gov.hmcts.divorce.bulkscan.data;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.ccd.sdk.api.CCD;
+import uk.gov.hmcts.ccd.sdk.type.Document;
+
+import java.time.LocalDateTime;
+
+import static uk.gov.hmcts.ccd.sdk.type.FieldType.FixedList;
+import static uk.gov.hmcts.ccd.sdk.type.FieldType.Label;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScannedDocument {
+
+    @CCD(
+        label = "Scanned Records",
+        typeOverride = Label
+    )
+    private String recordMetaData;
+
+    @CCD(
+        label = "Select document type",
+        typeOverride = FixedList,
+        typeParameterOverride = "ScannedDocumentType"
+    )
+    private ScannedDocumentType type;
+
+    @CCD(
+        label = "Document subtype"
+    )
+    private String subtype;
+
+    @CCD(
+        label = "Scanned document url"
+    )
+    private Document url;
+
+    @CCD(
+        label = "Document control number"
+    )
+    private String controlNumber;
+
+    @CCD(
+        label = "File Name"
+    )
+    private String fileName;
+
+    @CCD(
+        label = "Scanned date"
+    )
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    private LocalDateTime scannedDate;
+
+    @CCD(
+        label = "Delivery date"
+    )
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    private LocalDateTime deliveryDate;
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/data/ScannedDocumentType.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/data/ScannedDocumentType.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.divorce.bulkscan.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import uk.gov.hmcts.ccd.sdk.api.HasLabel;
+
+@Getter
+@AllArgsConstructor
+public enum ScannedDocumentType implements HasLabel {
+
+    @JsonProperty("cherished")
+    CHERISHED("Cherished"),
+
+    @JsonProperty("coversheet")
+    COVERSHEET("Coversheet"),
+
+    @JsonProperty("form")
+    FORM("Form"),
+
+    @JsonProperty("other")
+    OTHER("Other");
+
+    private final String label;
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/search/ExceptionRecordSearchInputFields.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/search/ExceptionRecordSearchInputFields.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.bulkscan.search;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.SearchField;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import java.util.List;
+
+import static java.util.List.of;
+
+@Component
+public class ExceptionRecordSearchInputFields implements CCDConfig<ExceptionRecord, ExceptionRecordState, UserRole> {
+
+    @Override
+    public void configure(final ConfigBuilder<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder) {
+        final List<SearchField> searchFieldList = of(
+            SearchField.builder().label("Delivery date").id("deliveryDate").build(),
+            SearchField.builder().label("Opening date").id("openingDate").build(),
+            SearchField.builder().label("PO Box").id("poBox").build(),
+            SearchField.builder().label("PO Box jurisdiction").id("poBoxJurisdiction").build(),
+            SearchField.builder().label("New case reference").id("caseReference").build(),
+            SearchField.builder().label("Attach to case reference").id("attachToCaseReference").build(),
+            SearchField.builder().label("Journey classification").id("journeyClassification").build(),
+            SearchField.builder().label("Form type").id("formType").build(),
+            SearchField.builder().label("Contains payments").id("containsPayments").build()
+        );
+
+        configBuilder.searchInputFields().fields(searchFieldList);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/search/ExceptionRecordSearchResultFields.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/search/ExceptionRecordSearchResultFields.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.divorce.bulkscan.search;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.SearchField;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import java.util.List;
+
+import static java.util.List.of;
+
+@Component
+public class ExceptionRecordSearchResultFields implements CCDConfig<ExceptionRecord, ExceptionRecordState, UserRole> {
+
+    @Override
+    public void configure(final ConfigBuilder<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder) {
+        final List<SearchField> searchFieldList = of(
+            SearchField.builder().label("Exception created date").id("[CREATED_DATE]").build(),
+            SearchField.builder().label("Delivery date").id("deliveryDate").build(),
+            SearchField.builder().label("New case reference").id("caseReference").build(),
+            SearchField.builder().label("Attach to case reference").id("attachToCaseReference").build(),
+            SearchField.builder().label("Form type").id("formType").build()
+        );
+
+        configBuilder.searchResultFields().fields(searchFieldList);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/workbasket/ExceptionRecordWorkBasketInputFields.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/workbasket/ExceptionRecordWorkBasketInputFields.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.divorce.bulkscan.workbasket;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.WorkBasketField;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import java.util.List;
+
+import static java.util.List.of;
+
+@Component
+public class ExceptionRecordWorkBasketInputFields implements CCDConfig<ExceptionRecord, ExceptionRecordState, UserRole> {
+
+    @Override
+    public void configure(final ConfigBuilder<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder) {
+        final List<WorkBasketField> workBasketFieldList = of(
+            WorkBasketField.builder().label("Form type").id("formType").build(),
+            WorkBasketField.builder().label("Contains payments").id("containsPayments").build()
+        );
+
+        configBuilder.workBasketInputFields().fields(workBasketFieldList);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/workbasket/ExceptionRecordWorkBasketResultFields.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/workbasket/ExceptionRecordWorkBasketResultFields.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.bulkscan.workbasket;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.WorkBasketField;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import java.util.List;
+
+import static java.util.List.of;
+
+@Component
+public class ExceptionRecordWorkBasketResultFields implements CCDConfig<ExceptionRecord, ExceptionRecordState, UserRole> {
+
+    @Override
+    public void configure(final ConfigBuilder<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder) {
+        final List<WorkBasketField> workBasketFieldList = of(
+            WorkBasketField.builder().label("Exception Id").id("[CASE_REFERENCE]").build(),
+            WorkBasketField.builder().label("Exception created date").id("[CREATED_DATE]").build(),
+            WorkBasketField.builder().label("Delivery date").id("deliveryDate").build(),
+            WorkBasketField.builder().label("Opening date").id("openingDate").build(),
+            WorkBasketField.builder().label("New case reference").id("caseReference").build(),
+            WorkBasketField.builder().label("Attach to case reference").id("attachToCaseReference").build(),
+            WorkBasketField.builder().label("PO Box").id("poBox").build(),
+            WorkBasketField.builder().label("Journey classification").id("journeyClassification").build(),
+            WorkBasketField.builder().label("Form type").id("formType").build()
+        );
+
+        configBuilder.workBasketResultFields().fields(workBasketFieldList);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/UserRole.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/UserRole.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.ccd.sdk.api.HasRole;
 public enum UserRole implements HasRole {
 
     CASE_WORKER("caseworker-divorce-courtadmin_beta", "CRU"),
+    CASE_WORKER_BULK_SCAN("caseworker-divorce-bulkscan", "CRU"),
     LEGAL_ADVISOR("caseworker-divorce-courtadmin-la", "CRU"),
     SUPER_USER("caseworker-divorce-superuser", "CRU"),
     SYSTEMUPDATE("caseworker-divorce-systemupdate", "CRU"),

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/AttachExceptionRecordToCaseTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/AttachExceptionRecordToCaseTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.bulkscan.ccd.event.AttachExceptionRecordToCase.ATTACH_TO_EXISTING_CASE;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createExceptionRecordConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+
+@ExtendWith(MockitoExtension.class)
+class AttachExceptionRecordToCaseTest {
+
+    @InjectMocks
+    private AttachExceptionRecordToCase attachExceptionRecordToCase;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() {
+        final ConfigBuilderImpl<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder = createExceptionRecordConfigBuilder();
+
+        attachExceptionRecordToCase.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(ATTACH_TO_EXISTING_CASE);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/CompleteAwaitingPaymentDcnProcessingTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/CompleteAwaitingPaymentDcnProcessingTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.bulkscan.ccd.event.CompleteAwaitingPaymentDcnProcessing.COMPLETE_AWAITING_PAYMENT_DCNPROCESSING;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createExceptionRecordConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+
+@ExtendWith(MockitoExtension.class)
+class CompleteAwaitingPaymentDcnProcessingTest {
+
+    @InjectMocks
+    private CompleteAwaitingPaymentDcnProcessing completeAwaitingPaymentDcnProcessing;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() {
+        final ConfigBuilderImpl<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder = createExceptionRecordConfigBuilder();
+
+        completeAwaitingPaymentDcnProcessing.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(COMPLETE_AWAITING_PAYMENT_DCNPROCESSING);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/CreateCaseFromExceptionRecordTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/CreateCaseFromExceptionRecordTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.bulkscan.ccd.event.CreateCaseFromExceptionRecord.CREATE_NEW_CASE;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createExceptionRecordConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+
+@ExtendWith(MockitoExtension.class)
+class CreateCaseFromExceptionRecordTest {
+
+    @InjectMocks
+    private CreateCaseFromExceptionRecord createCaseFromExceptionRecord;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() {
+        final ConfigBuilderImpl<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder = createExceptionRecordConfigBuilder();
+
+        createCaseFromExceptionRecord.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(CREATE_NEW_CASE);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/CreateExceptionRecordTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/CreateExceptionRecordTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.bulkscan.ccd.event.CreateExceptionRecord.CREATE_EXCEPTION;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createExceptionRecordConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+
+@ExtendWith(MockitoExtension.class)
+class CreateExceptionRecordTest {
+
+    @InjectMocks
+    private CreateExceptionRecord createExceptionRecord;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() {
+        final ConfigBuilderImpl<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder = createExceptionRecordConfigBuilder();
+
+        createExceptionRecord.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(CREATE_EXCEPTION);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/ManuallyHandleExceptionRecordTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/ManuallyHandleExceptionRecordTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.bulkscan.ccd.event.ManuallyHandleExceptionRecord.UPDATE_MANUALLY;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createExceptionRecordConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+
+@ExtendWith(MockitoExtension.class)
+class ManuallyHandleExceptionRecordTest {
+
+    @InjectMocks
+    private ManuallyHandleExceptionRecord manuallyHandleExceptionRecord;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() {
+        final ConfigBuilderImpl<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder = createExceptionRecordConfigBuilder();
+
+        manuallyHandleExceptionRecord.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(UPDATE_MANUALLY);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/RejectExceptionRecordTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/event/RejectExceptionRecordTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.bulkscan.ccd.event.RejectExceptionRecord.REJECT_RECORD;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createExceptionRecordConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+
+@ExtendWith(MockitoExtension.class)
+class RejectExceptionRecordTest {
+
+    @InjectMocks
+    private RejectExceptionRecord rejectExceptionRecord;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() {
+        final ConfigBuilderImpl<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder = createExceptionRecordConfigBuilder();
+
+        rejectExceptionRecord.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(REJECT_RECORD);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/search/ExceptionRecordSearchInputFieldsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/search/ExceptionRecordSearchInputFieldsTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.search;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.bulkscan.search.ExceptionRecordSearchInputFields;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createExceptionRecordConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getSearchInputFields;
+
+public class ExceptionRecordSearchInputFieldsTest {
+    private ExceptionRecordSearchInputFields searchInputFields;
+
+    @BeforeEach
+    void setUp() {
+        searchInputFields = new ExceptionRecordSearchInputFields();
+    }
+
+    @Test
+    void shouldSetSearchInputFields() throws Exception {
+        final ConfigBuilderImpl<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder = createExceptionRecordConfigBuilder();
+
+        searchInputFields.configure(configBuilder);
+
+        assertThat(getSearchInputFields(configBuilder).getFields())
+            .extracting("id", "label")
+            .contains(
+                tuple("deliveryDate", "Delivery date"),
+                tuple("openingDate", "Opening date"),
+                tuple("poBox", "PO Box"),
+                tuple("poBoxJurisdiction", "PO Box jurisdiction"),
+                tuple("caseReference", "New case reference"),
+                tuple("attachToCaseReference", "Attach to case reference"),
+                tuple("journeyClassification", "Journey classification"),
+                tuple("formType", "Form type"),
+                tuple("containsPayments", "Contains payments")
+            );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/search/ExceptionRecordSearchResultFieldsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/search/ExceptionRecordSearchResultFieldsTest.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.search;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.bulkscan.search.ExceptionRecordSearchResultFields;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createExceptionRecordConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getSearchResultFields;
+
+public class ExceptionRecordSearchResultFieldsTest {
+    private ExceptionRecordSearchResultFields searchResultFields;
+
+    @BeforeEach
+    void setUp() {
+        searchResultFields = new ExceptionRecordSearchResultFields();
+    }
+
+    @Test
+    void shouldSetSearchInputFields() throws Exception {
+        final ConfigBuilderImpl<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder = createExceptionRecordConfigBuilder();
+
+        searchResultFields.configure(configBuilder);
+
+        assertThat(getSearchResultFields(configBuilder).getFields())
+            .extracting("id", "label")
+            .contains(
+                tuple("[CREATED_DATE]", "Exception created date"),
+                tuple("deliveryDate", "Delivery date"),
+                tuple("caseReference", "New case reference"),
+                tuple("attachToCaseReference", "Attach to case reference"),
+                tuple("formType", "Form type")
+            );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/workbasket/ExceptionRecordWorkBasketInputFieldsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/workbasket/ExceptionRecordWorkBasketInputFieldsTest.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.workbasket;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.bulkscan.workbasket.ExceptionRecordWorkBasketInputFields;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createExceptionRecordConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getWorkBasketInputFields;
+
+public class ExceptionRecordWorkBasketInputFieldsTest {
+    private ExceptionRecordWorkBasketInputFields workbasketInputFields;
+
+    @BeforeEach
+    void setUp() {
+        workbasketInputFields = new ExceptionRecordWorkBasketInputFields();
+    }
+
+    @Test
+    void shouldSetWorkBasketInputFields() throws Exception {
+        final ConfigBuilderImpl<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder = createExceptionRecordConfigBuilder();
+
+        workbasketInputFields.configure(configBuilder);
+
+        assertThat(getWorkBasketInputFields(configBuilder).getFields())
+            .extracting("id", "label")
+            .contains(
+                tuple("formType", "Form type"),
+                tuple("containsPayments", "Contains payments")
+            );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/workbasket/ExceptionRecordWorkBasketResultFieldsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/ccd/workbasket/ExceptionRecordWorkBasketResultFieldsTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.divorce.bulkscan.ccd.workbasket;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
+import uk.gov.hmcts.divorce.bulkscan.workbasket.ExceptionRecordWorkBasketResultFields;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createExceptionRecordConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getWorkBasketResultFields;
+
+public class ExceptionRecordWorkBasketResultFieldsTest {
+    private ExceptionRecordWorkBasketResultFields workbasketResultFields;
+
+    @BeforeEach
+    void setUp() {
+        workbasketResultFields = new ExceptionRecordWorkBasketResultFields();
+    }
+
+    @Test
+    void shouldSetWorkBasketInputFields() throws Exception {
+        final ConfigBuilderImpl<ExceptionRecord, ExceptionRecordState, UserRole> configBuilder = createExceptionRecordConfigBuilder();
+
+        workbasketResultFields.configure(configBuilder);
+
+        assertThat(getWorkBasketResultFields(configBuilder).getFields())
+            .extracting("id", "label")
+            .contains(
+                tuple("[CASE_REFERENCE]", "Exception Id"),
+                tuple("[CREATED_DATE]", "Exception created date"),
+                tuple("deliveryDate", "Delivery date"),
+                tuple("openingDate", "Opening date"),
+                tuple("poBox", "PO Box"),
+                tuple("caseReference", "New case reference"),
+                tuple("attachToCaseReference", "Attach to case reference"),
+                tuple("journeyClassification", "Journey classification"),
+                tuple("formType", "Form type")
+            );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/testutil/ConfigTestUtil.java
+++ b/src/test/java/uk/gov/hmcts/divorce/testutil/ConfigTestUtil.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.ccd.sdk.api.WorkBasket;
 import uk.gov.hmcts.ccd.sdk.api.WorkBasket.WorkBasketBuilder;
 import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState;
 import uk.gov.hmcts.divorce.bulkaction.data.BulkActionCaseData;
+import uk.gov.hmcts.divorce.bulkscan.ccd.ExceptionRecordState;
+import uk.gov.hmcts.divorce.bulkscan.data.ExceptionRecord;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
@@ -35,6 +37,15 @@ public final class ConfigTestUtil {
             UserRole.class,
             new HashMap<>(),
             ImmutableSet.copyOf(State.class.getEnumConstants())));
+    }
+
+    public static ConfigBuilderImpl<ExceptionRecord, ExceptionRecordState, UserRole> createExceptionRecordConfigBuilder() {
+        return new ConfigBuilderImpl<>(new ResolvedCCDConfig<>(
+            ExceptionRecord.class,
+            ExceptionRecordState.class,
+            UserRole.class,
+            new HashMap<>(),
+            ImmutableSet.copyOf(ExceptionRecordState.class.getEnumConstants())));
     }
 
     public static ConfigBuilderImpl<BulkActionCaseData, BulkActionState, UserRole> createBulkActionConfigBuilder() {


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-1637

### Change description ###

- Includes changes to script to exclude exception record excel getting imported into ccd as it is managed by bulk scanning team. We still want to generate the json and excel and it may be needed for testing.
- allowedAbbreviationLength is being bumped to 3 as some of the bulk scanning exception records fields has length of 3 and this can't be changed as bsp service expects the fields to be same.