### PR TITLE
NFDIV-1654 Notice of change

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChange.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChange.java
@@ -7,6 +7,8 @@ import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.Organisation;
+import uk.gov.hmcts.ccd.sdk.type.OrganisationPolicy;
 import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
 import uk.gov.hmcts.divorce.divorcecase.model.AlternativeService;
 import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
@@ -15,25 +17,45 @@ import uk.gov.hmcts.divorce.divorcecase.model.NoticeOfChange;
 import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.divorce.solicitor.service.CcdAccessService;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
+import static uk.gov.hmcts.divorce.divorcecase.model.NoticeOfChange.WhichApplicant.APPLICANT_1;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingAos;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingBailiffReferral;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingBailiffService;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_1_SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2_SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
 public class CaseworkerNoticeOfChange implements CCDConfig<CaseData, State, UserRole> {
     public static final String CASEWORKER_NOTICE_OF_CHANGE = "caseworker-notice-of-change";
+    private static final String NEVER_SHOW = "nocWhichApplicant=\"never\"";
+
+    @Autowired
+    private HttpServletRequest request;
+
+    @Autowired
+    private CcdAccessService caseAccessService;
 
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
@@ -45,7 +67,7 @@ public class CaseworkerNoticeOfChange implements CCDConfig<CaseData, State, User
             .showSummary()
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
-            .grant(CREATE_READ, CASE_WORKER, SUPER_USER)
+            .grant(CREATE_READ_UPDATE, CASE_WORKER, SUPER_USER)
             .grant(READ, LEGAL_ADVISOR))
             .page("changeRepresentation-1")
             .pageLabel("Which applicant")
@@ -54,19 +76,49 @@ public class CaseworkerNoticeOfChange implements CCDConfig<CaseData, State, User
                 .done()
             .page("changeRepresentation-2")
             .showCondition("nocWhichApplicant=\"applicant1\"")
-            .pageLabel("Change applicant 1 representation")
+            .pageLabel("Change representation")
             .complex(CaseData::getNoticeOfChange)
                 .mandatory(NoticeOfChange::getAreTheyRepresented)
+                .mandatory(NoticeOfChange::getAreTheyDigital, "nocAreTheyRepresented=\"Yes\"")
                 .done()
             .complex(CaseData::getApplicant1)
                 .complex(Applicant::getSolicitor)
-                    .optional(Solicitor::getName, "nocAreTheyRepresented=\"Yes\"")
-                    .optional(Solicitor::getPhone, "nocAreTheyRepresented=\"Yes\"")
-                    .optional(Solicitor::getEmail, "nocAreTheyRepresented=\"Yes\"")
-                    .optional(Solicitor::getAddress, "nocAreTheyRepresented=\"Yes\"")
+                    .mandatory(Solicitor::getName, "nocAreTheyRepresented=\"Yes\"")
+                    .mandatory(Solicitor::getPhone, "nocAreTheyRepresented=\"Yes\"")
+                    .mandatory(Solicitor::getEmail, "nocAreTheyRepresented=\"Yes\"")
+                    .mandatory(Solicitor::getAddress, "nocAreTheyRepresented=\"Yes\" AND nocAreTheyDigital=\"No\"")
+                    .complex(Solicitor::getOrganisationPolicy, "nocAreTheyRepresented=\"Yes\" AND nocAreTheyDigital=\"Yes\"")
+                        .complex(OrganisationPolicy::getOrganisation)
+                            .mandatory(Organisation::getOrganisationId)
+                            .done()
+                        .optional(OrganisationPolicy::getOrgPolicyCaseAssignedRole, NEVER_SHOW, APPLICANT_1_SOLICITOR)
+                        .optional(OrganisationPolicy::getOrgPolicyReference, NEVER_SHOW)
+                        .done()
                     .done()
-                .label("nocWhereSentLabel", "Where should documents be sent?")
-                .optional(Applicant::getCorrespondenceAddress, "nocAreTheyRepresented=\"No\"")
+                .mandatory(Applicant::getCorrespondenceAddress, "nocAreTheyRepresented=\"No\"")
+                .done()
+            .page("changeRepresentation-3")
+            .showCondition("nocWhichApplicant=\"applicant2\"")
+            .pageLabel("Change representation")
+            .complex(CaseData::getNoticeOfChange)
+                .mandatory(NoticeOfChange::getAreTheyRepresented)
+                .mandatory(NoticeOfChange::getAreTheyDigital, "nocAreTheyRepresented=\"Yes\"")
+                .done()
+            .complex(CaseData::getApplicant2)
+                .complex(Applicant::getSolicitor)
+                    .mandatory(Solicitor::getName, "nocAreTheyRepresented=\"Yes\"")
+                    .mandatory(Solicitor::getPhone, "nocAreTheyRepresented=\"Yes\"")
+                    .mandatory(Solicitor::getEmail, "nocAreTheyRepresented=\"Yes\"")
+                    .mandatory(Solicitor::getAddress, "nocAreTheyRepresented=\"Yes\" AND nocAreTheyDigital=\"No\"")
+                    .complex(Solicitor::getOrganisationPolicy, "nocAreTheyRepresented=\"Yes\" AND nocAreTheyDigital=\"Yes\"")
+                        .complex(OrganisationPolicy::getOrganisation)
+                            .mandatory(Organisation::getOrganisationId)
+                            .done()
+                        .optional(OrganisationPolicy::getOrgPolicyCaseAssignedRole, NEVER_SHOW, APPLICANT_2_SOLICITOR)
+                        .optional(OrganisationPolicy::getOrgPolicyReference, NEVER_SHOW)
+                        .done()
+                    .done()
+                .mandatory(Applicant::getCorrespondenceAddress, "nocAreTheyRepresented=\"No\"")
                 .done();
     }
 
@@ -75,10 +127,27 @@ public class CaseworkerNoticeOfChange implements CCDConfig<CaseData, State, User
         final CaseDetails<CaseData, State> beforeDetails
     ) {
         log.info("Caseworker notice of change aboutToSubmit callback started");
-        // TODO set offline, remove org policy, remove case access
+
+        final var data = details.getData();
+        final var applicant = data.getNoticeOfChange().getWhichApplicant() == APPLICANT_1
+            ? data.getApplicant1()
+            : data.getApplicant2();
+
+        if (data.getNoticeOfChange().getAreTheyDigital() == null || !data.getNoticeOfChange().getAreTheyDigital().toBoolean()) {
+            applicant.getSolicitor().setOrganisationPolicy(null);
+            applicant.setOffline(YES);
+        } else {
+            applicant.setOffline(NO);
+        }
+
+        final var roles = data.getNoticeOfChange().getWhichApplicant() == APPLICANT_1
+            ? List.of(CREATOR.getRole(), APPLICANT_1_SOLICITOR.getRole())
+            : List.of(APPLICANT_2.getRole(), APPLICANT_2_SOLICITOR.getRole());
+
+        caseAccessService.removeUsersWithRole(request.getHeader(AUTHORIZATION), details.getId(), roles);
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
-            .data(details.getData())
+            .data(data)
             .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChange.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChange.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.Organisation;
 import uk.gov.hmcts.ccd.sdk.type.OrganisationPolicy;
 import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
-import uk.gov.hmcts.divorce.divorcecase.model.AlternativeService;
 import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.NoticeOfChange;
@@ -19,29 +18,20 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.solicitor.service.CcdAccessService;
 
-import java.time.Clock;
-import java.time.LocalDate;
 import java.util.List;
-
 import javax.servlet.http.HttpServletRequest;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.NoticeOfChange.WhichApplicant.APPLICANT_1;
-import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingAos;
-import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingBailiffReferral;
-import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingBailiffService;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_1_SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2_SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
@@ -133,18 +123,25 @@ public class CaseworkerNoticeOfChange implements CCDConfig<CaseData, State, User
             ? data.getApplicant1()
             : data.getApplicant2();
 
-        if (data.getNoticeOfChange().getAreTheyDigital() == null || !data.getNoticeOfChange().getAreTheyDigital().toBoolean()) {
+        if (!data.getNoticeOfChange().getAreTheyRepresented().toBoolean()) {
+            applicant.setSolicitor(null);
+            applicant.setSolicitorRepresented(NO);
+            applicant.setOffline(YES);
+        } else if (data.getNoticeOfChange().getAreTheyDigital() == null || !data.getNoticeOfChange().getAreTheyDigital().toBoolean()) {
             applicant.getSolicitor().setOrganisationPolicy(null);
+            applicant.setSolicitorRepresented(YES);
             applicant.setOffline(YES);
         } else {
+            applicant.setSolicitorRepresented(YES);
             applicant.setOffline(NO);
         }
 
+        final var auth = request.getHeader(AUTHORIZATION);
         final var roles = data.getNoticeOfChange().getWhichApplicant() == APPLICANT_1
             ? List.of(CREATOR.getRole(), APPLICANT_1_SOLICITOR.getRole())
             : List.of(APPLICANT_2.getRole(), APPLICANT_2_SOLICITOR.getRole());
 
-        caseAccessService.removeUsersWithRole(request.getHeader(AUTHORIZATION), details.getId(), roles);
+        caseAccessService.removeUsersWithRole(auth, details.getId(), roles);
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(data)

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChange.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChange.java
@@ -1,0 +1,84 @@
+package uk.gov.hmcts.divorce.caseworker.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
+import uk.gov.hmcts.divorce.divorcecase.model.AlternativeService;
+import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.NoticeOfChange;
+import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingAos;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingBailiffReferral;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingBailiffService;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
+
+@Component
+@Slf4j
+public class CaseworkerNoticeOfChange implements CCDConfig<CaseData, State, UserRole> {
+    public static final String CASEWORKER_NOTICE_OF_CHANGE = "caseworker-notice-of-change";
+
+    @Override
+    public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
+        new PageBuilder(configBuilder
+            .event(CASEWORKER_NOTICE_OF_CHANGE)
+            .forAllStates()
+            .name("Notice of change")
+            .description("Change applicant representation")
+            .showSummary()
+            .showEventNotes()
+            .aboutToSubmitCallback(this::aboutToSubmit)
+            .grant(CREATE_READ, CASE_WORKER, SUPER_USER)
+            .grant(READ, LEGAL_ADVISOR))
+            .page("changeRepresentation-1")
+            .pageLabel("Which applicant")
+            .complex(CaseData::getNoticeOfChange)
+                .mandatory(NoticeOfChange::getWhichApplicant)
+                .done()
+            .page("changeRepresentation-2")
+            .showCondition("nocWhichApplicant=\"applicant1\"")
+            .pageLabel("Change applicant 1 representation")
+            .complex(CaseData::getNoticeOfChange)
+                .mandatory(NoticeOfChange::getAreTheyRepresented)
+                .done()
+            .complex(CaseData::getApplicant1)
+                .complex(Applicant::getSolicitor)
+                    .optional(Solicitor::getName, "nocAreTheyRepresented=\"Yes\"")
+                    .optional(Solicitor::getPhone, "nocAreTheyRepresented=\"Yes\"")
+                    .optional(Solicitor::getEmail, "nocAreTheyRepresented=\"Yes\"")
+                    .optional(Solicitor::getAddress, "nocAreTheyRepresented=\"Yes\"")
+                    .done()
+                .label("nocWhereSentLabel", "Where should documents be sent?")
+                .optional(Applicant::getCorrespondenceAddress, "nocAreTheyRepresented=\"No\"")
+                .done();
+    }
+
+    public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(
+        final CaseDetails<CaseData, State> details,
+        final CaseDetails<CaseData, State> beforeDetails
+    ) {
+        log.info("Caseworker notice of change aboutToSubmit callback started");
+        // TODO set offline, remove org policy, remove case access
+
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(details.getData())
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/CreateTestCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/CreateTestCase.java
@@ -84,7 +84,7 @@ public class CreateTestCase implements CCDConfig<CaseData, State, UserRole> {
             .complex(CaseData::getCaseInvite)
                 .label("userIdLabel", "<pre>Use ./bin/get-user-id-by-email.sh [email] to get an ID"
                     + ".\n\nTEST_SOLICITOR@mailinator.com is 93b108b7-4b26-41bf-ae8f-6e356efb11b3 in AAT.\n</pre>")
-                .mandatoryWithLabel(CaseInvite::getApplicant2UserId, "Applicant 2 user ID")
+                .optionalWithLabel(CaseInvite::getApplicant2UserId, "Applicant 2 user ID")
                 .done()
             .complex(CaseData::getApplication)
                 .mandatoryWithLabel(Application::getStateToTransitionApplicationTo, "Case state")
@@ -103,6 +103,7 @@ public class CreateTestCase implements CCDConfig<CaseData, State, UserRole> {
         fixture.getApplicant1().setSolicitorRepresented(details.getData().getApplicant1().getSolicitorRepresented());
         fixture.getApplicant2().setSolicitorRepresented(details.getData().getApplicant2().getSolicitorRepresented());
         fixture.getCaseInvite().setApplicant2UserId(details.getData().getCaseInvite().getApplicant2UserId());
+        fixture.setHyphenatedCaseRef(fixture.formatCaseRef(details.getId()));
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(fixture)
@@ -129,7 +130,7 @@ public class CreateTestCase implements CCDConfig<CaseData, State, UserRole> {
             ccdAccessService.addApplicant1SolicitorRole(auth, caseId, orgId);
         }
 
-        if (data.getApplicant2().isRepresented()) {
+        if (data.getCaseInvite().getApplicant2UserId() != null && data.getApplicant2().isRepresented()) {
             var orgId = details
                 .getData()
                 .getApplicant2()
@@ -139,7 +140,7 @@ public class CreateTestCase implements CCDConfig<CaseData, State, UserRole> {
                 .getOrganisationId();
 
             ccdAccessService.addRoleToCase(app2Id, caseId, orgId, APPLICANT_1_SOLICITOR);
-        } else {
+        } else if (data.getCaseInvite().getApplicant2UserId() != null) {
             ccdAccessService.linkRespondentToApplication(auth, caseId, app2Id);
         }
 

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/CaseData.java
@@ -239,6 +239,13 @@ public class CaseData {
     )
     private YesOrNo evidenceHandled;
 
+    @CCD(
+        label = "Supplementary evidence handled",
+        access = {CaseworkerAccess.class}
+    )
+    @JsonUnwrapped(prefix = "noc")
+    private NoticeOfChange noticeOfChange;
+
     @JsonIgnore
     public String formatCaseRef(long caseId) {
         String temp = String.format("%016d", caseId);

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/NoticeOfChange.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/NoticeOfChange.java
@@ -32,6 +32,12 @@ public class NoticeOfChange {
     )
     private YesOrNo areTheyRepresented;
 
+    @CCD(
+        label = "Is the solicitor digital?",
+        access = {CaseworkerAccess.class}
+    )
+    private YesOrNo areTheyDigital;
+
     @Getter
     @AllArgsConstructor
     public enum WhichApplicant implements HasLabel {

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/NoticeOfChange.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/NoticeOfChange.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.divorce.divorcecase.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.ccd.sdk.api.CCD;
+import uk.gov.hmcts.ccd.sdk.api.HasLabel;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
+import uk.gov.hmcts.divorce.divorcecase.model.access.CaseworkerAccess;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
+public class NoticeOfChange {
+
+    @CCD(
+        label = "Which applicant?",
+        access = {CaseworkerAccess.class}
+    )
+    private WhichApplicant whichApplicant;
+
+    @CCD(
+        label = "Are they represented by a solicitor?",
+        access = {CaseworkerAccess.class}
+    )
+    private YesOrNo areTheyRepresented;
+
+    @Getter
+    @AllArgsConstructor
+    public enum WhichApplicant implements HasLabel {
+        @JsonProperty("applicant1")
+        APPLICANT_1("Applicant 1"),
+        @JsonProperty("applicant2")
+        APPLICANT_2("Applicant 2");
+
+        private final String label;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/UserRole.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/UserRole.java
@@ -28,4 +28,13 @@ public enum UserRole implements HasRole {
     private final String role;
     private final String caseTypePermissions;
 
+    public static UserRole fromString(String value) {
+        for (UserRole role : UserRole.values()) {
+            if (role.getRole().equals(value)) {
+                return role;
+            }
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/service/CcdAccessService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/service/CcdAccessService.java
@@ -9,17 +9,16 @@ import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.idam.IdamService;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.CaseAssignmentApi;
-import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseAssignmentUserRoleWithOrganisation;
 import uk.gov.hmcts.reform.ccd.client.model.CaseAssignmentUserRolesRequest;
 import uk.gov.hmcts.reform.idam.client.models.User;
 
 import java.util.List;
 
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.*;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_1_SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.fromString;
 
 @Service
 @Slf4j
@@ -129,7 +128,7 @@ public class CcdAccessService {
         response.getCaseAssignmentUserRoles()
             .stream()
             .filter(assignment -> roles.contains(assignment.getCaseRole()))
-            .map(a -> getCaseAssignmentRequest(caseId, a.getUserId(), null, valueOf(a.getCaseRole())))
+            .map(a -> getCaseAssignmentRequest(caseId, a.getUserId(), null, fromString(a.getCaseRole())))
             .forEach(request -> caseAssignmentApi.removeCaseUserRoles(auth, s2sToken, request));
     }
 }

--- a/src/main/resources/data/joint.json
+++ b/src/main/resources/data/joint.json
@@ -1,6 +1,8 @@
 {
   "divorceOrDissolution": "divorce",
   "applicationType": "jointApplication",
+  "applicant1Offline": "No",
+  "applicant2Offline": "No",
   "applicant1FirstName": "test_first_name",
   "applicant1MiddleName": "test_middle_name",
   "applicant1LastName": "test_last_name",
@@ -31,7 +33,7 @@
   "applicant1SolicitorOrganisationPolicy": {
     "Organisation": {
       "OrganisationName": "Test 1 Organisation",
-      "OrganisationID": "ABC456"
+      "OrganisationID": "0FA7S8S"
     }
   },
   "applicant2FirstName": "test_first_name",
@@ -47,7 +49,7 @@
   "applicant2SolicitorOrganisationPolicy": {
     "Organisation": {
       "OrganisationName": "Test 2 Organisation",
-      "OrganisationID": "ABC123"
+      "OrganisationID": "N5AFUXG"
     }
   },
   "marriageApplicant1Name": "test_first_name test_last_name",

--- a/src/main/resources/data/sole.json
+++ b/src/main/resources/data/sole.json
@@ -1,6 +1,8 @@
 {
   "divorceOrDissolution": "divorce",
   "applicationType": "soleApplication",
+  "applicant1Offline": "No",
+  "applicant2Offline": "No",
   "applicant1FirstName": "test_first_name",
   "applicant1MiddleName": "test_middle_name",
   "applicant1LastName": "test_last_name",
@@ -31,7 +33,7 @@
   "applicant1SolicitorOrganisationPolicy": {
     "Organisation": {
       "OrganisationName": "Test 1 Organisation",
-      "OrganisationID": "ABC456"
+      "OrganisationID": "0FA7S8S"
     }
   },
   "applicant2FirstName": "test_first_name",
@@ -47,7 +49,7 @@
   "applicant2SolicitorOrganisationPolicy": {
     "Organisation": {
       "OrganisationName": "Test 2 Organisation",
-      "OrganisationID": "ABC123"
+      "OrganisationID": "N5AFUXG"
     }
   },
   "marriageApplicant1Name": "test_first_name test_last_name",

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChangeTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChangeTest.java
@@ -1,0 +1,221 @@
+package uk.gov.hmcts.divorce.caseworker.event;
+
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.NoticeOfChange;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.divorce.solicitor.service.CcdAccessService;
+
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
+import static uk.gov.hmcts.divorce.caseworker.event.CaseworkerNoticeOfChange.CASEWORKER_NOTICE_OF_CHANGE;
+import static uk.gov.hmcts.divorce.divorcecase.model.NoticeOfChange.WhichApplicant.APPLICANT_1;
+import static uk.gov.hmcts.divorce.divorcecase.model.NoticeOfChange.WhichApplicant.APPLICANT_2;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_1_SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2_SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.applicantRepresentedBySolicitor;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
+
+@ExtendWith(MockitoExtension.class)
+class CaseworkerNoticeOfChangeTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private CcdAccessService caseAccessService;
+
+    @InjectMocks
+    private CaseworkerNoticeOfChange noticeOfChange;
+
+    @Before
+    public void setup() {
+        doNothing().when(caseAccessService).removeUsersWithRole(anyString(), anyLong(), anyList());
+        when(request.getHeader(anyString())).thenReturn("TOKEN");
+    }
+
+    @Test
+    public void configure() {
+        final ConfigBuilderImpl<CaseData, State, UserRole> configBuilder = createCaseDataConfigBuilder();
+
+        noticeOfChange.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(CASEWORKER_NOTICE_OF_CHANGE);
+    }
+
+    private CaseDetails<CaseData, State> getCaseDetails() {
+        final var details = new CaseDetails<CaseData, State>();
+        final var data = caseData();
+
+        data.setApplicant1(applicantRepresentedBySolicitor());
+        data.setApplicant2(applicantRepresentedBySolicitor());
+        data.getApplicant1().setOffline(NO);
+        data.getApplicant2().setOffline(NO);
+        details.setData(data);
+        details.setId(1L);
+
+        return details;
+    }
+
+    @Test
+    public void testApp1NowCitizen() {
+        var caseDetails = getCaseDetails();
+        caseDetails.getData().setNoticeOfChange(NoticeOfChange.builder()
+            .whichApplicant(APPLICANT_1)
+            .areTheyRepresented(NO)
+            .build());
+
+        var result = noticeOfChange.aboutToSubmit(caseDetails, caseDetails);
+
+        assertThat(result.getData().getApplicant1().isOffline()).isTrue();
+        assertThat(result.getData().getApplicant1().getSolicitor()).isNull();
+        assertThat(result.getData().getApplicant1().getSolicitorRepresented()).isEqualTo(NO);
+
+        verify(caseAccessService).removeUsersWithRole(eq(null), anyLong(), eq(
+            List.of(
+                CREATOR.getRole(),
+                APPLICANT_1_SOLICITOR.getRole()
+            )
+        ));
+    }
+
+    @Test
+    public void testApp1NowOfflineSolicitor() {
+        var caseDetails = getCaseDetails();
+        caseDetails.getData().setNoticeOfChange(NoticeOfChange.builder()
+            .whichApplicant(APPLICANT_1)
+            .areTheyRepresented(YES)
+            .areTheyDigital(NO)
+            .build());
+
+        var result = noticeOfChange.aboutToSubmit(caseDetails, caseDetails);
+
+        assertThat(result.getData().getApplicant1().isOffline()).isTrue();
+        assertThat(result.getData().getApplicant1().getSolicitor()).isNotNull();
+        assertThat(result.getData().getApplicant1().getSolicitorRepresented()).isEqualTo(YES);
+
+        verify(caseAccessService).removeUsersWithRole(eq(null), anyLong(), eq(
+            List.of(
+                CREATOR.getRole(),
+                APPLICANT_1_SOLICITOR.getRole()
+            )
+        ));
+    }
+
+    @Test
+    public void testApp1NowOnlineSolicitor() {
+        var caseDetails = getCaseDetails();
+        caseDetails.getData().setNoticeOfChange(NoticeOfChange.builder()
+            .whichApplicant(APPLICANT_1)
+            .areTheyRepresented(YES)
+            .areTheyDigital(YES)
+            .build());
+
+        var result = noticeOfChange.aboutToSubmit(caseDetails, caseDetails);
+
+        assertThat(result.getData().getApplicant1().isOffline()).isFalse();
+        assertThat(result.getData().getApplicant1().getSolicitor()).isNotNull();
+        assertThat(result.getData().getApplicant1().getSolicitorRepresented()).isEqualTo(YES);
+
+        verify(caseAccessService).removeUsersWithRole(eq(null), anyLong(), eq(
+            List.of(
+                CREATOR.getRole(),
+                APPLICANT_1_SOLICITOR.getRole()
+            )
+        ));
+    }
+
+    @Test
+    public void testApp2NowCitizen() {
+        var caseDetails = getCaseDetails();
+        caseDetails.getData().setNoticeOfChange(NoticeOfChange.builder()
+            .whichApplicant(APPLICANT_2)
+            .areTheyRepresented(NO)
+            .build());
+
+        var result = noticeOfChange.aboutToSubmit(caseDetails, caseDetails);
+
+        assertThat(result.getData().getApplicant2().isOffline()).isTrue();
+        assertThat(result.getData().getApplicant2().getSolicitor()).isNull();
+        assertThat(result.getData().getApplicant2().getSolicitorRepresented()).isEqualTo(NO);
+
+        verify(caseAccessService).removeUsersWithRole(eq(null), anyLong(), eq(
+            List.of(
+                UserRole.APPLICANT_2.getRole(),
+                APPLICANT_2_SOLICITOR.getRole()
+            )
+        ));
+    }
+
+    @Test
+    public void testApp2NowOfflineSolicitor() {
+        var caseDetails = getCaseDetails();
+        caseDetails.getData().setNoticeOfChange(NoticeOfChange.builder()
+            .whichApplicant(APPLICANT_2)
+            .areTheyRepresented(YES)
+            .areTheyDigital(NO)
+            .build());
+
+        var result = noticeOfChange.aboutToSubmit(caseDetails, caseDetails);
+
+        assertThat(result.getData().getApplicant2().isOffline()).isTrue();
+        assertThat(result.getData().getApplicant2().getSolicitor()).isNotNull();
+        assertThat(result.getData().getApplicant2().getSolicitorRepresented()).isEqualTo(YES);
+
+        verify(caseAccessService).removeUsersWithRole(eq(null), anyLong(), eq(
+            List.of(
+                UserRole.APPLICANT_2.getRole(),
+                APPLICANT_2_SOLICITOR.getRole()
+            )
+        ));
+    }
+
+    @Test
+    public void testApp2NowOnlineSolicitor() {
+        var caseDetails = getCaseDetails();
+        caseDetails.getData().setNoticeOfChange(NoticeOfChange.builder()
+            .whichApplicant(APPLICANT_2)
+            .areTheyRepresented(YES)
+            .areTheyDigital(YES)
+            .build());
+
+        var result = noticeOfChange.aboutToSubmit(caseDetails, caseDetails);
+
+        assertThat(result.getData().getApplicant2().isOffline()).isFalse();
+        assertThat(result.getData().getApplicant2().getSolicitor()).isNotNull();
+        assertThat(result.getData().getApplicant2().getSolicitorRepresented()).isEqualTo(YES);
+
+        verify(caseAccessService).removeUsersWithRole(eq(null), anyLong(), eq(
+            List.of(
+                UserRole.APPLICANT_2.getRole(),
+                APPLICANT_2_SOLICITOR.getRole()
+            )
+        ));
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-1654

### Change description ###

This PR adds an event that allows a caseworker or admin to trigger Notice of Change when a case is in any state. The notice of change will remove all access to the case for one of the applicants and optionally replace the organisation policy of another solicitor organisation has taken the case over. Unless another digital solicitor will take over the case the applicant will be marked as offline.