### PR TITLE
Fix nullpointer during transformation and added missing fields

### DIFF
--- a/charts/nfdiv-case-api/Chart.yaml
+++ b/charts/nfdiv-case-api/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
   - name: HMCTS nfdiv team
 dependencies:
   - name: java
-    version: 3.7.3
+    version: 3.7.2
     repository: '@hmctspublic'
   - name: ccd
     version: 6.0.0

--- a/charts/nfdiv-case-api/Chart.yaml
+++ b/charts/nfdiv-case-api/Chart.yaml
@@ -3,12 +3,12 @@ appVersion: "1.0"
 description: A Helm chart for nfdiv-case-api App
 name: nfdiv-case-api
 home: https://github.com/hmcts/nfdiv-case-api
-version: 0.0.46
+version: 0.0.47
 maintainers:
   - name: HMCTS nfdiv team
 dependencies:
   - name: java
-    version: 3.6.0
+    version: 3.7.3
     repository: '@hmctspublic'
   - name: ccd
     version: 6.0.0

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/endpoint/BulkScanCaseTransformationControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/endpoint/BulkScanCaseTransformationControllerIT.java
@@ -80,7 +80,7 @@ public class BulkScanCaseTransformationControllerIT {
             .getResponse()
             .getContentAsString(UTF_8);
 
-        // dateSubmitted value is compared using ${json-unit.any-string}
+        // dateSubmitted and document ids are compared using ${json-unit.any-string}
         // assertion will fail if the above value is missing
         assertThatJson(response)
             .when(IGNORING_ARRAY_ORDER)

--- a/src/integrationTest/resources/transformation-success-response.json
+++ b/src/integrationTest/resources/transformation-success-response.json
@@ -10,6 +10,24 @@
       "paperFormApplicant1SigningSOT": "Yes",
       "labelContentGotMarriedOrFormedCivilPartnership": "got married",
       "applicant1HWFAppliedForFees": "No",
+      "scannedDocuments": [
+        {
+          "id": "${json-unit.any-string}",
+          "value": {
+            "type": "form",
+            "subtype": "D8",
+            "url": {
+              "document_url": "http://localhost:8080/documents/640055da-9330-11ec-b909-0242ac120002",
+              "document_filename": "61347040100200003.pdf",
+              "document_binary_url": "http://localhost:8080/documents/640055da-9330-11ec-b909-0242ac120002/binary"
+            },
+            "controlNumber": "61347040100200003",
+            "fileName": "61347040100200003.pdf",
+            "scannedDate": "2022-01-01T12:12:00.000Z",
+            "deliveryDate": "2022-01-01T12:12:00.000Z"
+          }
+        }
+      ],
       "marriageMarriedInUk": "Yes",
       "applicant1SolicitorFirmName": "some firm",
       "paperFormApplicant1SOTSignedOn": "18 01 2022",
@@ -19,6 +37,8 @@
       "marriageFormationType": "oppositeSexCouple",
       "applicant1MiddleName": "",
       "applicant2StatementOfTruth": "Yes",
+      "paperFormSoleOrApplicant1PaymentOtherDetail": "",
+      "coApplicant1IsDrafted": "No",
       "applicant1LegalProceedings": "No",
       "applicant1Email": "",
       "paperFormApplicant2PaymentOther": "No",
@@ -88,7 +108,6 @@
         "PostCode": "",
         "Country": ""
       },
-      "warnings": [],
       "applicant2FirstName": "respFname",
       "marriageCertifyMarriageCertificateIsCorrect": "Yes",
       "applicant1FinancialOrdersFor": [
@@ -109,6 +128,7 @@
       "paperFormServiceOutsideUK": "No",
       "paperFormFeeInPounds": "595£",
       "applicant2SolStatementOfReconciliationFirm": "",
+      "coApplicant1IsSubmitted": "No",
       "paperFormSummaryApplicant1FinancialOrdersFor": [
         "children"
       ],
@@ -123,33 +143,15 @@
         "Country": ""
       },
       "paperFormApplicant2LegalRepSigningSOT": "No",
+      "warnings": [],
       "applicant1SolicitorAddress": "some street\nsecond line of address\nUK",
       "screenHasMarriageCert": "Yes",
       "labelContentDivorceOrLegallyEnd": "get a divorce",
       "applicant2Email": "app2test@dummy.com",
       "applicant1SolicitorRepresented": "Yes",
-      "marriageIssueApplicationWithoutMarriageCertificate": "No",
-      "coApplicant1IsDrafted": "No",
-      "coApplicant1IsSubmitted": "No",
-      "scannedDocuments": [
-        {
-          "id": "${json-unit.any-string}",
-          "value": {
-            "type": "form",
-            "subtype": "D8",
-            "url": {
-              "document_url": "http://localhost:8080/documents/640055da-9330-11ec-b909-0242ac120002",
-              "document_filename": "61347040100200003.pdf",
-              "document_binary_url": "http://localhost:8080/documents/640055da-9330-11ec-b909-0242ac120002/binary"
-            },
-            "controlNumber": "61347040100200003",
-            "fileName": "61347040100200003.pdf",
-            "scannedDate": "2022-01-01T12:12:00.000Z",
-            "deliveryDate": "2022-01-01T12:12:00.000Z"
-          }
-        }
-      ]
+      "marriageIssueApplicationWithoutMarriageCertificate": "No"
     }
   },
   "warnings": []
 }
+

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/transformation/PaperFormDetailsTransformer.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/transformation/PaperFormDetailsTransformer.java
@@ -154,7 +154,12 @@ public class PaperFormDetailsTransformer implements Function<TransformationDetai
         caseData.getPaperFormDetails().setApplicant2NoPaymentIncluded(
             from(toBoolean(ocrDataFields.getApplicant2NoPaymentIncluded()))
         );
-
+        caseData.getPaperFormDetails().setSoleOrApplicant1PaymentOtherDetail(
+            ocrDataFields.getSoleOrApplicant1PaymentOtherDetail()
+        );
+        caseData.getPaperFormDetails().setApplicant2PaymentOtherDetail(
+            ocrDataFields.getApplicant2PaymentOtherDetail()
+        );
         caseData.getPaperFormDetails().setSoleOrApplicant1PaymentOther(
             from(toBoolean(ocrDataFields.getSoleOrApplicant1PaymentOther()))
         );

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/validation/data/OcrDataFields.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/validation/data/OcrDataFields.java
@@ -1,3 +1,4 @@
+
 package uk.gov.hmcts.divorce.bulkscan.validation.data;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -12,7 +13,9 @@ import uk.gov.hmcts.reform.bsp.common.model.shared.in.OcrDataField;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Optional;
+
+import static java.util.stream.Collectors.toMap;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
@@ -144,6 +147,7 @@ public class OcrDataFields {
     private String applicant2OrLegalRepFullName;
     private String applicant2LegalRepFirm;
     private String applicant2LegalRepPosition;
+    private String applicant2PaymentOtherDetail;
     private String courtFee;
     private String soleOrApplicant1NoPaymentIncluded;
     private String soleOrApplicant1HWFConfirmation;
@@ -164,15 +168,27 @@ public class OcrDataFields {
 
     public static OcrDataFields transformData(List<KeyValue> ocrDataFields) {
         final ObjectMapper mapper = new ObjectMapper();
-        final Map<String, String> map = ocrDataFields.stream()
-            .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));
+        final Map<String, String> map = ocrDataFields
+            .stream()
+            .collect(
+                toMap(
+                    entry -> entry.getKey(),
+                    entry -> Optional.ofNullable(entry.getValue()).orElse("")
+                )
+            );
         return mapper.convertValue(map, OcrDataFields.class);
     }
 
     public static OcrDataFields transformOcrMapToObject(List<OcrDataField> ocrDataFields) {
         final ObjectMapper mapper = new ObjectMapper();
-        final Map<String, String> map = ocrDataFields.stream()
-                .collect(Collectors.toMap(OcrDataField::getName, OcrDataField::getValue));
+        final Map<String, String> map = ocrDataFields
+            .stream()
+            .collect(
+                toMap(
+                    entry -> entry.getName(),
+                    entry -> Optional.ofNullable(entry.getValue()).orElse("")
+                )
+            );
         return mapper.convertValue(map, OcrDataFields.class);
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/PaperFormDetails.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/PaperFormDetails.java
@@ -55,6 +55,8 @@ public class PaperFormDetails {
 
     private String soleOrApplicant1PaymentOtherDetail;
 
+    private String applicant2PaymentOtherDetail;
+
     private YesOrNo debitCreditCardPayment;
 
     private YesOrNo debitCreditCardPaymentPhone;

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/transformation/ApplicationTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/transformation/ApplicationTransformerTest.java
@@ -78,6 +78,36 @@ public class ApplicationTransformerTest {
     }
 
     @Test
+    void shouldSuccessfullyTransformSoleApplicationWithoutWarningsWhenOcrFieldValuesAreNull() throws Exception {
+        String validApplicationOcrJson = loadJson("src/test/resources/transformation/input/valid-application-ocr-with-null-values.json");
+        List<OcrDataField> ocrDataFields = MAPPER.readValue(validApplicationOcrJson, new TypeReference<>() {
+        });
+
+        final var caseData = CaseData.builder().applicationType(SOLE_APPLICATION).divorceOrDissolution(DIVORCE).build();
+        final var transformationDetails =
+            TransformationDetails
+                .builder()
+                .ocrDataFields(transformOcrMapToObject(ocrDataFields))
+                .caseData(caseData)
+                .build();
+
+        final var transformedOutput = applicationTransformer.apply(transformationDetails);
+
+        assertThat(transformedOutput.getTransformationWarnings()).isEmpty();
+
+        final var expectedApplication =
+            jsonToObject("src/test/resources/transformation/output/application-transformed.json", Application.class);
+
+        assertThat(transformedOutput.getCaseData().getApplication())
+            .usingRecursiveComparison()
+            .ignoringFields("dateSubmitted")
+            .ignoringActualNullFields()
+            .isEqualTo(expectedApplication);
+
+        assertThat(transformedOutput.getCaseData().getApplication().getDateSubmitted()).isEqualTo(getExpectedLocalDateTime());
+    }
+
+    @Test
     void shouldSuccessfullyTransformSoleApplicationWithoutWarningsWhenApp1IsDomiciled() throws Exception {
         String validApplicationOcrJson = loadJson("src/test/resources/transformation/input/valid-application-ocr.json");
         List<OcrDataField> ocrDataFields = MAPPER.readValue(validApplicationOcrJson, new TypeReference<>() {

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/validation/OcrValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/validation/OcrValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.type.KeyValue;
 import uk.gov.hmcts.divorce.endpoint.data.OcrDataValidationRequest;
 import uk.gov.hmcts.divorce.endpoint.data.OcrValidationResponse;
 
@@ -40,6 +41,24 @@ public class OcrValidatorTest {
         assertThat(response.getWarnings()).hasSize(0);
         assertThat(response.getStatus()).isEqualTo(SUCCESS);
     }
+
+    @Test
+    void shouldValidateOcrDataSuccessfullyWhenOcrDataFieldValuesAreNull() {
+        List<KeyValue> ocrDataFields = populateD8OcrDataFields();
+        ocrDataFields.add(populateKeyValue("howToPayEmail", "null"));
+        ocrDataFields.add(populateKeyValue("debitCreditCardPayment", "null"));
+
+        final OcrDataValidationRequest request = OcrDataValidationRequest.builder()
+            .ocrDataFields(ocrDataFields)
+            .build();
+
+        OcrValidationResponse response = validator.validateExceptionRecord(D8.getName(), request);
+
+        assertThat(response.getErrors()).isEmpty();
+        assertThat(response.getWarnings()).isEmpty();
+        assertThat(response.getStatus()).isEqualTo(SUCCESS);
+    }
+
 
     @Test
     void shouldReturnErrorsAndWarningsWhenNoOcrDataPassed() {

--- a/src/test/resources/transformation/input/valid-application-ocr-with-null-values.json
+++ b/src/test/resources/transformation/input/valid-application-ocr-with-null-values.json
@@ -1,0 +1,131 @@
+[
+  {
+    "name": "jurisdictionReasonsBothPartiesHabitual",
+    "value": "true"
+  },
+  {
+    "name": "jurisdictionReasonsBothPartiesLastHabitual",
+    "value": "true"
+  },
+  {
+    "name": "jurisdictionReasonsJointHabitual",
+    "value": "true"
+  },
+  {
+    "name": "jurisdictionReasons6MonthsHabitual",
+    "value": "true"
+  },
+  {
+    "name": "jurisdictionReasonsBothPartiesDomiciled",
+    "value": "true"
+  },
+  {
+    "name": "jurisdictionReasonsSameSex",
+    "value": "false"
+  },
+  {
+    "name": "soleOrApplicant1ConfirmationOfBreakdown",
+    "value": "true"
+  },
+  {
+    "name": "applicant2ConfirmationOfBreakdown",
+    "value": "false"
+  },
+  {
+    "name": "existingOrPreviousCourtCases",
+    "value": "Both"
+  },
+  {
+    "name": "existingOrPreviousCourtCaseNumbers",
+    "value": null
+  },
+  {
+    "name": "summaryOfExistingOrPreviousCourtCases",
+    "value": null
+  },
+  {
+    "name": "soleOrApplicant1FinancialOrder",
+    "value": "Yes"
+  },
+  {
+    "name": "soleOrApplicant1FinancialOrderFor",
+    "value": "myself,children"
+  },
+  {
+    "name": "applicant2FinancialOrder",
+    "value": "No"
+  },
+  {
+    "name": "applicant2FinancialOrderFor",
+    "value": null
+  },
+  {
+    "name": "prayerMarriageDissolved",
+    "value": "true"
+  },
+  {
+    "name": "prayerCivilPartnershipDissolved",
+    "value": null
+  },
+  {
+    "name": "courtFee",
+    "value": "595£"
+  },
+  {
+    "name": "soleOrApplicant1NoPaymentIncluded",
+    "value": "Yes"
+  },
+  {
+    "name": "soleOrApplicant1HWFConfirmation",
+    "value": "HWF-123"
+  },
+  {
+    "name": "soleOrApplicant1HWFApp",
+    "value": "true"
+  },
+  {
+    "name": "soleOrApplicant1PaymentOther",
+    "value": "false"
+  },
+  {
+    "name": "soleOrApplicant1PaymentOtherDetail",
+    "value": null
+  },
+  {
+    "name": "applicant2NoPaymentIncluded",
+    "value": "true"
+  },
+  {
+    "name": "applicant2HWFConfirmation",
+    "value": "true"
+  },
+  {
+    "name": "applicant2HWFNo",
+    "value": "HWF456"
+  },
+  {
+    "name": "applicant2HWFApp",
+    "value": "true"
+  },
+  {
+    "name": "applicant2PaymentOther",
+    "value": "false"
+  },
+  {
+    "name": "debitCreditCardPayment",
+    "value": "false"
+  },
+  {
+    "name": "debitCreditCardPaymentPhone",
+    "value": "false"
+  },
+  {
+    "name": "paymentDetailEmail",
+    "value": null
+  },
+  {
+    "name": "chequeOrPostalOrderPayment",
+    "value": "false"
+  }
+]
+

--- a/src/test/resources/transformation/input/valid-paper-form-ocr.json
+++ b/src/test/resources/transformation/input/valid-paper-form-ocr.json
@@ -121,7 +121,11 @@
   },
   {
     "name": "soleOrApplicant1PaymentOtherDetail",
-    "value": ""
+    "value": "pay details app1"
+  },
+  {
+    "name": "applicant2PaymentOtherDetail",
+    "value": "pay details app2"
   }
 ]
 

--- a/src/test/resources/transformation/output/paper-form-transformed.json
+++ b/src/test/resources/transformation/output/paper-form-transformed.json
@@ -22,10 +22,11 @@
   "Applicant2NoPaymentIncluded": "No",
   "SoleOrApplicant1PaymentOther": "No",
   "Applicant2PaymentOther": "No",
-  "SoleOrApplicant1PaymentOtherDetail": null,
   "DebitCreditCardPayment": null,
   "DebitCreditCardPaymentPhone": null,
   "HowToPayEmail": null,
   "PaymentDetailEmail": null,
-  "ChequeOrPostalOrderPayment": null
+  "ChequeOrPostalOrderPayment": null,
+  "Applicant2PaymentOtherDetail": "pay details app2",
+  "SoleOrApplicant1PaymentOtherDetail": "pay details app1"
 }


### PR DESCRIPTION
- OCR fields are converted to null when invoked from an exception record. Handle this as `Collector.toMap` doesn't allow null values and we need to retain the keys in the map.
- Added transformation for missing fields.