### PR TITLE
Bug fix - field jurisdictionReasonsJointHabitualWho not being set correctly

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/bulkscan/transformation/ApplicationTransformer.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkscan/transformation/ApplicationTransformer.java
@@ -94,13 +94,13 @@ public class ApplicationTransformer implements Function<TransformationDetails, T
         if (toBoolean(ocrDataFields.getJurisdictionReasonsRespHabitual())) {
             connections.add(APP_2_RESIDENT_SOLE);
         }
-        if (toBoolean(ocrDataFields.getJurisdictionReasonsJointHabitual())) {
-            if (APPLICANT_2.equalsIgnoreCase(ocrDataFields.getJurisdictionReasonsJointHabitualWho())) {
-                connections.add(APP_2_RESIDENT_JOINT);
-            } else if (APPLICANT_APPLICANT_1.equalsIgnoreCase(ocrDataFields.getJurisdictionReasonsJointHabitualWho())) {
-                connections.add(APP_1_RESIDENT_JOINT);
-            }
+
+        if (APPLICANT_2.equalsIgnoreCase(ocrDataFields.getJurisdictionReasonsJointHabitualWho())) {
+            connections.add(APP_2_RESIDENT_JOINT);
+        } else if (APPLICANT_APPLICANT_1.equalsIgnoreCase(ocrDataFields.getJurisdictionReasonsJointHabitualWho())) {
+            connections.add(APP_1_RESIDENT_JOINT);
         }
+
         if (toBoolean(ocrDataFields.getJurisdictionReasons1YrHabitual())) {
             connections.add(APP_1_RESIDENT_TWELVE_MONTHS);
         }

--- a/src/test/java/uk/gov/hmcts/divorce/bulkscan/transformation/ApplicationTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkscan/transformation/ApplicationTransformerTest.java
@@ -28,7 +28,9 @@ import static uk.gov.hmcts.divorce.divorcecase.model.ApplicationType.SOLE_APPLIC
 import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DISSOLUTION;
 import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DIVORCE;
 import static uk.gov.hmcts.divorce.divorcecase.model.JurisdictionConnections.APP_1_DOMICILED;
+import static uk.gov.hmcts.divorce.divorcecase.model.JurisdictionConnections.APP_1_RESIDENT_JOINT;
 import static uk.gov.hmcts.divorce.divorcecase.model.JurisdictionConnections.APP_2_DOMICILED;
+import static uk.gov.hmcts.divorce.divorcecase.model.JurisdictionConnections.APP_2_RESIDENT_JOINT;
 import static uk.gov.hmcts.divorce.divorcecase.model.JurisdictionConnections.RESIDUAL_JURISDICTION_CP;
 import static uk.gov.hmcts.divorce.testutil.ClockTestUtil.getExpectedLocalDateTime;
 import static uk.gov.hmcts.divorce.testutil.ClockTestUtil.setMockClock;
@@ -140,7 +142,7 @@ public class ApplicationTransformerTest {
 
         final var expectedApplication =
             jsonToObject("src/test/resources/transformation/output/application-transformed.json", Application.class);
-        expectedApplication.getJurisdiction().setConnections(Set.of(APP_1_DOMICILED, RESIDUAL_JURISDICTION_CP));
+        expectedApplication.getJurisdiction().setConnections(Set.of(APP_1_DOMICILED, APP_1_RESIDENT_JOINT, RESIDUAL_JURISDICTION_CP));
 
         assertThat(transformedOutput.getCaseData().getApplication())
             .usingRecursiveComparison()
@@ -168,7 +170,6 @@ public class ApplicationTransformerTest {
         dataFields.setJurisdictionReasonsBothPartiesLastHabitual(EMPTY);
         dataFields.setJurisdictionReasons6MonthsHabitual(EMPTY);
         dataFields.setJurisdictionReasonsBothPartiesDomiciled(EMPTY);
-        dataFields.setJurisdictionReasonsJointHabitual(EMPTY);
 
         final var caseData = CaseData.builder().applicationType(SOLE_APPLICATION).divorceOrDissolution(DIVORCE).build();
         final var transformationDetails =
@@ -184,7 +185,7 @@ public class ApplicationTransformerTest {
 
         final var expectedApplication =
             jsonToObject("src/test/resources/transformation/output/application-transformed.json", Application.class);
-        expectedApplication.getJurisdiction().setConnections(Set.of(APP_2_DOMICILED));
+        expectedApplication.getJurisdiction().setConnections(Set.of(APP_2_RESIDENT_JOINT, APP_2_DOMICILED));
 
         assertThat(transformedOutput.getCaseData().getApplication())
             .usingRecursiveComparison()


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/NFDIV-2007


### Change description ###
When jurisdictionReasonsJointHabitualWho has a value other thank blank,
then add that jurisdiction connection even if jurictionReasonsJointHabitual is
marked as false.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
