### PR TITLE
Fix state transition when AOS documents is received and classified by  caseworker

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerOfflineDocumentVerifiedIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerOfflineDocumentVerifiedIT.java
@@ -39,7 +39,6 @@ import static uk.gov.hmcts.divorce.caseworker.event.CaseworkerOfflineDocumentVer
 import static uk.gov.hmcts.divorce.divorcecase.model.AcknowledgementOfService.OfflineDocumentReceived.AOS_D10;
 import static uk.gov.hmcts.divorce.divorcecase.model.AcknowledgementOfService.OfflineDocumentReceived.OTHER;
 import static uk.gov.hmcts.divorce.divorcecase.model.HowToRespondApplication.DISPUTE_DIVORCE;
-import static uk.gov.hmcts.divorce.divorcecase.model.State.AosDrafted;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.IssuedToBailiff;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.OfflineDocumentReceived;
 import static uk.gov.hmcts.divorce.testutil.ClockTestUtil.getExpectedLocalDate;

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerOfflineDocumentVerifiedIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerOfflineDocumentVerifiedIT.java
@@ -41,6 +41,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.AcknowledgementOfService.Of
 import static uk.gov.hmcts.divorce.divorcecase.model.HowToRespondApplication.DISPUTE_DIVORCE;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AosDrafted;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.IssuedToBailiff;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.OfflineDocumentReceived;
 import static uk.gov.hmcts.divorce.testutil.ClockTestUtil.getExpectedLocalDate;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.ABOUT_TO_START_URL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.ABOUT_TO_SUBMIT_URL;
@@ -152,7 +153,7 @@ public class CaseworkerOfflineDocumentVerifiedIT {
                 .header(AUTHORIZATION, TEST_SYSTEM_AUTHORISATION_TOKEN)
                 .content(
                     objectMapper.writeValueAsString(
-                        callbackRequest(caseData, CASEWORKER_OFFLINE_DOCUMENT_VERIFIED, AosDrafted.name())))
+                        callbackRequest(caseData, CASEWORKER_OFFLINE_DOCUMENT_VERIFIED, OfflineDocumentReceived.name())))
                 .accept(APPLICATION_JSON))
             .andReturn()
             .getResponse()

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerOfflineDocumentVerified.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerOfflineDocumentVerified.java
@@ -32,6 +32,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.AcknowledgementOfService.OfflineDocumentReceived.AOS_D10;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AosDrafted;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.OfflineDocumentReceived;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER_BULK_SCAN;
@@ -113,6 +114,8 @@ public class CaseworkerOfflineDocumentVerified implements CCDConfig<CaseData, St
         if (AOS_D10.equals(caseData.getAcknowledgementOfService().getTypeOfDocumentAttached())) {
 
             reclassifyAosScannedDocumentToRespondentAnswers(caseData);
+            // setting the status as drafted as AOS answers has been received and is being classified by caseworker
+            details.setState(AosDrafted);
 
             final CaseDetails<CaseData, State> response = submitAosService.submitOfflineAos(details);
             response.getData().getApplicant2().setOffline(YES);


### PR DESCRIPTION

### Change description ###

- Currently when Offline document verified event is triggered by the caseworker and document is AOS D10 then state is not transitioned as the task checks the status of case is AosDrafted.
- We are now setting it to AosDrafted once the scanned document is reclassified as D10.
- Integration test was passing as it was passing incorrect state in the request which is now fixed.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2319

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [x] README and other documentation has been updated / added (if needed)

