### PR TITLE
Update ccd chart as ingress has been patched on Elasticsearch charts

### DIFF
--- a/charts/nfdiv-case-api/Chart.yaml
+++ b/charts/nfdiv-case-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for nfdiv-case-api App
 name: nfdiv-case-api
 home: https://github.com/hmcts/nfdiv-case-api
-version: 0.0.59
+version: 0.0.60
 maintainers:
   - name: HMCTS nfdiv team
 dependencies:
@@ -11,7 +11,7 @@ dependencies:
     version: 4.0.1
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: ccd
-    version: 7.1.0
+    version: 8.0.17
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     tags:
         - ccd-idam-pr

--- a/charts/nfdiv-case-api/values.preview.template.yaml
+++ b/charts/nfdiv-case-api/values.preview.template.yaml
@@ -141,6 +141,7 @@ ccd:
       enabled: false
 
   elasticsearch:
+    nameOverride: ${SERVICE_NAME}-es
     clusterName: "es"
     imageTag: "7.17.0"
     replicas: 1


### PR DESCRIPTION
### Change description ###

CFT have patched ingress on our elasticsearch chart. This is in relation to the ongoing cluster upgrades across all environments. We need teams using the chart-ccd chart to bump the chart version to 8.0.17CFT have patched ingress on our elasticsearch chart. This is in relation to the ongoing cluster upgrades across all environments. We need teams using the chart-ccd chart to bump the chart version to 8.0.17

