### PR TITLE
Add pba number null check to solicitor submit application event

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Application.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Application.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.lang.Integer.parseInt;
@@ -593,7 +594,8 @@ public class Application {
     }
 
     @JsonIgnore
-    public String getPbaNumber() {
-        return this.getPbaNumbers().getValue().getLabel();
+    public Optional<String> getPbaNumber() {
+        return Optional.ofNullable(pbaNumbers)
+            .map(dynamicList -> dynamicList.getValue().getLabel());
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/ApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/ApplicationTest.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.divorce.divorcecase.model;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.ccd.sdk.type.DynamicList;
+import uk.gov.hmcts.ccd.sdk.type.DynamicListElement;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.ccd.sdk.type.OrderSummary;
 import uk.gov.hmcts.divorce.payment.model.Payment;
@@ -9,6 +11,7 @@ import uk.gov.hmcts.divorce.payment.model.PaymentStatus;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Collections.emptyList;
@@ -360,6 +363,27 @@ class ApplicationTest {
         final Application application = Application.builder().build();
 
         assertThat(application.isHelpWithFeesApplication()).isFalse();
+    }
+
+    @Test
+    void shouldReturnOptionalPbaNumberIfPbaNumberIsPresent() {
+
+        final String pbaNumber = "123456";
+        final Application application = Application.builder()
+            .pbaNumbers(DynamicList.builder()
+                .value(DynamicListElement.builder().label(pbaNumber).build())
+                .build())
+            .build();
+
+        assertThat(application.getPbaNumber()).isEqualTo(Optional.of(pbaNumber));
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyIfPbaNumberIsNotPresent() {
+
+        final Application application = Application.builder().build();
+
+        assertThat(application.getPbaNumber()).isEqualTo(Optional.empty());
     }
 
     private ListValue<Payment> paymentValue(final Payment payment) {

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitApplicationTest.java
@@ -489,6 +489,27 @@ public class SolicitorSubmitApplicationTest {
         assertThat(response.getErrors()).containsExactly("Account balance insufficient");
     }
 
+    @Test
+    void shouldReturnErrorMessageIfPaymentMethodIsPbaAndPbaNumberIsNotPresent() {
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        final CaseDetails<CaseData, State> beforeCaseDetails = new CaseDetails<>();
+
+        final var caseData = validApplicant1CaseData();
+        caseData.getApplication().setSolSignStatementOfTruth(YES);
+        caseData.getApplication().setSolPaymentHowToPay(FEE_PAY_BY_ACCOUNT);
+        caseData.getApplication().setFeeAccountReference(FEE_ACCOUNT_REF);
+        caseData.getApplication().setApplicationFeeOrderSummary(orderSummary);
+
+        caseDetails.setData(caseData);
+        caseDetails.setId(TEST_CASE_ID);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response =
+            solicitorSubmitApplication.aboutToSubmit(caseDetails, beforeCaseDetails);
+
+        assertThat(response.getErrors())
+            .containsExactly("PBA number not present when payment method is 'Solicitor fee account (PBA)'");
+    }
+
     private void mockExpectedCaseDetails(CaseDetails<CaseData, State> caseDetails, CaseData caseData, State state) {
         final CaseDetails<CaseData, State> expectedCaseDetails = new CaseDetails<>();
         expectedCaseDetails.setData(caseData);


### PR DESCRIPTION
### Change description ###

On solicitor submit application event, if pay with PBA is selected then check PBA number is present
Log error if PBA number is null and return error message to user

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2413

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [x] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

