### PR TITLE
remove label

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.6.3'
   id 'com.github.ben-manes.versions' version '0.41.0'
-  id 'hmcts.ccd.sdk' version '0.25.13'
+  id 'hmcts.ccd.sdk' version '0.25.14'
 }
 
 apply plugin: 'cz.habarta.typescript-generator'

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/CaseData.java
@@ -230,10 +230,7 @@ public class CaseData {
     @JsonUnwrapped
     private RetiredFields retiredFields;
 
-    @CCD(
-        label = "hyphenatedCaseReference",
-        access = {CaseworkerAccess.class}
-    )
+    @CCD(access = {CaseworkerAccess.class})
     private String hyphenatedCaseRef;
 
     @CCD(
@@ -243,13 +240,9 @@ public class CaseData {
     )
     private List<ListValue<ScannedDocument>> scannedDocuments;
 
-    @CCD(
-        label = "Supplementary evidence handled"
-    )
     private YesOrNo evidenceHandled;
 
     @CCD(
-        label = "Supplementary evidence handled",
         access = {CaseworkerAccess.class}
     )
     @JsonUnwrapped(prefix = "noc")

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemAttachScannedDocuments.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemAttachScannedDocuments.java
@@ -27,6 +27,6 @@ public class SystemAttachScannedDocuments implements CCDConfig<CaseData, State, 
             .page("attachScannedDocs")
             .pageLabel("Correspondence")
             .mandatory(CaseData::getScannedDocuments)
-            .mandatory(CaseData::getEvidenceHandled);
+            .mandatoryWithLabel(CaseData::getEvidenceHandled, "Supplementary evidence handled");
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemHandleSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemHandleSupplementaryEvidence.java
@@ -23,6 +23,6 @@ public class SystemHandleSupplementaryEvidence implements CCDConfig<CaseData, St
             .grant(CREATE_READ_UPDATE_DELETE, SYSTEMUPDATE, CASE_WORKER))
             .page("handleEvidence")
             .pageLabel("Correspondence")
-            .mandatory(CaseData::getEvidenceHandled);
+            .mandatoryWithLabel(CaseData::getEvidenceHandled, "Supplementary evidence handled");
     }
 }


### PR DESCRIPTION
Labels are now optional. Where possible we should use labels defined in the event. The `@CCD` is also optional if no other options are required.