### PR TITLE
Fix ocr validation response during transformation if there are validation errors- D8 & D8S

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/exception/InvalidOcrDataException.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/exception/InvalidOcrDataException.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.divorce.bulkscan.exception;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class InvalidOcrDataException extends RuntimeException {
+    private static final long serialVersionUID = -2240235036273410173L;
+
+    private final List<String> errors;
+    private final List<String> warnings;
+
+    public InvalidOcrDataException(String message, List<String> warnings, List<String> errors) {
+        super(message);
+        this.warnings = Optional.ofNullable(warnings).orElse(Collections.emptyList());
+        this.errors = Optional.ofNullable(errors).orElse(Collections.emptyList());
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public List<String> getWarnings() {
+        return warnings;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/transformation/D8FormToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/transformation/D8FormToCaseTransformer.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.divorce.bulkscan.transformation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.divorce.bulkscan.exception.InvalidOcrDataException;
 import uk.gov.hmcts.divorce.bulkscan.validation.OcrValidator;
 import uk.gov.hmcts.divorce.bulkscan.validation.data.OcrDataFields;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
@@ -59,7 +60,7 @@ public class D8FormToCaseTransformer extends BulkScanFormTransformer {
         OcrValidationResponse ocrValidationResponse = validator.validateOcrData(D8.getName(), ocrDataFields);
 
         if (!isEmpty(ocrValidationResponse.getErrors())) {
-            throw new InvalidDataException(
+            throw new InvalidOcrDataException(
                 "OCR validation errors",
                 ocrValidationResponse.getWarnings(),
                 ocrValidationResponse.getErrors()

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/transformation/D8sFormToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/transformation/D8sFormToCaseTransformer.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.divorce.bulkscan.transformation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.divorce.bulkscan.exception.InvalidOcrDataException;
 import uk.gov.hmcts.divorce.bulkscan.validation.OcrValidator;
 import uk.gov.hmcts.divorce.bulkscan.validation.data.OcrDataFields;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
@@ -56,7 +57,7 @@ public class D8sFormToCaseTransformer extends BulkScanFormTransformer {
         OcrValidationResponse ocrValidationResponse = validator.validateOcrData(D8S.getName(), ocrDataFields);
 
         if (!isEmpty(ocrValidationResponse.getErrors())) {
-            throw new InvalidDataException(
+            throw new InvalidOcrDataException(
                 "OCR validation errors",
                 ocrValidationResponse.getWarnings(),
                 ocrValidationResponse.getErrors()

--- a/src/main/java/uk/gov/hmcts/divorce/common/config/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/config/advice/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import uk.gov.hmcts.divorce.bulkscan.exception.InvalidOcrDataException;
 import uk.gov.hmcts.divorce.common.config.interceptors.UnAuthorisedServiceException;
 import uk.gov.hmcts.divorce.document.print.exception.InvalidResourceException;
 import uk.gov.hmcts.divorce.notification.exception.NotificationException;
@@ -20,6 +21,8 @@ import uk.gov.service.notify.NotificationClientException;
 import java.util.Collections;
 
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import static org.springframework.http.ResponseEntity.status;
 
 @Slf4j
@@ -73,7 +76,20 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<Object> handleInvalidDataException(InvalidDataException exception) {
         log.warn(exception.getMessage(), exception);
 
-        return status(HttpStatus.UNPROCESSABLE_ENTITY)
+        return status(UNPROCESSABLE_ENTITY)
+            .body(
+                BspErrorResponse.builder()
+                    .errors(exception.getErrors())
+                    .warnings(exception.getWarnings())
+                    .build()
+            );
+    }
+
+    @ExceptionHandler(InvalidOcrDataException.class)
+    public ResponseEntity<Object> handleInvalidOcrDataException(InvalidOcrDataException exception) {
+        log.warn(exception.getMessage(), exception);
+
+        return status(OK)
             .body(
                 BspErrorResponse.builder()
                     .errors(exception.getErrors())
@@ -86,7 +102,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<Object> handleUnsupportedFormTypeException(UnsupportedFormTypeException exception) {
         log.warn(exception.getMessage(), exception);
 
-        return status(HttpStatus.UNPROCESSABLE_ENTITY)
+        return status(UNPROCESSABLE_ENTITY)
             .body(
                 BspErrorResponse.builder()
                     .errors(Collections.singletonList(exception.getMessage()))

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/transformation/D8FormToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/transformation/D8FormToCaseTransformerTest.java
@@ -187,15 +187,15 @@ public class D8FormToCaseTransformerTest {
         });
 
         when(validator.validateOcrData(D8.getName(), transformOcrMapToObject(ocrDataFields)))
-            .thenReturn(OcrValidationResponse.builder().errors(List.of("some error")).build());
+            .thenReturn(OcrValidationResponse.builder().errors(List.of("some error")).warnings(List.of("some warning")).build());
 
         ExceptionRecord exceptionRecord = exceptionRecord(ocrDataFields);
 
         assertThatThrownBy(() -> d8FormToCaseTransformer.transformIntoCaseData(exceptionRecord))
             .isExactlyInstanceOf(InvalidOcrDataException.class)
             .hasMessageContaining("OCR validation errors")
-            .extracting("errors")
-            .isEqualTo(List.of("some error"));
+            .extracting("errors", "warnings")
+            .contains(List.of("some error"), List.of("some warning"));
 
     }
 

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/transformation/D8FormToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/transformation/D8FormToCaseTransformerTest.java
@@ -8,6 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.divorce.bulkscan.exception.InvalidOcrDataException;
 import uk.gov.hmcts.divorce.bulkscan.validation.OcrValidator;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.endpoint.data.OcrValidationResponse;
@@ -180,7 +181,7 @@ public class D8FormToCaseTransformerTest {
     }
 
     @Test
-    void shouldThrowInvalidDataExceptionWhenOcrValidationContainsErrors() throws Exception {
+    void shouldThrowInvalidOcrDataExceptionWhenOcrValidationContainsErrors() throws Exception {
         String validApplicationOcrJson = loadJson("src/test/resources/transformation/input/valid-d8-form-ocr.json");
         List<OcrDataField> ocrDataFields = MAPPER.readValue(validApplicationOcrJson, new TypeReference<>() {
         });
@@ -191,7 +192,7 @@ public class D8FormToCaseTransformerTest {
         ExceptionRecord exceptionRecord = exceptionRecord(ocrDataFields);
 
         assertThatThrownBy(() -> d8FormToCaseTransformer.transformIntoCaseData(exceptionRecord))
-            .isExactlyInstanceOf(InvalidDataException.class)
+            .isExactlyInstanceOf(InvalidOcrDataException.class)
             .hasMessageContaining("OCR validation errors")
             .extracting("errors")
             .isEqualTo(List.of("some error"));

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/transformation/D8sFormToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/transformation/D8sFormToCaseTransformerTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.divorce.bulkscan.exception.InvalidOcrDataException;
 import uk.gov.hmcts.divorce.bulkscan.validation.OcrValidator;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.endpoint.data.OcrValidationResponse;
@@ -212,7 +213,7 @@ class D8sFormToCaseTransformerTest {
     }
 
     @Test
-    void shouldThrowInvalidDataExceptionWhenOcrValidationContainsErrors() throws Exception {
+    void shouldThrowInvalidOcrDataExceptionWhenOcrValidationContainsErrors() throws Exception {
         final String validApplicationOcrJson = loadJson("src/test/resources/transformation/input/valid-d8s-form-ocr.json");
         final List<OcrDataField> ocrDataFields = MAPPER.readValue(validApplicationOcrJson, new TypeReference<>() {
         });
@@ -223,7 +224,7 @@ class D8sFormToCaseTransformerTest {
         final ExceptionRecord exceptionRecord = exceptionRecord(ocrDataFields);
 
         assertThatThrownBy(() -> d8sFormToCaseTransformer.transformIntoCaseData(exceptionRecord))
-            .isExactlyInstanceOf(InvalidDataException.class)
+            .isExactlyInstanceOf(InvalidOcrDataException.class)
             .hasMessageContaining("OCR validation errors")
             .extracting("errors")
             .isEqualTo(List.of("some error"));


### PR DESCRIPTION
- During transformation if there are OCR validation errors then we need to return 200 rather than 422 so that warnings are displayed in warning tab. 
- Returning 422 makes bulk scan service display generic message on warnings tab.