### PR TITLE
Handle confirm service and confirm alternative service in draft CO

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerConfirmAlternativeService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerConfirmAlternativeService.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.divorce.caseworker.service.task.SetHoldingDueDate;
 import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
+import uk.gov.hmcts.divorce.common.service.task.SetServiceConfirmed;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
@@ -32,6 +33,9 @@ public class CaseworkerConfirmAlternativeService implements CCDConfig<CaseData, 
     @Autowired
     private SetHoldingDueDate setHoldingDueDate;
 
+    @Autowired
+    private SetServiceConfirmed setServiceConfirmed;
+
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         new PageBuilder(configBuilder
@@ -54,7 +58,7 @@ public class CaseworkerConfirmAlternativeService implements CCDConfig<CaseData, 
 
         log.info("Caseworker confirm alternative service about to submit callback invoked with Case Id: {}", details.getId());
 
-        final CaseDetails<CaseData, State> updatedDetails = caseTasks(setHoldingDueDate).run(details);
+        final CaseDetails<CaseData, State> updatedDetails = caseTasks(setHoldingDueDate, setServiceConfirmed).run(details);
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(updatedDetails.getData())

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/DraftConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/DraftConditionalOrder.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.solicitor.service.task.AddLastAlternativeServiceDocumentLink;
 import uk.gov.hmcts.divorce.solicitor.service.task.AddMiniApplicationLink;
+import uk.gov.hmcts.divorce.solicitor.service.task.AddOfflineRespondentAnswersLink;
 import uk.gov.hmcts.divorce.solicitor.service.task.ProgressDraftConditionalOrderState;
 
 import java.util.List;
@@ -64,6 +65,9 @@ public class DraftConditionalOrder implements CCDConfig<CaseData, State, UserRol
 
     @Autowired
     private AddLastAlternativeServiceDocumentLink addLastAlternativeServiceDocumentLink;
+
+    @Autowired
+    private AddOfflineRespondentAnswersLink addOfflineRespondentAnswersLink;
 
     @Override
     public void configure(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
@@ -128,7 +132,8 @@ public class DraftConditionalOrder implements CCDConfig<CaseData, State, UserRol
             .data(caseTasks(
                 addMiniApplicationLink,
                 addLastAlternativeServiceDocumentLink,
-                setLatestBailiffApplicationStatus)
+                setLatestBailiffApplicationStatus,
+                addOfflineRespondentAnswersLink)
                 .run(details)
                 .getData())
             .build();

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/DraftConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/DraftConditionalOrder.java
@@ -27,6 +27,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
+import static uk.gov.hmcts.divorce.divorcecase.model.CaseDocuments.sortByNewest;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingConditionalOrder;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.ConditionalOrderDrafted;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.ConditionalOrderPending;
@@ -105,6 +106,11 @@ public class DraftConditionalOrder implements CCDConfig<CaseData, State, UserRol
         }
 
         data.getConditionalOrder().getConditionalOrderApplicant1Questions().setIsDrafted(YES);
+
+        data.getConditionalOrder().setProofOfServiceUploadDocuments(sortByNewest(
+            beforeDetails.getData().getConditionalOrder().getProofOfServiceUploadDocuments(),
+            data.getConditionalOrder().getProofOfServiceUploadDocuments()
+        ));
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(details.getData())

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/UpdateConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/UpdateConditionalOrder.java
@@ -1,8 +1,11 @@
 package uk.gov.hmcts.divorce.common.event;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.divorce.common.ccd.CcdPageConfiguration;
 import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
 import uk.gov.hmcts.divorce.common.event.page.ConditionalOrderReviewAoS;
@@ -16,6 +19,7 @@ import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static uk.gov.hmcts.divorce.divorcecase.model.CaseDocuments.sortByNewest;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.ConditionalOrderDrafted;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.ConditionalOrderPending;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_1_SOLICITOR;
@@ -25,6 +29,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 
+@Slf4j
 @Component
 public class UpdateConditionalOrder implements CCDConfig<CaseData, State, UserRole> {
     public static final String UPDATE_CONDITIONAL_ORDER = "update-conditional-order";
@@ -50,10 +55,28 @@ public class UpdateConditionalOrder implements CCDConfig<CaseData, State, UserRo
             .description("Update conditional order")
             .endButtonLabel("Save conditional order")
             .showCondition("coApplicant1IsDrafted=\"Yes\"")
+            .aboutToSubmitCallback(this::aboutToSubmit)
             .grant(CREATE_READ_UPDATE, APPLICANT_1_SOLICITOR, CREATOR)
             .grantHistoryOnly(
                 CASE_WORKER,
                 SUPER_USER,
                 LEGAL_ADVISOR));
+    }
+
+    public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(final CaseDetails<CaseData, State> details,
+                                                                       final CaseDetails<CaseData, State> beforeDetails) {
+
+        log.info("Update conditional order about to submit callback invoked for Case Id: {}", details.getId());
+
+        final CaseData caseData = details.getData();
+
+        caseData.getConditionalOrder().setProofOfServiceUploadDocuments(sortByNewest(
+            beforeDetails.getData().getConditionalOrder().getProofOfServiceUploadDocuments(),
+            caseData.getConditionalOrder().getProofOfServiceUploadDocuments()
+        ));
+
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(details.getData())
+            .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/UpdateConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/UpdateConditionalOrder.java
@@ -32,6 +32,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_R
 @Slf4j
 @Component
 public class UpdateConditionalOrder implements CCDConfig<CaseData, State, UserRole> {
+
     public static final String UPDATE_CONDITIONAL_ORDER = "update-conditional-order";
 
     private final List<CcdPageConfiguration> pages = asList(

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/page/ConditionalOrderReviewAoS.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/page/ConditionalOrderReviewAoS.java
@@ -43,13 +43,14 @@ public class ConditionalOrderReviewAoS implements CcdPageConfiguration {
                 .readonly(ConditionalOrder::getLastAlternativeServiceDocumentLink,
                     " applicationType=\"soleApplication\" AND dateAosSubmitted!=\"*\" AND coServiceConfirmed!=\"Yes\"")
                 .readonly(ConditionalOrder::getRespondentAnswersLink,
-                    "applicationType=\"soleApplication\" AND dateAosSubmitted=\"*\" AND coServiceConfirmed!=\"Yes\"")
+                    "applicationType=\"soleApplication\" AND dateAosSubmitted=\"*\"")
                 .readonly(ConditionalOrder::getServiceConfirmed, NEVER_SHOW)
                 .optionalWithoutDefaultValue(ConditionalOrder::getProofOfServiceUploadDocuments,
-                    "applicationType=\"soleApplication\" AND dateAosSubmitted=\"*\" AND coServiceConfirmed=\"Yes\"",
+                    "applicationType=\"soleApplication\" AND dateAosSubmitted!=\"*\" AND coServiceConfirmed=\"Yes\"",
                     "Please upload proof of service below")
                 .complex(ConditionalOrder::getConditionalOrderApplicant1Questions)
-                .mandatory(ConditionalOrderQuestions::getApplyForConditionalOrder)
+                    .mandatory(ConditionalOrderQuestions::getApplyForConditionalOrder)
+                    .done()
                 .done()
             .label(
                 "ConditionalOrderReviewAoSNo",

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/page/ConditionalOrderReviewAoS.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/page/ConditionalOrderReviewAoS.java
@@ -26,6 +26,7 @@ public class ConditionalOrderReviewAoS implements CcdPageConfiguration {
     public void addTo(PageBuilder pageBuilder) {
         pageBuilder
             .page("ConditionalOrderReviewAoS", this::midEvent)
+            .pageLabel("Draft Conditional Order")
             .readonlyNoSummary(CaseData::getApplicationType, NEVER_SHOW)
             .complex(CaseData::getLabelContent)
                 .readonlyNoSummary(LabelContent::getUnionType, NEVER_SHOW)
@@ -40,11 +41,15 @@ public class ConditionalOrderReviewAoS implements CcdPageConfiguration {
                 .readonly(ConditionalOrder::getCertificateOfServiceDate,
                     "coLastApprovedServiceApplicationIsBailiffApplication=\"Yes\"")
                 .readonly(ConditionalOrder::getLastAlternativeServiceDocumentLink,
-                " applicationType=\"soleApplication\" AND dateAosSubmitted!=\"*\"")
+                    " applicationType=\"soleApplication\" AND dateAosSubmitted!=\"*\" AND coServiceConfirmed!=\"Yes\"")
                 .readonly(ConditionalOrder::getRespondentAnswersLink,
-                    "applicationType=\"soleApplication\" AND dateAosSubmitted=\"*\"")
+                    "applicationType=\"soleApplication\" AND dateAosSubmitted=\"*\" AND coServiceConfirmed!=\"Yes\"")
+                .readonly(ConditionalOrder::getServiceConfirmed, NEVER_SHOW)
+                .optionalWithoutDefaultValue(ConditionalOrder::getProofOfServiceUploadDocuments,
+                    "applicationType=\"soleApplication\" AND dateAosSubmitted=\"*\" AND coServiceConfirmed=\"Yes\"",
+                    "Please upload proof of service below")
                 .complex(ConditionalOrder::getConditionalOrderApplicant1Questions)
-                    .mandatory(ConditionalOrderQuestions::getApplyForConditionalOrder)
+                .mandatory(ConditionalOrderQuestions::getApplyForConditionalOrder)
                 .done()
             .label(
                 "ConditionalOrderReviewAoSNo",

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/SetServiceConfirmed.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/SetServiceConfirmed.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.divorce.common.service.task;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
+
+@Component
+@Slf4j
+public class SetServiceConfirmed implements CaseTask {
+
+    @Override
+    public CaseDetails<CaseData, State> apply(final CaseDetails<CaseData, State> caseDetails) {
+
+        log.info("Setting Service Confirmed.  Case ID: {}", caseDetails.getId());
+        caseDetails.getData().getConditionalOrder().setServiceConfirmed(YES);
+
+        return caseDetails;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDocuments.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDocuments.java
@@ -189,14 +189,24 @@ public class CaseDocuments {
                 .anyMatch(beforeValue -> Objects.equals(beforeValue.getId(), afterValue.getId())));
     }
 
-    @JsonIgnore
-    public Optional<Document> getFirstGeneratedDocumentLinkWith(final DocumentType documentType) {
-        return Stream.ofNullable(getDocumentsGenerated())
+    public static Optional<Document> getFirstDocumentLink(final List<ListValue<DivorceDocument>> documents,
+                                                          final DocumentType documentType) {
+        return Stream.ofNullable(documents)
             .flatMap(java.util.Collection::stream)
             .map(ListValue::getValue)
             .filter(divorceDocument -> documentType == divorceDocument.getDocumentType())
             .map(DivorceDocument::getDocumentLink)
             .findFirst();
+    }
+
+    @JsonIgnore
+    public Optional<Document> getFirstGeneratedDocumentLinkWith(final DocumentType documentType) {
+        return getFirstDocumentLink(getDocumentsGenerated(), documentType);
+    }
+
+    @JsonIgnore
+    public Optional<Document> getFirstUploadedDocumentLinkWith(final DocumentType documentType) {
+        return getFirstDocumentLink(getDocumentsUploaded(), documentType);
     }
 
     @JsonIgnore
@@ -206,7 +216,7 @@ public class CaseDocuments {
                 .removeIf(document -> documentType.equals(document.getValue().getDocumentType()));
         }
     }
-    
+
     public Optional<ListValue<DivorceDocument>> getDocumentGeneratedWithType(final DocumentType documentType) {
         return !isEmpty(this.getDocumentsGenerated())
             ? this.getDocumentsGenerated().stream()

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/ConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/ConditionalOrder.java
@@ -245,6 +245,17 @@ public class ConditionalOrder {
     )
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate rescindedDate;
+    @CCD(
+        label = "Service Confirmed"
+    )
+    private YesOrNo serviceConfirmed;
+
+    @CCD(
+        label = "Documents uploaded for Proof of Service ",
+        typeOverride = Collection,
+        typeParameterOverride = "DivorceDocument"
+    )
+    private List<ListValue<DivorceDocument>> proofOfServiceUploadDocuments;
 
     @CCD(
         label = "Is latest approved service application a bailiff application?"

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/ConditionalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/ConditionalOrder.java
@@ -251,7 +251,7 @@ public class ConditionalOrder {
     private YesOrNo serviceConfirmed;
 
     @CCD(
-        label = "Documents uploaded for Proof of Service ",
+        label = "Documents uploaded for Proof of Service",
         typeOverride = Collection,
         typeParameterOverride = "DivorceDocument"
     )

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
@@ -170,7 +170,8 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
             .field("documentsUploaded")
             .field(CaseData::getGeneralEmails)
             .field("certificateOfServiceDocument")
-            .field("coCertificateOfEntitlementDocument");
+            .field("coCertificateOfEntitlementDocument")
+            .field("coProofOfServiceUploadDocuments");
     }
 
     private void buildCorrespondenceTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitConfirmService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitConfirmService.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.common.service.task.SetServiceConfirmed;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.solicitor.service.task.SetConfirmServiceDueDate;
@@ -16,9 +17,13 @@ public class SolicitorSubmitConfirmService {
     @Autowired
     private SetConfirmServiceDueDate setConfirmServiceDueDate;
 
+    @Autowired
+    private SetServiceConfirmed setServiceConfirmed;
+
     public CaseDetails<CaseData, State> submitConfirmService(final CaseDetails<CaseData, State> caseDetails) {
         return caseTasks(
-            setConfirmServiceDueDate
+            setConfirmServiceDueDate,
+            setServiceConfirmed
         ).run(caseDetails);
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/service/task/AddOfflineRespondentAnswersLink.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/service/task/AddOfflineRespondentAnswersLink.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.divorce.solicitor.service.task;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import static uk.gov.hmcts.divorce.document.model.DocumentType.RESPONDENT_ANSWERS;
+
+@Component
+public class AddOfflineRespondentAnswersLink implements CaseTask {
+
+    @Override
+    public CaseDetails<CaseData, State> apply(final CaseDetails<CaseData, State> caseDetails) {
+
+        final CaseData caseData = caseDetails.getData();
+
+        caseData.getDocuments().getFirstUploadedDocumentLinkWith(RESPONDENT_ANSWERS)
+            .ifPresent(document -> caseData.getConditionalOrder().setRespondentAnswersLink(document));
+
+        return caseDetails;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerConfirmAlternativeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerConfirmAlternativeServiceTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.divorce.caseworker.service.task.SetHoldingDueDate;
+import uk.gov.hmcts.divorce.common.service.task.SetServiceConfirmed;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
@@ -29,6 +30,9 @@ class CaseworkerConfirmAlternativeServiceTest {
     @Mock
     private SetHoldingDueDate setHoldingDueDate;
 
+    @Mock
+    private SetServiceConfirmed setServiceConfirmed;
+
     @InjectMocks
     private CaseworkerConfirmAlternativeService caseworkerConfirmAlternativeService;
 
@@ -44,7 +48,7 @@ class CaseworkerConfirmAlternativeServiceTest {
     }
 
     @Test
-    void shouldCallSetHoldingDueDateTaskOnAboutToSubmit() {
+    void shouldCallSetHoldingDueDateAndSetServiceConfirmedTaskOnAboutToSubmit() {
 
         final CaseData caseData = caseData();
         final CaseData updatedCaseData = caseData();
@@ -56,7 +60,8 @@ class CaseworkerConfirmAlternativeServiceTest {
         final CaseDetails<CaseData, State> updatedCaseDetails = new CaseDetails<>();
         updatedCaseDetails.setData(updatedCaseData);
 
-        when(setHoldingDueDate.apply(caseDetails)).thenReturn(updatedCaseDetails);
+        when(setHoldingDueDate.apply(caseDetails)).thenReturn(caseDetails);
+        when(setServiceConfirmed.apply(caseDetails)).thenReturn(updatedCaseDetails);
 
         final AboutToStartOrSubmitResponse<CaseData, State> response = caseworkerConfirmAlternativeService.aboutToSubmit(
             caseDetails,
@@ -64,5 +69,6 @@ class CaseworkerConfirmAlternativeServiceTest {
 
         assertThat(response.getData()).isEqualTo(updatedCaseData);
         verify(setHoldingDueDate).apply(caseDetails);
+        verify(setServiceConfirmed).apply(caseDetails);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/common/event/DraftConditionalOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/event/DraftConditionalOrderTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.solicitor.service.task.AddLastAlternativeServiceDocumentLink;
 import uk.gov.hmcts.divorce.solicitor.service.task.AddMiniApplicationLink;
+import uk.gov.hmcts.divorce.solicitor.service.task.AddOfflineRespondentAnswersLink;
 import uk.gov.hmcts.divorce.solicitor.service.task.ProgressDraftConditionalOrderState;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,6 +44,9 @@ class DraftConditionalOrderTest {
 
     @Mock
     private SetLatestBailiffApplicationStatus setLatestBailiffApplicationStatus;
+
+    @Mock
+    private AddOfflineRespondentAnswersLink addOfflineRespondentAnswersLink;
 
     @InjectMocks
     private DraftConditionalOrder draftConditionalOrder;
@@ -137,7 +141,8 @@ class DraftConditionalOrderTest {
 
         when(addMiniApplicationLink.apply(caseDetails)).thenReturn(caseDetails);
         when(addLastAlternativeServiceDocumentLink.apply(caseDetails)).thenReturn(caseDetails);
-        when(setLatestBailiffApplicationStatus.apply(caseDetails)).thenReturn(updateCaseDetails);
+        when(setLatestBailiffApplicationStatus.apply(caseDetails)).thenReturn(caseDetails);
+        when(addOfflineRespondentAnswersLink.apply(caseDetails)).thenReturn(updateCaseDetails);
 
         final AboutToStartOrSubmitResponse<CaseData, State> response = draftConditionalOrder.aboutToStart(caseDetails);
 
@@ -146,5 +151,6 @@ class DraftConditionalOrderTest {
         verify(addMiniApplicationLink).apply(caseDetails);
         verify(addLastAlternativeServiceDocumentLink).apply(caseDetails);
         verify(setLatestBailiffApplicationStatus).apply(caseDetails);
+        verify(addOfflineRespondentAnswersLink).apply(caseDetails);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/common/event/DraftConditionalOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/event/DraftConditionalOrderTest.java
@@ -9,17 +9,22 @@ import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.divorce.common.service.task.SetLatestBailiffApplicationStatus;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrder;
 import uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrderQuestions;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.divorce.document.model.DivorceDocument;
 import uk.gov.hmcts.divorce.solicitor.service.task.AddLastAlternativeServiceDocumentLink;
 import uk.gov.hmcts.divorce.solicitor.service.task.AddMiniApplicationLink;
 import uk.gov.hmcts.divorce.solicitor.service.task.AddOfflineRespondentAnswersLink;
 import uk.gov.hmcts.divorce.solicitor.service.task.ProgressDraftConditionalOrderState;
 
+import java.util.List;
+
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,8 +32,14 @@ import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.common.event.DraftConditionalOrder.DRAFT_CONDITIONAL_ORDER;
 import static uk.gov.hmcts.divorce.divorcecase.model.ApplicationType.JOINT_APPLICATION;
+import static uk.gov.hmcts.divorce.divorcecase.model.ApplicationType.SOLE_APPLICATION;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.CERTIFICATE_OF_SERVICE;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.LOCAL_DATE_TIME;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getDivorceDocumentListValue;
 
 @ExtendWith(MockitoExtension.class)
 class DraftConditionalOrderTest {
@@ -152,5 +163,89 @@ class DraftConditionalOrderTest {
         verify(addLastAlternativeServiceDocumentLink).apply(caseDetails);
         verify(setLatestBailiffApplicationStatus).apply(caseDetails);
         verify(addOfflineRespondentAnswersLink).apply(caseDetails);
+    }
+
+    @Test
+    void shouldReturnProofOfServiceUploadDocumentsInDescendingOrderWhenNewDocumentsAreAdded() {
+
+        final ListValue<DivorceDocument> doc1 = getDivorceDocumentListValue(
+            "http://localhost:4200/assets/59a54ccc-979f-11eb-a8b3-0242ac130003",
+            "certificateOfCService.pdf",
+            CERTIFICATE_OF_SERVICE);
+
+        final ListValue<DivorceDocument> doc2 = getDivorceDocumentListValue(
+            "http://localhost:4200/assets/59a54ccc-979f-11eb-a8b3-0242ac130004",
+            "certificateOfCService2.pdf",
+            CERTIFICATE_OF_SERVICE);
+
+        final var previousCaseData = caseData();
+        previousCaseData.getConditionalOrder().setProofOfServiceUploadDocuments(singletonList(doc1));
+
+        final CaseDetails<CaseData, State> previousCaseDetails = new CaseDetails<>();
+        previousCaseDetails.setData(previousCaseData);
+        previousCaseDetails.setId(TEST_CASE_ID);
+        previousCaseDetails.setCreatedDate(LOCAL_DATE_TIME);
+
+        final var newCaseData = caseData();
+        newCaseData.setApplicationType(SOLE_APPLICATION);
+        newCaseData.getConditionalOrder().setProofOfServiceUploadDocuments(List.of(doc1, doc2));
+
+        final CaseDetails<CaseData, State> newCaseDetails = new CaseDetails<>();
+        newCaseDetails.setData(newCaseData);
+        newCaseDetails.setId(TEST_CASE_ID);
+        newCaseDetails.setCreatedDate(LOCAL_DATE_TIME);
+
+        when(progressDraftConditionalOrderState.apply(newCaseDetails)).thenReturn(newCaseDetails);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response =
+            draftConditionalOrder.aboutToSubmit(newCaseDetails, previousCaseDetails);
+
+        final List<ListValue<DivorceDocument>> proofOfServiceUploadDocuments = response
+            .getData()
+            .getConditionalOrder()
+            .getProofOfServiceUploadDocuments();
+
+        assertThat(proofOfServiceUploadDocuments).hasSize(2);
+        assertThat(proofOfServiceUploadDocuments.get(0).getValue()).isSameAs(doc2.getValue());
+        assertThat(proofOfServiceUploadDocuments.get(1).getValue()).isSameAs(doc1.getValue());
+    }
+
+    @Test
+    void shouldSkipSortingProofOfServiceUploadDocumentsWhenNoNewDocumentsAreAdded() {
+
+        final ListValue<DivorceDocument> doc1 = getDivorceDocumentListValue(
+            "http://localhost:4200/assets/59a54ccc-979f-11eb-a8b3-0242ac130003",
+            "certificateOfCService.pdf",
+            CERTIFICATE_OF_SERVICE);
+
+        final var previousCaseData = caseData();
+        previousCaseData.getConditionalOrder().setProofOfServiceUploadDocuments(singletonList(doc1));
+
+        final CaseDetails<CaseData, State> previousCaseDetails = new CaseDetails<>();
+        previousCaseDetails.setData(previousCaseData);
+        previousCaseDetails.setId(TEST_CASE_ID);
+        previousCaseDetails.setCreatedDate(LOCAL_DATE_TIME);
+
+        final var newCaseData = caseData();
+        newCaseData.setApplicationType(SOLE_APPLICATION);
+        newCaseData.getConditionalOrder().setProofOfServiceUploadDocuments(singletonList(doc1));
+
+        final CaseDetails<CaseData, State> newCaseDetails = new CaseDetails<>();
+        newCaseDetails.setData(newCaseData);
+        newCaseDetails.setId(TEST_CASE_ID);
+        newCaseDetails.setCreatedDate(LOCAL_DATE_TIME);
+
+        when(progressDraftConditionalOrderState.apply(newCaseDetails)).thenReturn(newCaseDetails);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response =
+            draftConditionalOrder.aboutToSubmit(newCaseDetails, previousCaseDetails);
+
+        final List<ListValue<DivorceDocument>> proofOfServiceUploadDocuments = response
+            .getData()
+            .getConditionalOrder()
+            .getProofOfServiceUploadDocuments();
+
+        assertThat(proofOfServiceUploadDocuments).hasSize(1);
+        assertThat(proofOfServiceUploadDocuments.get(0).getValue()).isSameAs(doc1.getValue());
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/common/event/UpdateConditionalOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/event/UpdateConditionalOrderTest.java
@@ -5,15 +5,27 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.divorce.document.model.DivorceDocument;
 
+import java.util.List;
+
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.divorce.common.event.UpdateConditionalOrder.UPDATE_CONDITIONAL_ORDER;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.CERTIFICATE_OF_SERVICE;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.LOCAL_DATE_TIME;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getDivorceDocumentListValue;
 
 @ExtendWith(MockitoExtension.class)
 class UpdateConditionalOrderTest {
@@ -29,5 +41,77 @@ class UpdateConditionalOrderTest {
         assertThat(getEventsFrom(configBuilder).values())
             .extracting(Event::getId)
             .contains(UPDATE_CONDITIONAL_ORDER);
+    }
+
+    @Test
+    void shouldReturnProofOfServiceUploadDocumentsInDescendingOrderWhenNewDocumentsAreAdded() {
+
+        final ListValue<DivorceDocument> doc1 =
+            getDivorceDocumentListValue("http://localhost:4200/assets/59a54ccc-979f-11eb-a8b3-0242ac130003", "certificateOfCService.pdf", CERTIFICATE_OF_SERVICE);
+
+        final ListValue<DivorceDocument> doc2 =
+            getDivorceDocumentListValue("http://localhost:4200/assets/59a54ccc-979f-11eb-a8b3-0242ac130004", "certificateOfCService2.pdf", CERTIFICATE_OF_SERVICE);
+
+        final var previousCaseData = caseData();
+        previousCaseData.getConditionalOrder().setProofOfServiceUploadDocuments(singletonList(doc1));
+
+        final CaseDetails<CaseData, State> previousCaseDetails = new CaseDetails<>();
+        previousCaseDetails.setData(previousCaseData);
+        previousCaseDetails.setId(TEST_CASE_ID);
+        previousCaseDetails.setCreatedDate(LOCAL_DATE_TIME);
+
+        final var newCaseData = caseData();
+        newCaseData.getConditionalOrder().setProofOfServiceUploadDocuments(List.of(doc1, doc2));
+
+        final CaseDetails<CaseData, State> newCaseDetails = new CaseDetails<>();
+        newCaseDetails.setData(newCaseData);
+        newCaseDetails.setId(TEST_CASE_ID);
+        newCaseDetails.setCreatedDate(LOCAL_DATE_TIME);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response =
+            updateConditionalOrder.aboutToSubmit(newCaseDetails, previousCaseDetails);
+
+        final List<ListValue<DivorceDocument>> proofOfServiceUploadDocuments = response
+            .getData()
+            .getConditionalOrder()
+            .getProofOfServiceUploadDocuments();
+
+        assertThat(proofOfServiceUploadDocuments).hasSize(2);
+        assertThat(proofOfServiceUploadDocuments.get(0).getValue()).isSameAs(doc2.getValue());
+        assertThat(proofOfServiceUploadDocuments.get(1).getValue()).isSameAs(doc1.getValue());
+    }
+
+    @Test
+    void shouldSkipSortingProofOfServiceUploadDocumentsWhenNoNewDocumentsAreAdded() {
+
+        final ListValue<DivorceDocument> doc1 =
+            getDivorceDocumentListValue("http://localhost:4200/assets/59a54ccc-979f-11eb-a8b3-0242ac130003", "certificateOfCService.pdf", CERTIFICATE_OF_SERVICE);
+
+        final var previousCaseData = caseData();
+        previousCaseData.getConditionalOrder().setProofOfServiceUploadDocuments(singletonList(doc1));
+
+        final CaseDetails<CaseData, State> previousCaseDetails = new CaseDetails<>();
+        previousCaseDetails.setData(previousCaseData);
+        previousCaseDetails.setId(TEST_CASE_ID);
+        previousCaseDetails.setCreatedDate(LOCAL_DATE_TIME);
+
+        final var newCaseData = caseData();
+        newCaseData.getConditionalOrder().setProofOfServiceUploadDocuments(singletonList(doc1));
+
+        final CaseDetails<CaseData, State> newCaseDetails = new CaseDetails<>();
+        newCaseDetails.setData(newCaseData);
+        newCaseDetails.setId(TEST_CASE_ID);
+        newCaseDetails.setCreatedDate(LOCAL_DATE_TIME);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response =
+            updateConditionalOrder.aboutToSubmit(newCaseDetails, previousCaseDetails);
+
+        final List<ListValue<DivorceDocument>> proofOfServiceUploadDocuments = response
+            .getData()
+            .getConditionalOrder()
+            .getProofOfServiceUploadDocuments();
+
+        assertThat(proofOfServiceUploadDocuments).hasSize(1);
+        assertThat(proofOfServiceUploadDocuments.get(0).getValue()).isSameAs(doc1.getValue());
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/common/service/task/SetServiceConfirmedTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/service/task/SetServiceConfirmedTest.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.divorce.common.service.task;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
+
+@ExtendWith(MockitoExtension.class)
+class SetServiceConfirmedTest {
+
+    @InjectMocks
+    private SetServiceConfirmed setServiceConfirmed;
+
+    @Test
+    void shouldSetServiceConfirmed() {
+
+        final CaseData caseData = CaseData.builder().build();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> updatedDetails = setServiceConfirmed.apply(caseDetails);
+
+        assertThat(updatedDetails.getData().getConditionalOrder().getServiceConfirmed()).isEqualTo(YES);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDocumentsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDocumentsTest.java
@@ -217,6 +217,35 @@ class CaseDocumentsTest {
         assertEquals(AMENDED_APPLICATION, caseDocuments.getDocumentsGenerated().get(0).getValue().getDocumentType());
     }
 
+    @Test
+    void shouldReturnFirstUploadedDocumentOfGivenType() {
+
+        final Document documentLink1 = Document.builder()
+            .filename("dispensedDocument1.pdf")
+            .build();
+        final Document documentLink2 = Document.builder()
+            .filename("deemedDocument1.pdf")
+            .build();
+        final Document documentLink3 = Document.builder()
+            .filename("dispensedDocument2.pdf")
+            .build();
+        final Document documentLink4 = Document.builder()
+            .filename("deemedDocument2.pdf")
+            .build();
+
+        final ListValue<DivorceDocument> documentListValue1 = documentWithType(DISPENSE_WITH_SERVICE_GRANTED, documentLink1);
+        final ListValue<DivorceDocument> documentListValue2 = documentWithType(DEEMED_AS_SERVICE_GRANTED, documentLink2);
+        final ListValue<DivorceDocument> documentListValue3 = documentWithType(DISPENSE_WITH_SERVICE_GRANTED, documentLink3);
+        final ListValue<DivorceDocument> documentListValue4 = documentWithType(DEEMED_AS_SERVICE_GRANTED, documentLink4);
+
+        final CaseDocuments caseDocuments = CaseDocuments.builder()
+            .documentsUploaded(List.of(documentListValue4, documentListValue2, documentListValue3, documentListValue1))
+            .build();
+
+        assertThat(caseDocuments.getFirstUploadedDocumentLinkWith(DISPENSE_WITH_SERVICE_GRANTED)).isEqualTo(Optional.of(documentLink3));
+        assertThat(caseDocuments.getFirstUploadedDocumentLinkWith(DEEMED_AS_SERVICE_GRANTED)).isEqualTo(Optional.of(documentLink4));
+    }
+
     private ListValue<ScannedDocument> getDocumentListValue(final String url,
                                                             final String filename,
                                                             final ScannedDocumentType scannedDocumentType) {

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitConfirmServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/service/SolicitorSubmitConfirmServiceTest.java
@@ -6,6 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.common.service.task.SetServiceConfirmed;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.solicitor.service.task.SetConfirmServiceDueDate;
@@ -22,6 +23,9 @@ public class SolicitorSubmitConfirmServiceTest {
 
     @Mock
     private SetConfirmServiceDueDate setConfirmServiceDueDate;
+
+    @Mock
+    private SetServiceConfirmed setServiceConfirmed;
 
     @InjectMocks
     private SolicitorSubmitConfirmService solicitorSubmitConfirmService;
@@ -43,6 +47,7 @@ public class SolicitorSubmitConfirmServiceTest {
         updatedCaseDetails.setData(updatedCaseData);
 
         when(setConfirmServiceDueDate.apply(caseDetails)).thenReturn(updatedCaseDetails);
+        when(setServiceConfirmed.apply(updatedCaseDetails)).thenReturn(updatedCaseDetails);
         final CaseDetails<CaseData, State> result = solicitorSubmitConfirmService.submitConfirmService(caseDetails);
 
         assertThat(result.getData().getDueDate()).isNotEqualTo(caseDetails.getData().getDueDate());

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/service/task/AddOfflineRespondentAnswersLinkTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/service/task/AddOfflineRespondentAnswersLinkTest.java
@@ -1,0 +1,81 @@
+package uk.gov.hmcts.divorce.solicitor.service.task;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.type.Document;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseDocuments;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.document.model.DivorceDocument;
+import uk.gov.hmcts.divorce.document.model.DocumentType;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.APPLICATION;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.DEEMED_AS_SERVICE_GRANTED;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.DISPENSE_WITH_SERVICE_GRANTED;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.RESPONDENT_ANSWERS;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
+
+@ExtendWith(MockitoExtension.class)
+class AddOfflineRespondentAnswersLinkTest {
+
+    @InjectMocks
+    private AddOfflineRespondentAnswersLink addOfflineRespondentAnswersLink;
+
+    @Test
+    void shouldSetRespondentAnswersLinkToUploadedRespondentAnswersDocument() {
+
+        final Document documentLink1 = Document.builder()
+            .filename("dispensedDocument1.pdf")
+            .build();
+        final Document documentLink2 = Document.builder()
+            .filename("deemedDocument1.pdf")
+            .build();
+        final Document documentLink3 = Document.builder()
+            .filename("respondentAnswers.pdf")
+            .build();
+        final Document documentLink4 = Document.builder()
+            .filename("deemedDocument2.pdf")
+            .build();
+
+        final ListValue<DivorceDocument> documentListValue1 = documentWithType(DISPENSE_WITH_SERVICE_GRANTED, documentLink1);
+        final ListValue<DivorceDocument> documentListValue2 = documentWithType(DEEMED_AS_SERVICE_GRANTED, documentLink2);
+        final ListValue<DivorceDocument> documentListValue3 = documentWithType(RESPONDENT_ANSWERS, documentLink3);
+        final ListValue<DivorceDocument> documentListValue4 = documentWithType(DEEMED_AS_SERVICE_GRANTED, documentLink4);
+
+        final CaseDocuments caseDocuments = CaseDocuments.builder()
+            .documentsUploaded(List.of(documentListValue4, documentListValue2, documentListValue3, documentListValue1))
+            .build();
+
+        final var caseData = CaseData.builder()
+            .documents(caseDocuments)
+            .build();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+        caseDetails.setId(TEST_CASE_ID);
+
+        final CaseDetails<CaseData, State> response = addOfflineRespondentAnswersLink.apply(caseDetails);
+
+        assertThat(response.getData().getConditionalOrder().getRespondentAnswersLink()).isEqualTo(documentLink3);
+    }
+
+    private ListValue<DivorceDocument> documentWithType(final DocumentType documentType, final Document document) {
+
+        return ListValue.<DivorceDocument>builder()
+            .id(APPLICATION.getLabel())
+            .value(DivorceDocument
+                .builder()
+                .documentLink(document)
+                .documentFileName("test-draft-divorce-application-12345.pdf")
+                .documentType(documentType)
+                .build())
+            .build();
+    }
+}


### PR DESCRIPTION
### Change description ###

Set serviceConfirmed field to Yes on caseworker-confirm-alternative-service event
Set serviceConfirmed field to Yes on caseworker-confirm-service event
Show uploading of proof of service document on draft-conditional-order event when serviceConfirmed field is set
Change draft-conditional-order event page name to 'Draft Conditional Order'

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2332

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

