### PR TITLE
Switch READ only event access

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.6.4'
   id 'com.github.ben-manes.versions' version '0.41.0'
-  id 'hmcts.ccd.sdk' version '1.0.2'
+  id 'hmcts.ccd.sdk' version '1.0.3'
   id 'com.github.hmcts.rse-cft-lib' version '0.14.2'
 }
 

--- a/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/CaseworkerPronounceList.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/CaseworkerPronounceList.java
@@ -31,7 +31,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -60,7 +59,7 @@ public class CaseworkerPronounceList implements CCDConfig<BulkActionCaseData, Bu
             .aboutToSubmitCallback(this::aboutToSubmit)
             .submittedCallback(this::submitted)
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
             .page("pronounceList", this::midEvent)
             .pageLabel("Pronounce List")
             .readonlyNoSummary(BulkActionCaseData::getPronouncementJudge)

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAddAdminClarification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAddAdminClarification.java
@@ -16,7 +16,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerAddAdminClarification implements CCDConfig<CaseData, State, UserRole> {
@@ -32,6 +31,6 @@ public class CaseworkerAddAdminClarification implements CCDConfig<CaseData, Stat
             .description("Add admin clarification")
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN));
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAddBailiffReturn.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAddBailiffReturn.java
@@ -32,7 +32,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -68,7 +67,7 @@ public class CaseworkerAddBailiffReturn implements CCDConfig<CaseData, State, Us
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
             .page("addBailiffReturn")
             .pageLabel("Add Bailiff Return")
             .complex(CaseData::getAlternativeService)

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAddNote.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAddNote.java
@@ -31,7 +31,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE_DELETE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -60,8 +59,7 @@ public class CaseworkerAddNote implements CCDConfig<CaseData, State, UserRole> {
                 CASE_WORKER)
             .grant(CREATE_READ_UPDATE_DELETE,
                 SUPER_USER)
-            .grant(READ,
-                LEGAL_ADVISOR))
+            .grantHistoryOnly(LEGAL_ADVISOR))
             .page("addCaseNotes")
             .pageLabel("Add case notes")
             .optional(CaseData::getNote);

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServiceApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServiceApplication.java
@@ -29,7 +29,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -53,7 +52,7 @@ public class CaseworkerAlternativeServiceApplication implements CCDConfig<CaseDa
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
             .page("serviceApplicationReceived")
             .pageLabel("Service application received")
             .complex(CaseData::getAlternativeService)

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServicePayment.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServicePayment.java
@@ -30,7 +30,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CITIZEN;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.payment.PaymentService.EVENT_ENFORCEMENT;
 import static uk.gov.hmcts.divorce.payment.PaymentService.EVENT_GENERAL;
 import static uk.gov.hmcts.divorce.payment.PaymentService.KEYWORD_BAILIFF;
@@ -62,7 +61,7 @@ public class CaseworkerAlternativeServicePayment implements CCDConfig<CaseData, 
             .aboutToStartCallback(this::aboutToStart)
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, CASE_WORKER, CITIZEN)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAmendCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAmendCase.java
@@ -25,7 +25,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerAmendCase implements CCDConfig<CaseData, State, UserRole> {
@@ -50,7 +49,7 @@ public class CaseworkerAmendCase implements CCDConfig<CaseData, State, UserRole>
             .showEventNotes()
             .grant(CREATE_READ_UPDATE,
                 CASE_WORKER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SUPER_USER,
                 LEGAL_ADVISOR));
     }

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAnswerReceived.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAnswerReceived.java
@@ -34,7 +34,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.payment.PaymentService.EVENT_ISSUE;
 import static uk.gov.hmcts.divorce.payment.PaymentService.KEYWORD_DEF;
 import static uk.gov.hmcts.divorce.payment.PaymentService.SERVICE_OTHER;
@@ -73,7 +72,7 @@ public class CaseworkerAnswerReceived implements CCDConfig<CaseData, State, User
             .aboutToStartCallback(this::aboutToStart)
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR));
     }
 
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToStart(final CaseDetails<CaseData, State> details) {

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerApplicantResponded.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerApplicantResponded.java
@@ -15,7 +15,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerApplicantResponded implements CCDConfig<CaseData, State, UserRole> {
@@ -31,7 +30,7 @@ public class CaseworkerApplicantResponded implements CCDConfig<CaseData, State, 
             .description("Applicant responded")
             .grant(CREATE_READ_UPDATE,
                 CASE_WORKER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SOLICITOR,
                 SUPER_USER,
                 LEGAL_ADVISOR));

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAwaitingApplicant.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAwaitingApplicant.java
@@ -16,7 +16,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -32,6 +31,6 @@ public class CaseworkerAwaitingApplicant implements CCDConfig<CaseData, State, U
             .name("Awaiting Applicant")
             .description("Awaiting Applicant")
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, SOLICITOR));
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR, SOLICITOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAwaitingDocuments.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAwaitingDocuments.java
@@ -19,7 +19,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerAwaitingDocuments implements CCDConfig<CaseData, State, UserRole> {
@@ -35,7 +34,7 @@ public class CaseworkerAwaitingDocuments implements CCDConfig<CaseData, State, U
             .name("Awaiting documents")
             .description("Awaiting documents from the applicant")
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SOLICITOR, SUPER_USER, LEGAL_ADVISOR))
+            .grantHistoryOnly(SOLICITOR, SUPER_USER, LEGAL_ADVISOR))
             .page("caseworkerAwaitingDocuments")
             .pageLabel("Update Due Date")
             .optional(CaseData::getDueDate);

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAwaitingPayment.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAwaitingPayment.java
@@ -15,7 +15,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerAwaitingPayment implements CCDConfig<CaseData, State, UserRole> {
@@ -31,6 +30,6 @@ public class CaseworkerAwaitingPayment implements CCDConfig<CaseData, State, Use
             .name("Awaiting payment")
             .description("Awaiting payment from the applicant")
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SOLICITOR, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SOLICITOR, SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerConfirmAlternativeService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerConfirmAlternativeService.java
@@ -17,7 +17,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -34,7 +33,7 @@ public class CaseworkerConfirmAlternativeService implements CCDConfig<CaseData, 
             .description("Confirm alternative service")
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SUPER_USER,
                 SOLICITOR,
                 LEGAL_ADVISOR,

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerCreateGeneralOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerCreateGeneralOrder.java
@@ -32,7 +32,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -70,7 +69,7 @@ public class CaseworkerCreateGeneralOrder implements CCDConfig<CaseData, State, 
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN));
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN));
     }
 
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerCreatePaperCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerCreatePaperCase.java
@@ -18,7 +18,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER_BULK_S
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Slf4j
 @Component
@@ -35,7 +34,7 @@ public class CaseworkerCreatePaperCase implements CCDConfig<CaseData, State, Use
             .name("Create paper case")
             .description("Create paper case")
             .grant(CREATE_READ_UPDATE, CASE_WORKER, CASE_WORKER_BULK_SCAN, SYSTEMUPDATE)
-            .grant(READ, SUPER_USER));
+            .grantHistoryOnly(SUPER_USER));
     }
 
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(final CaseDetails<CaseData, State> details,

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerFinalOrderPending.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerFinalOrderPending.java
@@ -20,7 +20,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerFinalOrderPending implements CCDConfig<CaseData, State, UserRole> {
@@ -36,6 +35,6 @@ public class CaseworkerFinalOrderPending implements CCDConfig<CaseData, State, U
             .description("Final Order pending")
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN));
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerGeneralApplicationReceived.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerGeneralApplicationReceived.java
@@ -13,7 +13,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerGeneralApplicationReceived implements CCDConfig<CaseData, State, UserRole> {
@@ -28,6 +27,6 @@ public class CaseworkerGeneralApplicationReceived implements CCDConfig<CaseData,
             .description("General application received")
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerGeneralEmail.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerGeneralEmail.java
@@ -21,7 +21,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -42,7 +41,7 @@ public class CaseworkerGeneralEmail implements CCDConfig<CaseData, State, UserRo
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
             .page("createGeneralEmail")
             .pageLabel("Create general email")
             .complex(CaseData::getGeneralEmail)

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerGeneralReferral.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerGeneralReferral.java
@@ -25,7 +25,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -46,7 +45,7 @@ public class CaseworkerGeneralReferral implements CCDConfig<CaseData, State, Use
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
             .page("generalReferral")
             .pageLabel("General referral")
             .complex(CaseData::getGeneralReferral)

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerGeneralReferralPayment.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerGeneralReferralPayment.java
@@ -28,7 +28,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.payment.PaymentService.EVENT_GENERAL;
 import static uk.gov.hmcts.divorce.payment.PaymentService.KEYWORD_DEEMED;
 import static uk.gov.hmcts.divorce.payment.PaymentService.SERVICE_OTHER;
@@ -62,7 +61,7 @@ public class CaseworkerGeneralReferralPayment implements CCDConfig<CaseData, Sta
             .showEventNotes()
             .aboutToStartCallback(this::aboutToStart)
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, SOLICITOR, CITIZEN, LEGAL_ADVISOR));
+            .grantHistoryOnly(SUPER_USER, SOLICITOR, CITIZEN, LEGAL_ADVISOR));
     }
 
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToStart(final CaseDetails<CaseData, State> details) {

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerGrantFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerGrantFinalOrder.java
@@ -24,7 +24,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerGrantFinalOrder implements CCDConfig<CaseData, State, UserRole> {
@@ -46,7 +45,7 @@ public class CaseworkerGrantFinalOrder implements CCDConfig<CaseData, State, Use
             .endButtonLabel("Submit")
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SOLICITOR, SUPER_USER, LEGAL_ADVISOR))
+            .grantHistoryOnly(SOLICITOR, SUPER_USER, LEGAL_ADVISOR))
             .page("grantFinalOrder")
             .pageLabel("Grant Final Order")
             .complex(CaseData::getFinalOrder)

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerHwfApplicationAccepted.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerHwfApplicationAccepted.java
@@ -19,7 +19,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerHwfApplicationAccepted implements CCDConfig<CaseData, State, UserRole> {
@@ -35,6 +34,6 @@ public class CaseworkerHwfApplicationAccepted implements CCDConfig<CaseData, Sta
             .description("HWF application accepted")
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SOLICITOR, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SOLICITOR, SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerHwfRefused.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerHwfRefused.java
@@ -15,7 +15,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerHwfRefused implements CCDConfig<CaseData, State, UserRole> {
@@ -31,6 +30,6 @@ public class CaseworkerHwfRefused implements CCDConfig<CaseData, State, UserRole
             .description("HWF refused")
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SOLICITOR, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SOLICITOR, SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerIssueApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerIssueApplication.java
@@ -32,7 +32,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ApplicationValidation.validateIssue;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueSolicitorServicePack.SYSTEM_ISSUE_SOLICITOR_SERVICE_PACK;
 
@@ -69,7 +68,7 @@ public class CaseworkerIssueApplication implements CCDConfig<CaseData, State, Us
             .submittedCallback(this::submitted)
             .grant(CREATE_READ_UPDATE,
                 CASE_WORKER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SOLICITOR,
                 SUPER_USER,
                 LEGAL_ADVISOR))

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerIssueBailiffPack.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerIssueBailiffPack.java
@@ -25,7 +25,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.CERTIFICATE_OF_SERVICE_DOCUMENT_NAME;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.CERTIFICATE_OF_SERVICE_TEMPLATE_ID;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CERTIFICATE_OF_SERVICE;
@@ -52,7 +51,7 @@ public class CaseworkerIssueBailiffPack implements CCDConfig<CaseData, State, Us
             .showSummary()
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
             .page("issueBailiffPack")
             .pageLabel("Local court details - Issue Bailiff Pack")
             .label("localCourtDetailsIntro",

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerMakeBailiffDecision.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerMakeBailiffDecision.java
@@ -28,7 +28,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.BAILIFF_APPLICATION_APPROVED_FILE_NAME;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.BAILIFF_APPLICATION_APPROVED_ID;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.BAILIFF_APPLICATION_NOT_APPROVED_FILE_NAME;
@@ -68,7 +67,7 @@ public class CaseworkerMakeBailiffDecision implements CCDConfig<CaseData, State,
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ, LEGAL_ADVISOR)
-            .grant(READ, CASE_WORKER, SOLICITOR, SYSTEMUPDATE))
+            .grantHistoryOnly(CASE_WORKER, SOLICITOR, SYSTEMUPDATE))
             .page("makeBailiffDecision-1")
             .pageLabel("Make Bailiff Decision")
             .complex(CaseData::getAlternativeService)

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChange.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChange.java
@@ -32,7 +32,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -54,7 +53,7 @@ public class CaseworkerNoticeOfChange implements CCDConfig<CaseData, State, User
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, CASE_WORKER, SUPER_USER)
-            .grant(READ, LEGAL_ADVISOR))
+            .grantHistoryOnly(LEGAL_ADVISOR))
             .page("changeRepresentation-1")
             .pageLabel("Which applicant")
             .complex(CaseData::getNoticeOfChange)

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerPaymentMade.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerPaymentMade.java
@@ -18,7 +18,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerPaymentMade implements CCDConfig<CaseData, State, UserRole> {
@@ -35,6 +34,6 @@ public class CaseworkerPaymentMade implements CCDConfig<CaseData, State, UserRol
             .description("Payment made")
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerProgressPaperCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerProgressPaperCase.java
@@ -23,7 +23,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE_DELETE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Slf4j
 @Component
@@ -45,7 +44,7 @@ public class CaseworkerProgressPaperCase implements CCDConfig<CaseData, State, U
                 CASE_WORKER)
             .grant(CREATE_READ_UPDATE_DELETE,
                 SUPER_USER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SOLICITOR,
                 LEGAL_ADVISOR))
             .page("Progress paper case")

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerRefund.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerRefund.java
@@ -14,7 +14,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerRefund implements CCDConfig<CaseData, State, UserRole> {
@@ -31,7 +30,7 @@ public class CaseworkerRefund implements CCDConfig<CaseData, State, UserRole> {
             .showEventNotes()
             .grant(CREATE_READ_UPDATE,
                 CASE_WORKER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SOLICITOR,
                 SUPER_USER,
                 LEGAL_ADVISOR));

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerReissueApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerReissueApplication.java
@@ -32,7 +32,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ApplicationValidation.validateIssue;
 
 @Component
@@ -57,7 +56,7 @@ public class CaseworkerReissueApplication implements CCDConfig<CaseData, State, 
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SOLICITOR,
                 SUPER_USER,
                 LEGAL_ADVISOR))

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerRejected.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerRejected.java
@@ -20,7 +20,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Slf4j
 @Component
@@ -40,7 +39,7 @@ public class CaseworkerRejected implements CCDConfig<CaseData, State, UserRole> 
             .showEventNotes()
             .grant(CREATE_READ_UPDATE,
                 CASE_WORKER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SOLICITOR,
                 SUPER_USER,
                 LEGAL_ADVISOR))

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerRequestDwpDisclosure.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerRequestDwpDisclosure.java
@@ -20,7 +20,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -37,7 +36,7 @@ public class CaseworkerRequestDwpDisclosure implements CCDConfig<CaseData, State
             .showEventNotes()
             .grant(CREATE_READ_UPDATE,
                 CASE_WORKER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SUPER_USER,
                 SOLICITOR,
                 LEGAL_ADVISOR,

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerServeByAlternativeMethod.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerServeByAlternativeMethod.java
@@ -17,7 +17,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -35,7 +34,7 @@ public class CaseworkerServeByAlternativeMethod implements CCDConfig<CaseData, S
             .showEventNotes()
             .grant(CREATE_READ_UPDATE,
                 CASE_WORKER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SUPER_USER,
                 SOLICITOR,
                 LEGAL_ADVISOR,

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUpdateContactDetails.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUpdateContactDetails.java
@@ -17,7 +17,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -47,7 +46,7 @@ public class CaseworkerUpdateContactDetails implements CCDConfig<CaseData, State
             .showSummary()
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SUPER_USER,
                 LEGAL_ADVISOR));
     }

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUpdateDueDate.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUpdateDueDate.java
@@ -16,7 +16,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE_DELETE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -35,7 +34,7 @@ public class CaseworkerUpdateDueDate implements CCDConfig<CaseData, State, UserR
                 CASE_WORKER)
             .grant(CREATE_READ_UPDATE_DELETE,
                 SUPER_USER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SOLICITOR,
                 LEGAL_ADVISOR))
             .page("updateDueDate")

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUploadConfidentialDocument.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUploadConfidentialDocument.java
@@ -16,7 +16,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -34,7 +33,7 @@ public class CaseworkerUploadConfidentialDocument implements CCDConfig<CaseData,
             .showSummary(false)
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR))
+            .grantHistoryOnly(SUPER_USER, LEGAL_ADVISOR))
             .page("uploadConfidentialDocuments")
             .pageLabel("Upload Confidential Documents")
             .optional(CaseData::getConfidentialDocumentsUploaded);

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUploadDocument.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUploadDocument.java
@@ -17,7 +17,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -35,7 +34,7 @@ public class CaseworkerUploadDocument implements CCDConfig<CaseData, State, User
             .showSummary(false)
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SOLICITOR, SUPER_USER, LEGAL_ADVISOR))
+            .grantHistoryOnly(SOLICITOR, SUPER_USER, LEGAL_ADVISOR))
             .page("uploadDocument")
             .pageLabel("Upload document")
             .optional(CaseData::getDocumentsUploaded);

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUploadDocumentsAndSubmit.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerUploadDocumentsAndSubmit.java
@@ -24,7 +24,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ApplicationValidation.validateSubmission;
 
 @Slf4j
@@ -47,7 +46,7 @@ public class CaseworkerUploadDocumentsAndSubmit implements CCDConfig<CaseData, S
             .aboutToStartCallback(this::aboutToStart)
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
-            .grant(READ, SOLICITOR, SUPER_USER, LEGAL_ADVISOR))
+            .grantHistoryOnly(SOLICITOR, SUPER_USER, LEGAL_ADVISOR))
             .page("caseworkerUploadDocuments")
             .pageLabel("Upload the documents")
             .label(

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerWithdrawn.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerWithdrawn.java
@@ -15,7 +15,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CaseworkerWithdrawn implements CCDConfig<CaseData, State, UserRole> {
@@ -31,7 +30,7 @@ public class CaseworkerWithdrawn implements CCDConfig<CaseData, State, UserRole>
             .showEventNotes()
             .grant(CREATE_READ_UPDATE,
                 CASE_WORKER)
-            .grant(READ,
+            .grantHistoryOnly(
                 SOLICITOR,
                 SUPER_USER,
                 LEGAL_ADVISOR));

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenAddPayment.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenAddPayment.java
@@ -21,7 +21,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CITIZEN;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ApplicationValidation.validateSubmission;
 import static uk.gov.hmcts.divorce.payment.model.PaymentStatus.IN_PROGRESS;
 import static uk.gov.hmcts.divorce.payment.model.PaymentStatus.SUCCESS;
@@ -44,7 +43,7 @@ public class CitizenAddPayment implements CCDConfig<CaseData, State, UserRole> {
             .description("Payment made")
             .retries(120, 120)
             .grant(CREATE_READ_UPDATE, CITIZEN)
-            .grant(READ, SUPER_USER, CASE_WORKER)
+            .grantHistoryOnly(SUPER_USER, CASE_WORKER)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }
 

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant1ConfirmReceipt.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant1ConfirmReceipt.java
@@ -13,7 +13,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CitizenApplicant1ConfirmReceipt implements CCDConfig<CaseData, State, UserRole> {
@@ -29,7 +28,7 @@ public class CitizenApplicant1ConfirmReceipt implements CCDConfig<CaseData, Stat
             .name("Applicant 1 Confirm Receipt")
             .description("Applicant 1 confirms receipt for joint application")
             .grant(CREATE_READ_UPDATE, CREATOR)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, CASE_WORKER);
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER, LEGAL_ADVISOR);
     }
 }
 

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant2ConfirmReceipt.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant2ConfirmReceipt.java
@@ -13,7 +13,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CitizenApplicant2ConfirmReceipt implements CCDConfig<CaseData, State, UserRole> {
@@ -29,7 +28,7 @@ public class CitizenApplicant2ConfirmReceipt implements CCDConfig<CaseData, Stat
             .name("Applicant 2 Confirm Receipt")
             .description("Applicant 2 confirms receipt for joint application")
             .grant(CREATE_READ_UPDATE, APPLICANT_2)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, CASE_WORKER);
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER, LEGAL_ADVISOR);
     }
 }
 

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant2NotBroken.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant2NotBroken.java
@@ -16,6 +16,8 @@ import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingApplicant1Response;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingApplicant2Response;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 
 @Slf4j
@@ -39,6 +41,7 @@ public class CitizenApplicant2NotBroken implements CCDConfig<CaseData, State, Us
             .name("Applicant 2 not broken")
             .description("Applicant 2 union has not broken")
             .grant(CREATE_READ_UPDATE, APPLICANT_2)
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER)
             .retries(120, 120)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant2UpdateApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant2UpdateApplication.java
@@ -18,7 +18,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.State.ConditionalOrderPendi
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CitizenApplicant2UpdateApplication implements CCDConfig<CaseData, State, UserRole> {
@@ -36,7 +35,7 @@ public class CitizenApplicant2UpdateApplication implements CCDConfig<CaseData, S
             .aboutToSubmitCallback(this::aboutToSubmit)
             .retries(120, 120)
             .grant(CREATE_READ_UPDATE, APPLICANT_2)
-            .grant(READ, SUPER_USER);
+            .grantHistoryOnly(SUPER_USER);
     }
 
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(CaseDetails<CaseData, State> details,

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenFinalOrderDelayReason.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenFinalOrderDelayReason.java
@@ -14,7 +14,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class CitizenFinalOrderDelayReason implements CCDConfig<CaseData, State, UserRole> {
@@ -30,7 +29,7 @@ public class CitizenFinalOrderDelayReason implements CCDConfig<CaseData, State, 
             .name("Citizen FO delay reason")
             .description("Citizen final order delay reason")
             .grant(CREATE_READ_UPDATE, CREATOR)
-            .grant(READ, SUPER_USER, LEGAL_ADVISOR, CASE_WORKER);
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER, LEGAL_ADVISOR);
     }
 }
 

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenSubmitApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenSubmitApplication.java
@@ -25,7 +25,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CITIZEN;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ApplicationValidation.validateReadyForPayment;
 import static uk.gov.hmcts.divorce.payment.PaymentService.EVENT_ISSUE;
 import static uk.gov.hmcts.divorce.payment.PaymentService.KEYWORD_DIVORCE;
@@ -53,7 +52,7 @@ public class CitizenSubmitApplication implements CCDConfig<CaseData, State, User
             .description("Apply: divorce or dissolution")
             .retries(120, 120)
             .grant(CREATE_READ_UPDATE, CITIZEN)
-            .grant(READ, CASE_WORKER, LEGAL_ADVISOR, SUPER_USER)
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }
 

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenSwitchedToSole.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenSwitchedToSole.java
@@ -29,7 +29,9 @@ import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingApplicant2Res
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingPayment;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Draft;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 
 @Slf4j
@@ -65,6 +67,7 @@ public class CitizenSwitchedToSole implements CCDConfig<CaseData, State, UserRol
             .name("Application switched to sole")
             .description("Application type switched to sole")
             .grant(CREATE_READ_UPDATE, CREATOR, APPLICANT_2)
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER)
             .retries(120, 120)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAat.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateCaseStateAat.java
@@ -16,7 +16,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CITIZEN;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Slf4j
 @Component
@@ -34,7 +33,7 @@ public class CitizenUpdateCaseStateAat implements CCDConfig<CaseData, State, Use
                 .name("Citizen update case state AAT")
                 .description("Citizen update the case state in AAT")
                 .grant(CREATE_READ_UPDATE, CITIZEN, APPLICANT_2, CASE_WORKER)
-                .grant(READ, SUPER_USER)
+                .grantHistoryOnly(SUPER_USER)
                 .aboutToSubmitCallback(this::aboutToSubmit);
         }
     }

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateContactDetails.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenUpdateContactDetails.java
@@ -16,10 +16,10 @@ import javax.servlet.http.HttpServletRequest;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CITIZEN;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Slf4j
 @Component
@@ -43,7 +43,7 @@ public class CitizenUpdateContactDetails implements CCDConfig<CaseData, State, U
             .description("Patch a case contact details for correct applicant")
             .retries(120, 120)
             .grant(CREATE_READ_UPDATE, CITIZEN, APPLICANT_2)
-            .grant(READ, SUPER_USER)
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }
 

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/Applicant1Resubmit.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/Applicant1Resubmit.java
@@ -20,7 +20,9 @@ import java.util.List;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingApplicant1Response;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingApplicant2Response;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_1_SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ValidationUtil.validateApplicant1BasicCase;
 
@@ -45,6 +47,7 @@ public class Applicant1Resubmit implements CCDConfig<CaseData, State, UserRole> 
             .name("Resubmit Applicant 1 Answers")
             .description("Applicant 1 resubmits for joint application")
             .grant(CREATE_READ_UPDATE, APPLICANT_1_SOLICITOR, CREATOR)
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER)
             .retries(120, 120)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/Applicant2Approve.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/Applicant2Approve.java
@@ -26,7 +26,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ValidationUtil.validateApplicant2BasicCase;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.DIVORCE_JOINT_APPLICANT_2_ANSWERS;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.JOINT_DIVORCE_APPLICANT_2_ANSWERS_DOCUMENT_NAME;
@@ -59,7 +58,7 @@ public class Applicant2Approve implements CCDConfig<CaseData, State, UserRole> {
             .name("Applicant 2 approve")
             .description("Applicant 2 has approved")
             .grant(CREATE_READ_UPDATE, APPLICANT_2, SYSTEMUPDATE)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER)
             .retries(120, 120)

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/Applicant2RequestChanges.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/Applicant2RequestChanges.java
@@ -23,7 +23,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ValidationUtil.validateApplicant2RequestChanges;
 
 @Slf4j
@@ -47,10 +46,7 @@ public class Applicant2RequestChanges implements CCDConfig<CaseData, State, User
             .name("Applicant 2 Request Changes")
             .description("Applicant 2 Requests changes to be made by Applicant 1")
             .grant(CREATE_READ_UPDATE, APPLICANT_2, SYSTEMUPDATE)
-            .grant(READ,
-                APPLICANT_1_SOLICITOR,
-                CASE_WORKER,
-                SUPER_USER)
+            .grantHistoryOnly(APPLICANT_1_SOLICITOR, CASE_WORKER, SUPER_USER)
             .retries(120, 120)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/ApplyForFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/ApplyForFinalOrder.java
@@ -28,7 +28,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -64,7 +63,7 @@ public class ApplyForFinalOrder implements CCDConfig<CaseData, State, UserRole> 
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, APPLICANT_1_SOLICITOR, CREATOR, APPLICANT_2)
             .aboutToSubmitCallback(this::aboutToSubmit)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER,
                 LEGAL_ADVISOR));

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/CreateTestCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/CreateTestCase.java
@@ -37,7 +37,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Slf4j
 @Component
@@ -63,8 +62,6 @@ public class CreateTestCase implements CCDConfig<CaseData, State, UserRole> {
 
         if (env.contains(ENVIRONMENT_AAT)) {
             roles.add(SOLICITOR);
-            roles.add(CASE_WORKER);
-            roles.add(SUPER_USER);
         }
 
         new PageBuilder(configBuilder
@@ -74,7 +71,7 @@ public class CreateTestCase implements CCDConfig<CaseData, State, UserRole> {
             .aboutToSubmitCallback(this::aboutToSubmit)
             .submittedCallback(this::submitted)
             .grant(CREATE_READ_UPDATE, roles.toArray(UserRole[]::new))
-            .grant(READ, SUPER_USER, CASE_WORKER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
+            .grantHistoryOnly(SUPER_USER, CASE_WORKER, LEGAL_ADVISOR, SOLICITOR, CITIZEN))
             .page("Create test case", this::midEvent)
             .mandatory(CaseData::getApplicationType)
             .complex(CaseData::getApplicant1)

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/DraftAos.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/DraftAos.java
@@ -29,7 +29,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.task.CaseTaskRunner.caseTasks;
 
 @Component
@@ -64,7 +63,7 @@ public class DraftAos implements CCDConfig<CaseData, State, UserRole> {
             .showSummary()
             .endButtonLabel("Save AoS Response")
             .grant(CREATE_READ_UPDATE, APPLICANT_2_SOLICITOR, APPLICANT_2)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER,
                 LEGAL_ADVISOR));

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/DraftConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/DraftConditionalOrder.java
@@ -30,7 +30,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.task.CaseTaskRunner.caseTasks;
 
 @Slf4j
@@ -65,7 +64,7 @@ public class DraftConditionalOrder implements CCDConfig<CaseData, State, UserRol
             .aboutToSubmitCallback(this::aboutToSubmit)
             .aboutToStartCallback(this::aboutToStart)
             .grant(CREATE_READ_UPDATE, APPLICANT_1_SOLICITOR, CREATOR, CITIZEN, APPLICANT_2)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER,
                 LEGAL_ADVISOR));

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/DraftJointConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/DraftJointConditionalOrder.java
@@ -29,7 +29,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.task.CaseTaskRunner.caseTasks;
 
 @Slf4j
@@ -64,7 +63,7 @@ public class DraftJointConditionalOrder implements CCDConfig<CaseData, State, Us
             .aboutToSubmitCallback(this::aboutToSubmit)
             .aboutToStartCallback(this::aboutToStart)
             .grant(CREATE_READ_UPDATE, APPLICANT_2_SOLICITOR, CREATOR, CITIZEN)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER,
                 LEGAL_ADVISOR));

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/InviteApplicant2.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/InviteApplicant2.java
@@ -25,7 +25,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CITIZEN;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ValidationUtil.validateApplicant1BasicCase;
 
 @Slf4j
@@ -52,7 +51,7 @@ public class InviteApplicant2 implements CCDConfig<CaseData, State, UserRole> {
             .showSummary()
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, CITIZEN, APPLICANT_1_SOLICITOR)
-            .grant(READ,
+            .grantHistoryOnly(
                 SUPER_USER,
                 CASE_WORKER,
                 LEGAL_ADVISOR)

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitAos.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitAos.java
@@ -35,7 +35,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueAosDisputed.SYSTEM_ISSUE_AOS_DISPUTED;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemIssueAosUnDisputed.SYSTEM_ISSUE_AOS_UNDISPUTED;
 
@@ -119,7 +118,7 @@ public class SubmitAos implements CCDConfig<CaseData, State, UserRole> {
             .aboutToSubmitCallback(this::aboutToSubmit)
             .submittedCallback(this::submitted)
             .grant(CREATE_READ_UPDATE, APPLICANT_2_SOLICITOR, APPLICANT_2)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 LEGAL_ADVISOR,
                 SUPER_USER));

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitClarification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitClarification.java
@@ -24,7 +24,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -49,7 +48,7 @@ public class SubmitClarification implements CCDConfig<CaseData, State, UserRole>
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, APPLICANT_1_SOLICITOR, CREATOR, APPLICANT_2)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER,
                 LEGAL_ADVISOR))

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitConditionalOrder.java
@@ -39,7 +39,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -79,7 +78,7 @@ public class SubmitConditionalOrder implements CCDConfig<CaseData, State, UserRo
             .showCondition("coApplicant1IsSubmitted=\"No\"")
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, APPLICANT_1_SOLICITOR, CREATOR, APPLICANT_2)
-            .grant(READ, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR))
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER, LEGAL_ADVISOR))
             .page("ConditionalOrderSoT")
             .pageLabel("Statement of Truth - submit conditional order")
             .complex(CaseData::getConditionalOrder)

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitJointConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SubmitJointConditionalOrder.java
@@ -27,7 +27,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -52,7 +51,7 @@ public class SubmitJointConditionalOrder implements CCDConfig<CaseData, State, U
             .showCondition("applicationType=\"jointApplication\" AND coApplicant2IsSubmitted=\"No\"")
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, APPLICANT_2_SOLICITOR)
-            .grant(READ, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR))
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER, LEGAL_ADVISOR))
             .page("JointConditionalOrderSoT")
             .pageLabel("Statement of Truth - submit joint conditional order")
             .complex(CaseData::getConditionalOrder)

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/UpdateAos.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/UpdateAos.java
@@ -18,7 +18,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class UpdateAos implements CCDConfig<CaseData, State, UserRole> {
@@ -44,7 +43,7 @@ public class UpdateAos implements CCDConfig<CaseData, State, UserRole> {
             .showSummary()
             .endButtonLabel("Save Updated AoS Response")
             .grant(CREATE_READ_UPDATE, APPLICANT_2_SOLICITOR)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER,
                 LEGAL_ADVISOR));

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/UpdateConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/UpdateConditionalOrder.java
@@ -21,7 +21,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class UpdateConditionalOrder implements CCDConfig<CaseData, State, UserRole> {
@@ -47,7 +46,7 @@ public class UpdateConditionalOrder implements CCDConfig<CaseData, State, UserRo
             .endButtonLabel("Save conditional order")
             .showCondition("coApplicant1IsDrafted=\"Yes\"")
             .grant(CREATE_READ_UPDATE, APPLICANT_1_SOLICITOR, CREATOR)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER,
                 LEGAL_ADVISOR));

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/UpdateJointConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/UpdateJointConditionalOrder.java
@@ -20,7 +20,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class UpdateJointConditionalOrder implements CCDConfig<CaseData, State, UserRole> {
@@ -47,7 +46,7 @@ public class UpdateJointConditionalOrder implements CCDConfig<CaseData, State, U
             .endButtonLabel("Save conditional order")
             .showCondition("applicationType=\"jointApplication\" AND coApplicant2IsDrafted=\"Yes\"")
             .grant(CREATE_READ_UPDATE, APPLICANT_2_SOLICITOR)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER,
                 LEGAL_ADVISOR));

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/NoFaultDivorce.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/NoFaultDivorce.java
@@ -1,34 +1,21 @@
 package uk.gov.hmcts.divorce.divorcecase;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
-import uk.gov.hmcts.divorce.common.AddSystemUpdateRole;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.RetiredFields;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 
-import static uk.gov.hmcts.divorce.divorcecase.model.State.Draft;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_1_SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2_SOLICITOR;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CITIZEN;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class NoFaultDivorce implements CCDConfig<CaseData, State, UserRole> {
 
     public static final String CASE_TYPE = "NFD";
     public static final String JURISDICTION = "DIVORCE";
-
-    @Autowired
-    private AddSystemUpdateRole addSystemUpdateRole;
 
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
@@ -37,16 +24,6 @@ public class NoFaultDivorce implements CCDConfig<CaseData, State, UserRole> {
 
         configBuilder.caseType(CASE_TYPE, "New Law Case", "Handling of the dissolution of marriage");
         configBuilder.jurisdiction(JURISDICTION, "Family Divorce", "Family Divorce: dissolution of marriage");
-        configBuilder.omitHistoryForRoles(SOLICITOR, APPLICANT_2_SOLICITOR);
-
-        configBuilder.grant(Draft, CREATE_READ_UPDATE, CITIZEN);
-        configBuilder.grant(Draft, READ, CASE_WORKER);
-        configBuilder.grant(Draft, CREATE_READ_UPDATE, SOLICITOR);
-        configBuilder.grant(Draft, CREATE_READ_UPDATE, SUPER_USER);
-        configBuilder.grant(Draft, READ, LEGAL_ADVISOR);
-
-        if (addSystemUpdateRole.isEnvironmentAat()) {
-            configBuilder.grant(Draft, CREATE_READ_UPDATE, SYSTEMUPDATE);
-        }
+        configBuilder.omitHistoryForRoles(APPLICANT_1_SOLICITOR, APPLICANT_2_SOLICITOR);
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/legaladvisor/event/LegalAdvisorGeneralConsideration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/legaladvisor/event/LegalAdvisorGeneralConsideration.java
@@ -26,7 +26,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -48,7 +47,7 @@ public class LegalAdvisorGeneralConsideration implements CCDConfig<CaseData, Sta
             .showSummary()
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, LEGAL_ADVISOR)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER))
             .page("generalConsiderationResponse")

--- a/src/main/java/uk/gov/hmcts/divorce/legaladvisor/event/LegalAdvisorMakeDecision.java
+++ b/src/main/java/uk/gov/hmcts/divorce/legaladvisor/event/LegalAdvisorMakeDecision.java
@@ -38,7 +38,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.REFUSAL_ORDER_DOCUMENT_NAME;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.REFUSAL_ORDER_TEMPLATE_ID;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CONDITIONAL_ORDER_REFUSAL;
@@ -77,7 +76,7 @@ public class LegalAdvisorMakeDecision implements CCDConfig<CaseData, State, User
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, LEGAL_ADVISOR)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER,
                 APPLICANT_1_SOLICITOR))

--- a/src/main/java/uk/gov/hmcts/divorce/legaladvisor/event/LegalAdvisorMakeServiceDecision.java
+++ b/src/main/java/uk/gov/hmcts/divorce/legaladvisor/event/LegalAdvisorMakeServiceDecision.java
@@ -38,7 +38,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.DEEMED_AS_SERVICE_GRANTED;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.DEEMED_SERVICE_REFUSED_FILE_NAME;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.DISPENSED_AS_SERVICE_GRANTED;
@@ -77,7 +76,7 @@ public class LegalAdvisorMakeServiceDecision implements CCDConfig<CaseData, Stat
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, LEGAL_ADVISOR)
-            .grant(READ, CASE_WORKER, SUPER_USER, SOLICITOR, CITIZEN, SYSTEMUPDATE))
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER, SOLICITOR, CITIZEN, SYSTEMUPDATE))
             .page("makeServiceDecision")
             .pageLabel("Approve service application")
             .complex(CaseData::getAlternativeService)

--- a/src/main/java/uk/gov/hmcts/divorce/legaladvisor/event/LegalAdvisorRequestClarification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/legaladvisor/event/LegalAdvisorRequestClarification.java
@@ -19,7 +19,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class LegalAdvisorRequestClarification implements CCDConfig<CaseData, State, UserRole> {
@@ -40,7 +39,7 @@ public class LegalAdvisorRequestClarification implements CCDConfig<CaseData, Sta
             .name("Request clarification")
             .description("Request clarification")
             .grant(CREATE_READ_UPDATE, LEGAL_ADVISOR)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER,
                 APPLICANT_1_SOLICITOR));

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorConfirmReceipt.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorConfirmReceipt.java
@@ -15,7 +15,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class SolicitorConfirmReceipt implements CCDConfig<CaseData, State, UserRole> {
@@ -32,9 +31,6 @@ public class SolicitorConfirmReceipt implements CCDConfig<CaseData, State, UserR
             .showSummary()
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, SOLICITOR, APPLICANT_2_SOLICITOR)
-            .grant(READ,
-                SUPER_USER,
-                CASE_WORKER,
-                LEGAL_ADVISOR));
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorConfirmService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorConfirmService.java
@@ -26,7 +26,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Slf4j
 @Component
@@ -90,10 +89,7 @@ public class SolicitorConfirmService implements CCDConfig<CaseData, State, UserR
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, SOLICITOR)
-            .grant(READ,
-                CASE_WORKER,
-                SUPER_USER,
-                LEGAL_ADVISOR));
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 
     private List<String> validateConfirmService(Application application) {

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorCreateApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorCreateApplication.java
@@ -40,8 +40,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ_UPDATE;
 
 @Slf4j
 @Component
@@ -115,8 +113,7 @@ public class SolicitorCreateApplication implements CCDConfig<CaseData, State, Us
             .aboutToSubmitCallback(this::aboutToSubmit)
             .submittedCallback(this::submitted)
             .grant(CREATE_READ_UPDATE, updatedRoles.toArray(UserRole[]::new))
-            .grant(READ_UPDATE, SUPER_USER)
-            .grant(READ, CASE_WORKER, LEGAL_ADVISOR));
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 
     public SubmittedCallbackResponse submitted(CaseDetails<CaseData, State> details, CaseDetails<CaseData, State> before) {

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorGeneralApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorGeneralApplication.java
@@ -33,7 +33,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class SolicitorGeneralApplication implements CCDConfig<CaseData, State, UserRole> {
@@ -98,6 +97,6 @@ public class SolicitorGeneralApplication implements CCDConfig<CaseData, State, U
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, SOLICITOR)
-            .grant(READ, CASE_WORKER, LEGAL_ADVISOR, SUPER_USER));
+            .grantHistoryOnly(CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitApplication.java
@@ -44,7 +44,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.validation.ApplicationValidation.validateReadyForPayment;
 import static uk.gov.hmcts.divorce.payment.PaymentService.EVENT_ISSUE;
 import static uk.gov.hmcts.divorce.payment.PaymentService.KEYWORD_DIVORCE;
@@ -198,7 +197,7 @@ public class SolicitorSubmitApplication implements CCDConfig<CaseData, State, Us
             .aboutToStartCallback(this::aboutToStart)
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, SOLICITOR)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER,
                 LEGAL_ADVISOR));

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplication.java
@@ -37,7 +37,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.util.SolicitorAddressPopulator.populateSolicitorAddress;
 
 @Slf4j
@@ -90,7 +89,7 @@ public class SolicitorSubmitJointApplication implements CCDConfig<CaseData, Stat
             .showSummary()
             .endButtonLabel("Submit Application")
             .grant(CREATE_READ_UPDATE, APPLICANT_2_SOLICITOR)
-            .grant(READ,
+            .grantHistoryOnly(
                 APPLICANT_1_SOLICITOR,
                 CASE_WORKER,
                 SUPER_USER,

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateApplicant1ContactDetails.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateApplicant1ContactDetails.java
@@ -15,8 +15,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ_UPDATE;
 
 @Component
 public class SolicitorUpdateApplicant1ContactDetails implements CCDConfig<CaseData, State, UserRole> {
@@ -41,9 +39,9 @@ public class SolicitorUpdateApplicant1ContactDetails implements CCDConfig<CaseDa
             .showSummary()
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, APPLICANT_1_SOLICITOR)
-            .grant(READ_UPDATE, SUPER_USER)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
+                SUPER_USER,
                 LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateApplicant2ContactDetails.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateApplicant2ContactDetails.java
@@ -15,8 +15,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ_UPDATE;
 
 @Component
 public class SolicitorUpdateApplicant2ContactDetails implements CCDConfig<CaseData, State, UserRole> {
@@ -41,9 +39,9 @@ public class SolicitorUpdateApplicant2ContactDetails implements CCDConfig<CaseDa
             .showSummary()
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, APPLICANT_2_SOLICITOR)
-            .grant(READ_UPDATE, SUPER_USER)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
+                SUPER_USER,
                 LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateContactDetails.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorUpdateContactDetails.java
@@ -20,8 +20,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ_UPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.task.CaseTaskRunner.caseTasks;
 
 @Component
@@ -64,9 +62,9 @@ public class SolicitorUpdateContactDetails implements CCDConfig<CaseData, State,
             .showEventNotes()
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, SOLICITOR)
-            .grant(READ_UPDATE, SUPER_USER)
-            .grant(READ,
+            .grantHistoryOnly(
                 CASE_WORKER,
+                SUPER_USER,
                 LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueAosDisputed.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueAosDisputed.java
@@ -18,7 +18,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -35,6 +34,6 @@ public class SystemIssueAosDisputed implements CCDConfig<CaseData, State, UserRo
             .name("AoS disputed")
             .description("AoS disputed")
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueAosUnDisputed.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueAosUnDisputed.java
@@ -18,7 +18,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -35,6 +34,6 @@ public class SystemIssueAosUnDisputed implements CCDConfig<CaseData, State, User
             .name("AoS undisputed")
             .description("AoS undisputed")
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueSolicitorServicePack.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemIssueSolicitorServicePack.java
@@ -16,7 +16,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -33,7 +32,7 @@ public class SystemIssueSolicitorServicePack implements CCDConfig<CaseData, Stat
             .name("Issue solicitor service pack")
             .description("Issue solicitor service pack to applicant's solicitor (if service method = Solicitor Service)")
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
             .retries(120, 120));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemLinkWithBulkCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemLinkWithBulkCase.java
@@ -16,7 +16,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class SystemLinkWithBulkCase implements CCDConfig<CaseData, State, UserRole> {
@@ -32,6 +31,6 @@ public class SystemLinkWithBulkCase implements CCDConfig<CaseData, State, UserRo
             .name("Link with bulk case")
             .description("Linked with bulk case")
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyFinalOrderOverdue.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyFinalOrderOverdue.java
@@ -15,7 +15,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class SystemNotifyFinalOrderOverdue implements CCDConfig<CaseData, State, UserRole> {
@@ -30,6 +29,6 @@ public class SystemNotifyFinalOrderOverdue implements CCDConfig<CaseData, State,
             .name("Alert Applicant 1")
             .description("Alert Applicant 1 that Final Order request is overdue")
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR);
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR);
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyRespondentApplyFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyRespondentApplyFinalOrder.java
@@ -21,7 +21,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -44,7 +43,7 @@ public class SystemNotifyRespondentApplyFinalOrder implements CCDConfig<CaseData
             .name("Notify respondent final order")
             .description("Notify respondent that they can make a Final Order application")
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
             .retries(120, 120)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressCaseToAosOverdue.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressCaseToAosOverdue.java
@@ -24,7 +24,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class SystemProgressCaseToAosOverdue implements CCDConfig<CaseData, State, UserRole> {
@@ -48,7 +47,7 @@ public class SystemProgressCaseToAosOverdue implements CCDConfig<CaseData, State
             .name("AoS not received within SLA")
             .description("AoS not received within SLA")
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
             .aboutToSubmitCallback(this::aboutToSubmit));
     }
 

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressCaseToAwaitingFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressCaseToAwaitingFinalOrder.java
@@ -22,7 +22,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -45,7 +44,7 @@ public class SystemProgressCaseToAwaitingFinalOrder implements CCDConfig<CaseDat
             .description("Progress case to Awaiting Final Order")
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(final CaseDetails<CaseData, State> details,

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressHeldCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemProgressHeldCase.java
@@ -22,7 +22,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -45,7 +44,7 @@ public class SystemProgressHeldCase implements CCDConfig<CaseData, State, UserRo
             .description("Progress held case to Awaiting Conditional Order")
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(final CaseDetails<CaseData, State> details,

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemPronounceCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemPronounceCase.java
@@ -24,7 +24,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 @Slf4j
@@ -49,7 +48,7 @@ public class SystemPronounceCase implements CCDConfig<CaseData, State, UserRole>
                 .name("System pronounce case")
                 .description("System pronounce case")
                 .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-                .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
+                .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
                 .aboutToSubmitCallback(this::aboutToSubmit)
         );
     }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicantsApplyForFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicantsApplyForFinalOrder.java
@@ -20,7 +20,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class SystemRemindApplicantsApplyForFinalOrder implements CCDConfig<CaseData, State, UserRole> {
@@ -42,7 +41,7 @@ public class SystemRemindApplicantsApplyForFinalOrder implements CCDConfig<CaseD
             .name("Remind Applicants Final Order")
             .description("Remind Applicant(s) that they can apply for a Final Order")
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
             .retries(120, 120)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemoveBulkCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemoveBulkCase.java
@@ -17,7 +17,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE_DELETE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class SystemRemoveBulkCase implements CCDConfig<CaseData, State, UserRole> {
@@ -33,6 +32,6 @@ public class SystemRemoveBulkCase implements CCDConfig<CaseData, State, UserRole
             .name("System remove bulk case")
             .description("System remove bulk case")
             .grant(CREATE_READ_UPDATE_DELETE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemUpdateCaseWithCourtHearing.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemUpdateCaseWithCourtHearing.java
@@ -23,7 +23,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 import static uk.gov.hmcts.divorce.divorcecase.task.CaseTaskRunner.caseTasks;
 
 @Component
@@ -51,7 +50,7 @@ public class SystemUpdateCaseWithCourtHearing implements CCDConfig<CaseData, Sta
             .description("Update case with court hearing")
             .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(final CaseDetails<CaseData, State> details,

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemUpdateCaseWithPronouncementJudge.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemUpdateCaseWithPronouncementJudge.java
@@ -15,7 +15,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.READ;
 
 @Component
 public class SystemUpdateCaseWithPronouncementJudge implements CCDConfig<CaseData, State, UserRole> {
@@ -30,6 +29,6 @@ public class SystemUpdateCaseWithPronouncementJudge implements CCDConfig<CaseDat
             .name("Update pronouncement judge")
             .description("Update case with pronouncement judge")
             .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-            .grant(READ, SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
+            .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR));
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/divorcecase/NoFaultDivorceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/divorcecase/NoFaultDivorceTest.java
@@ -3,37 +3,17 @@ package uk.gov.hmcts.divorce.divorcecase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
-import uk.gov.hmcts.divorce.common.AddSystemUpdateRole;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 
-import java.util.Set;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.ccd.sdk.api.Permission.C;
-import static uk.gov.hmcts.ccd.sdk.api.Permission.R;
-import static uk.gov.hmcts.ccd.sdk.api.Permission.U;
-import static uk.gov.hmcts.divorce.divorcecase.model.State.Draft;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CITIZEN;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
-import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 
 @ExtendWith(MockitoExtension.class)
 public class NoFaultDivorceTest {
-
-    @Mock
-    private AddSystemUpdateRole addSystemUpdateRole;
 
     @InjectMocks
     private NoFaultDivorce noFaultDivorce;
@@ -42,58 +22,10 @@ public class NoFaultDivorceTest {
     void shouldAddSystemUpdateUserAccessToDraftStateWhenEnvironmentIsAat() {
         final ConfigBuilderImpl<CaseData, State, UserRole> configBuilder = createCaseDataConfigBuilder();
 
-        when(addSystemUpdateRole.isEnvironmentAat()).thenReturn(true);
-
         noFaultDivorce.configure(configBuilder);
 
         assertThat(configBuilder.build().getCaseType()).isEqualTo("NFD");
 
-        assertThat(configBuilder.build().getStateRolePermissions().columnMap().get(CITIZEN))
-            .contains(entry(Draft, Set.of(C, R, U)));
-
-        assertThat(configBuilder.build().getStateRolePermissions().columnMap().get(SYSTEMUPDATE))
-            .contains(entry(Draft, Set.of(C, R, U)));
-
-        assertThat(configBuilder.build().getStateRolePermissions().columnMap().get(SOLICITOR))
-            .contains(entry(Draft, Set.of(C, R, U)));
-
-        assertThat(configBuilder.build().getStateRolePermissions().columnMap().get(SUPER_USER))
-            .contains(entry(Draft, Set.of(C, R, U)));
-
-        assertThat(configBuilder.build().getStateRolePermissions().columnMap().get(LEGAL_ADVISOR))
-            .contains(entry(Draft, Set.of(R)));
-
-        assertThat(configBuilder.build().getStateRolePermissions().columnMap().get(CASE_WORKER))
-            .contains(entry(Draft, Set.of(R)));
-
-        verify(addSystemUpdateRole).isEnvironmentAat();
     }
 
-    @Test
-    void shouldNotAddSystemUpdateUserAccessToDraftStateWhenEnvironmentIsNotAat() {
-        final ConfigBuilderImpl<CaseData, State, UserRole> configBuilder = createCaseDataConfigBuilder();
-
-        when(addSystemUpdateRole.isEnvironmentAat()).thenReturn(false);
-
-        noFaultDivorce.configure(configBuilder);
-
-        assertThat(configBuilder.build().getCaseType()).isEqualTo("NFD");
-
-        assertThat(configBuilder.build().getStateRolePermissions().columnMap().get(CITIZEN))
-            .contains(entry(Draft, Set.of(C, R, U)));
-
-        assertThat(configBuilder.build().getStateRolePermissions().columnMap().get(SOLICITOR))
-            .contains(entry(Draft, Set.of(C, R, U)));
-
-        assertThat(configBuilder.build().getStateRolePermissions().columnMap().get(SUPER_USER))
-            .contains(entry(Draft, Set.of(C, R, U)));
-
-        assertThat(configBuilder.build().getStateRolePermissions().columnMap().get(LEGAL_ADVISOR))
-            .contains(entry(Draft, Set.of(R)));
-
-        assertThat(configBuilder.build().getStateRolePermissions().columnMap().get(CASE_WORKER))
-            .contains(entry(Draft, Set.of(R)));
-
-        verify(addSystemUpdateRole).isEnvironmentAat();
-    }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorCreateApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorCreateApplicationTest.java
@@ -98,7 +98,6 @@ class SolicitorCreateApplicationTest {
             .put(SYSTEMUPDATE, R)
             .put(SYSTEMUPDATE, U)
             .put(SUPER_USER, R)
-            .put(SUPER_USER, U)
             .put(CASE_WORKER, R)
             .put(LEGAL_ADVISOR, R)
             .build();


### PR DESCRIPTION
Switch READ only event access to use history only to avoid granting state access where it's not wanted but keep access to event history.
