### PR TITLE
Wrap send to applicant1 notification with notificationDispatcher

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServiceApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServiceApplication.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.divorce.divorcecase.model.AlternativeService;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 
 import java.time.Clock;
 import java.time.LocalDate;
@@ -41,6 +42,9 @@ public class CaseworkerAlternativeServiceApplication implements CCDConfig<CaseDa
 
     @Autowired
     private GeneralApplicationReceivedNotification generalApplicationReceivedNotification;
+
+    @Autowired
+    private NotificationDispatcher notificationDispatcher;
 
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
@@ -72,7 +76,7 @@ public class CaseworkerAlternativeServiceApplication implements CCDConfig<CaseDa
 
         caseData.getAlternativeService().setReceivedServiceAddedDate(LocalDate.now(clock));
 
-        generalApplicationReceivedNotification.sendToApplicant1(caseData, details.getId());
+        notificationDispatcher.send(generalApplicationReceivedNotification, caseData, details.getId());
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(caseData)

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServiceApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerAlternativeServiceApplicationTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.divorce.divorcecase.model.ApplicationType;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 
 import java.time.Clock;
 
@@ -31,6 +32,9 @@ class CaseworkerAlternativeServiceApplicationTest {
 
     @Mock
     private GeneralApplicationReceivedNotification generalApplicationReceivedNotification;
+
+    @Mock
+    private NotificationDispatcher notificationDispatcher;
 
     @Mock
     private Clock clock;
@@ -58,7 +62,7 @@ class CaseworkerAlternativeServiceApplicationTest {
 
         caseworkerAlternativeServiceApplication.aboutToSubmit(caseDetails, null);
 
-        verify(generalApplicationReceivedNotification).sendToApplicant1(caseData, 1L);
+        verify(notificationDispatcher).send(generalApplicationReceivedNotification, caseData, caseDetails.getId());
     }
 
     private CaseData caseData() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
An error is showing in our test environment where it is missing
the applicants email address when sending a notification to applicant1.

After looking through the code we shouldn't call to send to applicant1
directly but rather wrap the call in the notificationDispatcher.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
