### PR TITLE
nfdiv-1833: prevent awaitingHWFDecision state notification

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenSubmitApplicationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenSubmitApplicationIT.java
@@ -44,7 +44,6 @@ import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.citizen.event.CitizenSubmitApplication.CITIZEN_SUBMIT;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Draft;
-import static uk.gov.hmcts.divorce.notification.EmailTemplateName.APPLICATION_SUBMITTED;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.OUTSTANDING_ACTIONS;
 import static uk.gov.hmcts.divorce.testutil.FeesWireMock.stubForFeesLookup;
 import static uk.gov.hmcts.divorce.testutil.FeesWireMock.stubForFeesNotFound;

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenSubmitApplicationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenSubmitApplicationIT.java
@@ -131,9 +131,6 @@ public class CitizenSubmitApplicationIT {
             .getContentAsString();
 
         verify(notificationService)
-            .sendEmail(eq(TEST_USER_EMAIL), eq(APPLICATION_SUBMITTED), anyMap(), eq(ENGLISH));
-
-        verify(notificationService)
             .sendEmail(eq(TEST_USER_EMAIL), eq(OUTSTANDING_ACTIONS), anyMap(), eq(ENGLISH));
 
         // marriageDate and payments.id are ignored using ${json-unit.ignore}

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/SendCitizenSubmissionNotifications.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/SendCitizenSubmissionNotifications.java
@@ -11,9 +11,6 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 
-import java.util.EnumSet;
-
-import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingHWFDecision;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Submitted;
 
 @Component
@@ -36,7 +33,7 @@ public class SendCitizenSubmissionNotifications implements CaseTask {
         final Long caseId = caseDetails.getId();
         final State state = caseDetails.getState();
 
-        if (EnumSet.of(Submitted, AwaitingHWFDecision).contains(state)) {
+        if (state == Submitted) {
             log.info("Sending application submitted notifications for case : {}", caseId);
             notificationDispatcher.send(applicationSubmittedNotification, caseData, caseId);
         }

--- a/src/test/java/uk/gov/hmcts/divorce/common/service/task/SendCitizenSubmissionNotificationsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/service/task/SendCitizenSubmissionNotificationsTest.java
@@ -52,7 +52,7 @@ class SendCitizenSubmissionNotificationsTest {
     }
 
     @Test
-    void shouldDispatchSubmittedNotificationsAndOutstandingActionNotificationsIfAwaitingHwfDecisionState() {
+    void shouldOnlyDispatchOutstandingNotificationIfAwaitingHwfDecisionState() {
 
         final CaseData caseData = caseData();
         final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
@@ -62,8 +62,8 @@ class SendCitizenSubmissionNotificationsTest {
 
         sendCitizenSubmissionNotifications.apply(caseDetails);
 
-        verify(notificationDispatcher).send(applicationSubmittedNotification, caseData, TEST_CASE_ID);
         verify(notificationDispatcher).send(applicationOutstandingActionNotification, caseData, TEST_CASE_ID);
+        verifyNoMoreInteractions(notificationDispatcher);
     }
 
     @Test
@@ -78,6 +78,7 @@ class SendCitizenSubmissionNotificationsTest {
         sendCitizenSubmissionNotifications.apply(caseDetails);
 
         verify(notificationDispatcher).send(applicationOutstandingActionNotification, caseData, TEST_CASE_ID);
+        verifyNoMoreInteractions(notificationDispatcher);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
- https://tools.hmcts.net/jira/browse/NFDIV-1833

### Change description ###
- prevent application-submitted notifications if AwaitingHWFDecision

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
