### PR TITLE
check if applicant2email is set before unlinking in switch to sole

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenSwitchedToSole.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenSwitchedToSole.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.divorce.solicitor.service.CcdAccessService;
 import javax.servlet.http.HttpServletRequest;
 
 import static java.util.Objects.isNull;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Applicant2Approved;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingApplicant1Response;
@@ -86,7 +87,7 @@ public class CitizenSwitchedToSole implements CCDConfig<CaseData, State, UserRol
         CaseData beforeDetailsData = beforeDetails.getData();
         CaseInvite caseInviteBefore = beforeDetailsData.getCaseInvite();
 
-        if (isNull(caseInviteBefore.accessCode()) && beforeDetailsData.getApplicant2().getEmail() != null) {
+        if (isNull(caseInviteBefore.accessCode()) && isNotEmpty(beforeDetailsData.getApplicant2().getEmail())) {
             log.info("Unlinking Applicant 2 from Case Id: {}", caseId);
             ccdAccessService.unlinkApplicant2FromCase(caseId, caseInviteBefore.applicant2UserId());
         }

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenSwitchedToSole.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenSwitchedToSole.java
@@ -83,9 +83,10 @@ public class CitizenSwitchedToSole implements CCDConfig<CaseData, State, UserRol
         removeApplicant2AnswersFromCase(data);
         data.getApplication().setJurisdiction(null);
 
-        CaseInvite caseInviteBefore = beforeDetails.getData().getCaseInvite();
+        CaseData beforeDetailsData = beforeDetails.getData();
+        CaseInvite caseInviteBefore = beforeDetailsData.getCaseInvite();
 
-        if (isNull(caseInviteBefore.accessCode())) {
+        if (isNull(caseInviteBefore.accessCode()) && beforeDetailsData.getApplicant2().getEmail() != null) {
             log.info("Unlinking Applicant 2 from Case Id: {}", caseId);
             ccdAccessService.unlinkApplicant2FromCase(caseId, caseInviteBefore.applicant2UserId());
         }

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/event/CitizenSwitchedToSoleTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/event/CitizenSwitchedToSoleTest.java
@@ -104,7 +104,7 @@ class CitizenSwitchedToSoleTest {
     }
 
     @Test
-    void givenEventStartedWithValidJointCaseForApplicant1SwitchToSoleWithApplicant2NotLinkedShouldRemoveAccessCodeAndSendNotifications() {
+    void givenEventStartedWithValidJointCaseForApplicant1SwitchToSoleWithApplicant2NotLinkedShouldSendNotifications() {
         final long caseId = 1L;
         CaseData caseData = validJointApplicant1CaseData();
         CaseData caseDataBefore = validJointApplicant1CaseData();
@@ -113,6 +113,34 @@ class CitizenSwitchedToSoleTest {
         final CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder().data(caseData).id(caseId).build();
         final CaseDetails<CaseData, State> caseDetailsBefore =
             CaseDetails.<CaseData, State>builder().data(caseDataBefore).id(caseId).build();
+
+        when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn("app1-token");
+        when(ccdAccessService.isApplicant1("app1-token", caseId)).thenReturn(true);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response = citizenSwitchedToSole.aboutToSubmit(caseDetails, caseDetailsBefore);
+
+        verify(notificationDispatcher).send(applicant1SwitchToSoleNotification, caseData, caseDetails.getId());
+        verifyNoMoreInteractions(notificationDispatcher);
+        verify(ccdAccessService, times(0)).unlinkApplicant2FromCase(anyLong(), anyString());
+        assertThat(response.getData().getApplicationType()).isEqualTo(SOLE_APPLICATION);
+        assertThat(response.getData().getCaseInvite().accessCode()).isNull();
+    }
+
+    @Test
+    void givenEventStartedWithValidJointCaseForApplicant1SwitchToSoleWithApplicant2LinkedShouldRemoveAccessCodeAndSendNotifications() {
+        final long caseId = 1L;
+        CaseData caseData = validJointApplicant1CaseData();
+        CaseData caseDataBefore = validJointApplicant1CaseData();
+        setValidCaseInviteData(caseData);
+        setValidCaseInviteData(caseDataBefore);
+        final CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder().data(caseData).id(caseId).build();
+        final CaseDetails<CaseData, State> caseDetailsBefore =
+            CaseDetails.<CaseData, State>builder().data(caseDataBefore).id(caseId).build();
+        caseDataBefore.setApplicant2(
+            Applicant.builder()
+                .email(TEST_APPLICANT_2_EMAIL)
+                .build()
+        );
 
         when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn("app1-token");
         when(ccdAccessService.isApplicant1("app1-token", caseId)).thenReturn(true);
@@ -136,6 +164,11 @@ class CitizenSwitchedToSoleTest {
         setValidCaseInviteData(caseDataBefore);
         final CaseDetails<CaseData, State> caseDetailsBefore =
             CaseDetails.<CaseData, State>builder().data(caseDataBefore).id(caseId).build();
+        caseDataBefore.setApplicant2(
+            Applicant.builder()
+                .email(TEST_APPLICANT_2_EMAIL)
+                .build()
+        );
         when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn("app2-token");
         when(ccdAccessService.isApplicant1("app2-token", caseId)).thenReturn(false);
 
@@ -155,7 +188,7 @@ class CitizenSwitchedToSoleTest {
         setValidCaseInviteData(caseData);
         CaseData caseDataBefore = validJointApplicant1CaseData();
         setValidCaseInviteData(caseDataBefore);
-        caseData.setApplicant2(
+        Applicant applicant2 =
             Applicant.builder()
                 .address(
                     AddressGlobalUK.builder()
@@ -166,8 +199,10 @@ class CitizenSwitchedToSoleTest {
                         .postCode("POSTCODE")
                         .build())
                 .contactDetailsType(PRIVATE)
-                .build()
-        );
+                .email(TEST_APPLICANT_2_EMAIL)
+                .build();
+        caseData.setApplicant2(applicant2);
+        caseDataBefore.setApplicant2(applicant2);
         final CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder().data(caseData).id(caseId).build();
         final CaseDetails<CaseData, State> caseDetailsBefore =
             CaseDetails.<CaseData, State>builder().data(caseDataBefore).id(caseId).build();
@@ -185,24 +220,25 @@ class CitizenSwitchedToSoleTest {
         final long caseId = 1L;
         CaseData caseData = validJointApplicant1CaseData();
         setValidCaseInviteData(caseData);
-        caseData.setApplicant2(
-            Applicant.builder()
-                .address(
-                    AddressGlobalUK.builder()
-                        .addressLine1("123 The Street")
-                        .postTown("The town")
-                        .county("County Durham")
-                        .country("England")
-                        .postCode("POSTCODE")
-                        .build())
-                .contactDetailsType(PUBLIC)
-                .build()
-        );
         final CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder().data(caseData).id(caseId).build();
         CaseData caseDataBefore = validJointApplicant1CaseData();
         setValidCaseInviteData(caseDataBefore);
         final CaseDetails<CaseData, State> caseDetailsBefore =
             CaseDetails.<CaseData, State>builder().data(caseDataBefore).id(caseId).build();
+        Applicant applicant2 = Applicant.builder()
+            .address(
+                AddressGlobalUK.builder()
+                    .addressLine1("123 The Street")
+                    .postTown("The town")
+                    .county("County Durham")
+                    .country("England")
+                    .postCode("POSTCODE")
+                    .build())
+            .contactDetailsType(PUBLIC)
+            .email(TEST_APPLICANT_2_EMAIL)
+            .build();
+        caseData.setApplicant2(applicant2);
+        caseDataBefore.setApplicant2(applicant2);
         when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn("app1-token");
         when(ccdAccessService.isApplicant1("app1-token", caseId)).thenReturn(true);
 
@@ -229,26 +265,6 @@ class CitizenSwitchedToSoleTest {
 
         setValidCaseInviteData(caseData);
         caseData.setCaseInvite(new CaseInvite(TEST_APPLICANT_2_EMAIL, ACCESS_CODE, null));
-        caseData.setApplicant2(
-            Applicant.builder()
-                .firstName("Bob")
-                .middleName("The")
-                .lastName("Build")
-                .email("bob@buildings.com")
-                .gender(MALE)
-                .financialOrder(YES)
-                .lastNameChangedWhenMarried(YES)
-                .address(
-                    AddressGlobalUK.builder()
-                        .addressLine1("123 The Street")
-                        .postTown("The town")
-                        .county("County Durham")
-                        .country("England")
-                        .postCode("POSTCODE")
-                        .build())
-                .contactDetailsType(PRIVATE)
-                .build()
-        );
         caseData.getDocuments().setApplicant2DocumentsUploaded(new ArrayList<>());
         caseData.getApplication().setApplicant2ScreenHasMarriageBroken(YES);
         caseData.getApplication().setApplicant2HelpWithFees(HelpWithFees.builder().build());
@@ -264,6 +280,27 @@ class CitizenSwitchedToSoleTest {
         setValidCaseInviteData(caseDataBefore);
         final CaseDetails<CaseData, State> caseDetailsBefore =
             CaseDetails.<CaseData, State>builder().data(caseDataBefore).id(caseId).build();
+        Applicant applicant2 = Applicant.builder()
+            .firstName("Bob")
+            .middleName("The")
+            .lastName("Build")
+            .email("bob@buildings.com")
+            .gender(MALE)
+            .financialOrder(YES)
+            .lastNameChangedWhenMarried(YES)
+            .address(
+                AddressGlobalUK.builder()
+                    .addressLine1("123 The Street")
+                    .postTown("The town")
+                    .county("County Durham")
+                    .country("England")
+                    .postCode("POSTCODE")
+                    .build())
+            .contactDetailsType(PRIVATE)
+            .email(TEST_APPLICANT_2_EMAIL)
+            .build();
+        caseData.setApplicant2(applicant2);
+        caseDataBefore.setApplicant2(applicant2);
         when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn("app1-token");
         when(ccdAccessService.isApplicant1("app1-token", caseId)).thenReturn(true);
 
@@ -308,6 +345,11 @@ class CitizenSwitchedToSoleTest {
         ).build();
         CaseDetails<CaseData, State> beforeDetails =
             CaseDetails.<CaseData, State>builder().data(caseDataBefore).id(caseId).build();
+        caseDataBefore.setApplicant2(
+            Applicant.builder()
+                .email(TEST_APPLICANT_2_EMAIL)
+                .build()
+        );
         CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder().data(caseData).id(caseId).build();
 
         citizenSwitchedToSole.aboutToSubmit(caseDetails, beforeDetails);


### PR DESCRIPTION
### Change description ###

Enter a description.
fix for a bug where if applicant2 wasnt linked and switch to sole event was called, it will throw an error trying to unlink a user which wasnt linked to case.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2677

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

