### PR TITLE
fix missing address when doing NoC

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChange.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChange.java
@@ -144,8 +144,10 @@ public class CaseworkerNoticeOfChange implements CCDConfig<CaseData, State, User
 
         if (data.getNoticeOfChange().getWhichApplicant().equals(APPLICANT_1)) {
             data.getApplicant2().setSolicitor(beforeData.getApplicant2().getSolicitor());
+            data.getApplicant2().setAddress(beforeData.getApplicant2().getAddress());
         } else {
             data.getApplicant1().setSolicitor(beforeData.getApplicant1().getSolicitor());
+            data.getApplicant1().setAddress(beforeData.getApplicant1().getAddress());
         }
 
         return data;


### PR DESCRIPTION
When doing a NoC the address for the applicant not selected disappears because we aren't using the RetainHiddenValue field (yet) so CCD will wipe the value.