### PR TITLE
Remove additional DNS for frontend

### DIFF
--- a/charts/nfdiv-case-api/values.preview.template.yaml
+++ b/charts/nfdiv-case-api/values.preview.template.yaml
@@ -231,6 +231,8 @@ xui-mo-webapp:
 nfdiv-frontend:
   enabled: true
   nodejs:
+    registerAdditionalDns:
+      enabled: false
     imagePullPolicy: Always
     releaseNameOverride: ${SERVICE_NAME}-frontend
     image: hmctspublic.azurecr.io/nfdiv/frontend:latest #pr-xxxx


### PR DESCRIPTION
[Frontend is creating ](https://github.com/hmcts/nfdiv-frontend/blob/master/charts/nfdiv-frontend/values.yaml) an addiional DNS , this shouldn't be needed in preview. If needed, it has to be .internal . Currently its created as .aat.platform.hmcts.net.
