### PR TITLE
 return an error if applicationType is null (xui refresh issue), to avoid NPE

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorCreateApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorCreateApplication.java
@@ -30,6 +30,7 @@ import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 
 import static java.util.Arrays.asList;
@@ -86,6 +87,13 @@ public class SolicitorCreateApplication implements CCDConfig<CaseData, State, Us
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(CaseDetails<CaseData, State> details,
                                                                        CaseDetails<CaseData, State> beforeDetails) {
         log.info("Solicitor create application about to submit callback invoked");
+
+        if (Objects.isNull(details.getData().getApplicationType())) {
+            log.error("Application type must be selected (cannot be null)");
+            return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .errors(List.of("Application type must be selected (cannot be null)"))
+                .build();
+        }
 
         final CaseDetails<CaseData, State> result = solicitorCreateApplicationService.aboutToSubmit(details);
 

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorCreateApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorCreateApplicationTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.Organisation;
 import uk.gov.hmcts.ccd.sdk.type.OrganisationPolicy;
 import uk.gov.hmcts.divorce.common.AddSystemUpdateRole;
@@ -151,5 +152,16 @@ class SolicitorCreateApplicationTest {
             authorization,
             caseId,
             "1");
+    }
+
+    @Test
+    void shouldReturnErrorIfApplicationTypeIsNull() {
+        final CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder()
+            .data(CaseData.builder().build())
+            .build();
+
+        AboutToStartOrSubmitResponse<CaseData, State> response = solicitorCreateApplication.aboutToSubmit(caseDetails, caseDetails);
+
+        assertThat(response.getErrors()).contains("Application type must be selected (cannot be null)");
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorCreateApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorCreateApplicationTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.Organisation;
 import uk.gov.hmcts.ccd.sdk.type.OrganisationPolicy;
 import uk.gov.hmcts.divorce.common.AddSystemUpdateRole;
+import uk.gov.hmcts.divorce.divorcecase.model.ApplicationType;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
@@ -113,12 +114,12 @@ class SolicitorCreateApplicationTest {
     @Test
     void shouldPopulateMissingRequirementsFieldsInCaseData() {
         final CaseData caseData = caseData();
+        caseData.setApplicationType(ApplicationType.SOLE_APPLICATION);
         final CaseDetails<CaseData, State> beforeDetails = new CaseDetails<>();
         final CaseDetails<CaseData, State> details = new CaseDetails<>();
         details.setData(caseData);
         details.setId(TEST_CASE_ID);
         details.setCreatedDate(LOCAL_DATE_TIME);
-
         when(solicitorCreateApplicationService.aboutToSubmit(details)).thenReturn(details);
 
         solicitorCreateApplication.aboutToSubmit(details, beforeDetails);


### PR DESCRIPTION
### Change description ###
- return an error if applicationType is null (xui refresh issue), to avoid NPE  

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

