### PR TITLE
Fix marriage date parsing and include empty check for solicitor name

### DIFF
--- a/src/integrationTest/resources/d8-transformation-success-response.json
+++ b/src/integrationTest/resources/d8-transformation-success-response.json
@@ -94,7 +94,7 @@
       ],
       "applicant1NameDifferentToMarriageCertificate": "Yes",
       "applicant1LegalProceedingsDetails": "Case Number(s):",
-      "applicant2SolicitorRepresented": "Yes",
+      "applicant2SolicitorRepresented": "No",
       "marriagePlaceOfMarriage": "London",
       "applicant1FinancialOrder": "Yes",
       "applicant2FinancialOrdersFor": [

--- a/src/integrationTest/resources/d8s-transformation-success-response.json
+++ b/src/integrationTest/resources/d8s-transformation-success-response.json
@@ -115,7 +115,7 @@
       "paperFormSummaryApplicant1FinancialOrdersFor": [
         "children"
       ],
-      "applicant2SolicitorRepresented": "Yes",
+      "applicant2SolicitorRepresented": "No",
       "applicant1StatementOfTruth": "Yes",
       "applicant2Address": {
         "AddressLine1": "some street",

--- a/src/integrationTest/resources/transformation-success-warning-response.json
+++ b/src/integrationTest/resources/transformation-success-warning-response.json
@@ -94,7 +94,7 @@
       ],
       "applicant1NameDifferentToMarriageCertificate": "Yes",
       "applicant1LegalProceedingsDetails": "Case Number(s):",
-      "applicant2SolicitorRepresented": "Yes",
+      "applicant2SolicitorRepresented": "No",
       "marriagePlaceOfMarriage": "London",
       "applicant1FinancialOrder": "Yes",
       "applicant2FinancialOrdersFor": [

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/transformation/Applicant2Transformer.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/transformation/Applicant2Transformer.java
@@ -16,7 +16,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.BooleanUtils.toBoolean;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -73,7 +72,7 @@ public class Applicant2Transformer implements Function<TransformationDetails, Tr
             .lastName(ocrDataFields.getRespondentOrApplicant2LastName())
             .nameDifferentToMarriageCertificate(nameDifferentToMarriageCertificate)
             .nameChangedHowOtherDetails(ocrDataFields.getRespondentOrApplicant2WhyMarriedNameChanged())
-            .solicitorRepresented(from(!isNull(ocrDataFields.getRespondentOrApplicant2SolicitorName())))
+            .solicitorRepresented(from(isNotEmpty(ocrDataFields.getRespondentOrApplicant2SolicitorName())))
             .address(
                 AddressGlobalUK
                     .builder()

--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/transformation/MarriageDetailsTransformer.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/transformation/MarriageDetailsTransformer.java
@@ -124,7 +124,7 @@ public class MarriageDetailsTransformer implements Function<TransformationDetail
                         ocrDataFields.getDateOfMarriageOrCivilPartnershipMonth().toUpperCase(Locale.ROOT)) //format "June"
                     .getValue();
                 int yearParsed = Integer.parseInt(ocrDataFields.getDateOfMarriageOrCivilPartnershipYear()); // format "2022"
-                return LocalDate.of(yearParsed, dayParsed, monthParsed);
+                return LocalDate.of(yearParsed, monthParsed, dayParsed);
             } catch (DateTimeException | IllegalArgumentException exception) {
                 // log and add validation it as will be corrected manually the caseworker
                 warnings.add("Please review marriage date in the scanned form");

--- a/src/test/resources/transformation/output/applicant2-transformed-warnings.json
+++ b/src/test/resources/transformation/output/applicant2-transformed-warnings.json
@@ -23,7 +23,7 @@
   "Gender": null,
   "ContactDetailsType": null,
   "CorrespondenceAddress": null,
-  "SolicitorRepresented": "Yes",
+  "SolicitorRepresented": "No",
   "SolicitorName": "",
   "SolicitorReference": "",
   "SolicitorPhone": null,

--- a/src/test/resources/transformation/output/applicant2-transformed.json
+++ b/src/test/resources/transformation/output/applicant2-transformed.json
@@ -23,7 +23,7 @@
   "Gender": null,
   "ContactDetailsType": null,
   "CorrespondenceAddress": null,
-  "SolicitorRepresented": "Yes",
+  "SolicitorRepresented": "No",
   "SolicitorName": "",
   "SolicitorReference": "",
   "SolicitorPhone": null,


### PR DESCRIPTION
- When creating local date for marriage date pass the month and day parameter in correct order.

- When checking solicitor name to derive if applicant 2 is represented include empty as well otherwise if values is empty it is being treated as solicitor is represented.