### PR TITLE
Remove sending notification to applicant 2 / respondent

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServiceApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServiceApplication.java
@@ -13,9 +13,7 @@ import uk.gov.hmcts.divorce.divorcecase.model.AlternativeService;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
-import uk.gov.hmcts.divorce.solicitor.service.CcdAccessService;
 
-import javax.servlet.http.HttpServletRequest;
 import java.time.Clock;
 import java.time.LocalDate;
 
@@ -43,12 +41,6 @@ public class CaseworkerAlternativeServiceApplication implements CCDConfig<CaseDa
 
     @Autowired
     private GeneralApplicationReceivedNotification generalApplicationReceivedNotification;
-
-    @Autowired
-    private HttpServletRequest request;
-
-    @Autowired
-    private CcdAccessService ccdAccessService;
 
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServiceApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServiceApplication.java
@@ -15,11 +15,10 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.solicitor.service.CcdAccessService;
 
+import javax.servlet.http.HttpServletRequest;
 import java.time.Clock;
 import java.time.LocalDate;
-import javax.servlet.http.HttpServletRequest;
 
-import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AosDrafted;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AosOverdue;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingAos;
@@ -81,11 +80,7 @@ public class CaseworkerAlternativeServiceApplication implements CCDConfig<CaseDa
 
         caseData.getAlternativeService().setReceivedServiceAddedDate(LocalDate.now(clock));
 
-        if (ccdAccessService.isApplicant1(request.getHeader(AUTHORIZATION), details.getId())) {
-            generalApplicationReceivedNotification.sendToApplicant1(caseData, details.getId());
-        } else {
-            generalApplicationReceivedNotification.sendToApplicant2(caseData, details.getId());
-        }
+        generalApplicationReceivedNotification.sendToApplicant1(caseData, details.getId());
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(caseData)

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/GeneralApplicationReceivedNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/GeneralApplicationReceivedNotification.java
@@ -49,23 +49,6 @@ public class GeneralApplicationReceivedNotification implements ApplicantNotifica
         );
     }
 
-    @Override
-    public void sendToApplicant2(final CaseData caseData, final Long id) {
-        log.info("Sending general application received notification to applicant 2 for case : {}", id);
-
-        Map<String, String> templateVars =
-            commonContent.mainTemplateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1());
-
-        setApplicationReceivedVars(caseData, templateVars);
-
-        notificationService.sendEmail(
-            caseData.getApplicant2().getEmail(),
-            GENERAL_APPLICATION_RECEIVED,
-            templateVars,
-            caseData.getApplicant2().getLanguagePreference()
-        );
-    }
-
     private void setApplicationReceivedVars(CaseData caseData, Map<String, String> templateVars) {
 
         templateVars.put(IS_DEEMED_SERVICE, NO);

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServiceApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServiceApplicationTest.java
@@ -14,17 +14,11 @@ import uk.gov.hmcts.divorce.divorcecase.model.ApplicationType;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
-import uk.gov.hmcts.divorce.solicitor.service.CcdAccessService;
 
 import java.time.Clock;
-import java.util.Objects;
-import javax.servlet.http.HttpServletRequest;
 
-import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.divorce.caseworker.event.CaseworkerAlternativeServiceApplication.CASEWORKER_SERVICE_RECEIVED;
 import static uk.gov.hmcts.divorce.testutil.ClockTestUtil.getExpectedLocalDate;
 import static uk.gov.hmcts.divorce.testutil.ClockTestUtil.setMockClock;
@@ -35,16 +29,8 @@ import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
 @ExtendWith(MockitoExtension.class)
 class CaseworkerAlternativeServiceApplicationTest {
 
-    private static final String DUMMY_AUTH_TOKEN = "DUMMY_AUTH_TOKEN";
-
     @Mock
     private GeneralApplicationReceivedNotification generalApplicationReceivedNotification;
-
-    @Mock
-    private CcdAccessService ccdAccessService;
-
-    @Mock
-    private HttpServletRequest request;
 
     @Mock
     private Clock clock;
@@ -65,7 +51,8 @@ class CaseworkerAlternativeServiceApplicationTest {
 
     @Test
     void shouldSendApp1NotificationsOnAboutToSubmit() {
-        setupMocks(clock);
+        setMockClock(clock);
+
         CaseData caseData = caseData();
         final CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder().id(1L).data(caseData).build();
 
@@ -74,30 +61,10 @@ class CaseworkerAlternativeServiceApplicationTest {
         verify(generalApplicationReceivedNotification).sendToApplicant1(caseData, 1L);
     }
 
-    @Test
-    void shouldSendApp2NotificationsOnAboutToSubmit() {
-        setupMocks(clock);
-        when(ccdAccessService.isApplicant1(DUMMY_AUTH_TOKEN, 1L)).thenReturn(false);
-        CaseData caseData = caseData();
-        final CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder().id(1L).data(caseData).build();
-
-        caseworkerAlternativeServiceApplication.aboutToSubmit(caseDetails, null);
-
-        verify(generalApplicationReceivedNotification).sendToApplicant2(caseData, 1L);
-    }
-
     private CaseData caseData() {
         return CaseData.builder()
             .applicationType(ApplicationType.SOLE_APPLICATION)
             .build();
-    }
-
-    private void setupMocks(Clock mockClock) {
-        if (Objects.nonNull(mockClock)) {
-            setMockClock(mockClock);
-        }
-        when(request.getHeader(eq(AUTHORIZATION))).thenReturn(DUMMY_AUTH_TOKEN);
-        when(ccdAccessService.isApplicant1(DUMMY_AUTH_TOKEN, 1L)).thenReturn(true);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/GeneralApplicationReceivedNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/GeneralApplicationReceivedNotificationTest.java
@@ -17,13 +17,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
-import static uk.gov.hmcts.divorce.citizen.notification.GeneralApplicationReceivedNotification.IS_BAILIFF_SERVICE;
 import static uk.gov.hmcts.divorce.citizen.notification.GeneralApplicationReceivedNotification.IS_DEEMED_SERVICE;
 import static uk.gov.hmcts.divorce.citizen.notification.GeneralApplicationReceivedNotification.IS_DISPENSE_SERVICE;
-import static uk.gov.hmcts.divorce.divorcecase.model.AlternativeServiceType.BAILIFF;
 import static uk.gov.hmcts.divorce.divorcecase.model.AlternativeServiceType.DEEMED;
 import static uk.gov.hmcts.divorce.divorcecase.model.AlternativeServiceType.DISPENSED;
-import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DISSOLUTION;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
 import static uk.gov.hmcts.divorce.notification.CommonContent.APPLICATION_REFERENCE;
 import static uk.gov.hmcts.divorce.notification.CommonContent.IS_DISSOLUTION;
@@ -35,7 +32,6 @@ import static uk.gov.hmcts.divorce.notification.FormatUtil.formatId;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_USER_EMAIL;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getMainTemplateVars;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.validApplicant1CaseData;
-import static uk.gov.hmcts.divorce.testutil.TestDataHelper.validApplicant2CaseData;
 
 @ExtendWith(MockitoExtension.class)
 class GeneralApplicationReceivedNotificationTest {
@@ -97,56 +93,5 @@ class GeneralApplicationReceivedNotificationTest {
             eq(ENGLISH)
         );
         verify(commonContent).mainTemplateVars(data, 1234567890123456L, data.getApplicant1(), data.getApplicant2());
-    }
-
-    @Test
-    void shouldSendGeneralApplicationReceivedEmailToSoleRespondentWithDivorceContent() {
-        CaseData data = validApplicant2CaseData();
-        data.getAlternativeService().setAlternativeServiceType(BAILIFF);
-
-        when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
-            .thenReturn(getMainTemplateVars());
-
-        generalApplicationReceivedNotification.sendToApplicant2(data, 1234567890123456L);
-
-        verify(notificationService).sendEmail(
-            eq(TEST_USER_EMAIL),
-            eq(GENERAL_APPLICATION_RECEIVED),
-            argThat(allOf(
-                hasEntry(APPLICATION_REFERENCE, formatId(1234567890123456L)),
-                hasEntry(IS_DIVORCE, YES),
-                hasEntry(IS_DISSOLUTION, NO),
-                hasEntry(IS_BAILIFF_SERVICE, YES)
-            )),
-            eq(ENGLISH)
-        );
-        verify(commonContent).mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1());
-    }
-
-    @Test
-    void shouldSendGeneralApplicationReceivedEmailToSoleRespondentWithDissolutionContent() {
-        CaseData data = validApplicant2CaseData();
-        data.getAlternativeService().setAlternativeServiceType(DEEMED);
-        data.setDivorceOrDissolution(DISSOLUTION);
-
-        final Map<String, String> templateVars = getMainTemplateVars();
-        templateVars.putAll(Map.of(IS_DIVORCE, NO, IS_DISSOLUTION, YES));
-        when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
-            .thenReturn(templateVars);
-
-        generalApplicationReceivedNotification.sendToApplicant2(data, 1234567890123456L);
-
-        verify(notificationService).sendEmail(
-            eq(TEST_USER_EMAIL),
-            eq(GENERAL_APPLICATION_RECEIVED),
-            argThat(allOf(
-                hasEntry(APPLICATION_REFERENCE, formatId(1234567890123456L)),
-                hasEntry(IS_DIVORCE, NO),
-                hasEntry(IS_DISSOLUTION, YES),
-                hasEntry(IS_DEEMED_SERVICE, YES)
-            )),
-            eq(ENGLISH)
-        );
-        verify(commonContent).mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/NFDIV-1736


### Change description ###
As per NFDIV-1736, the notification should only be sent to
applicant 1 and will always be sent regardless of if they
are logged in or not. Reworked logic to always send notification.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
