### PR TITLE
Fix missing condition to display applicant 2 financial orders on correct paper case

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/page/CorrectPaperCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/page/CorrectPaperCase.java
@@ -251,7 +251,7 @@ public class CorrectPaperCase implements CcdPageConfiguration {
                 "### ${labelContentRespondentsOrApplicant2s} financial order details", JOINT_APPLICATION)
                 .mandatory(Applicant::getFinancialOrder, JOINT_APPLICATION, null,
                 "Does ${labelContentTheApplicant2} wish to apply for a financial order?")
-                .mandatory(Applicant::getFinancialOrdersFor, "applicant2FinancialOrder=\"Yes\"")
+                .mandatory(Applicant::getFinancialOrdersFor, "applicant2FinancialOrder=\"Yes\" AND applicationType=\"jointApplication\"")
             .done();
     }
 


### PR DESCRIPTION
Fix below bug

<img width="362" alt="image" src="https://user-images.githubusercontent.com/13840402/161526116-a83a3641-b46b-4df8-9abb-acc897ec2a1f.png">
