### PR TITLE
Correct logging name and add default access to finalOrderReminderSent fields

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/FinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/FinalOrder.java
@@ -109,12 +109,14 @@ public class FinalOrder {
     private LocalDate dateFinalOrderNoLongerEligible;
 
     @CCD(
-        label = "Has the applicant been sent a reminder to apply for the Final Order?"
+        label = "Has the applicant been sent a reminder to apply for the Final Order?",
+        access = {DefaultAccess.class}
     )
     private YesOrNo finalOrderReminderSentApplicant1;
 
     @CCD(
-        label = "Has the respondent been sent a reminder to apply for the Final Order?"
+        label = "Has the respondent been sent a reminder to apply for the Final Order?",
+        access = {DefaultAccess.class}
     )
     private YesOrNo finalOrderReminderSentApplicant2;
 

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemNotifyRespondentApplyFinalOrderTask.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/SystemNotifyRespondentApplyFinalOrderTask.java
@@ -55,7 +55,7 @@ public class SystemNotifyRespondentApplyFinalOrderTask implements Runnable {
 
     @Override
     public void run() {
-        log.info("Final Order overdue scheduled task started");
+        log.info("SystemNotifyRespondentApplyFinalOrder scheduled task started");
 
         final User user = idamService.retrieveSystemUpdateUserDetails();
         final String serviceAuth = authTokenGenerator.generate();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-1622

### Change description ###

- NFDIV-1622 is broken because the reminderSent field isn't being set and so the cron job is always picking up the same 100 cases.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
