### PR TITLE
NFDIV-2520: Set offline to No for digital AoS

### DIFF
--- a/src/integrationTest/resources/caseworker-reissue-application-about-to-submit-app2-not-sol-rep-response.json
+++ b/src/integrationTest/resources/caseworker-reissue-application-about-to-submit-app2-not-sol-rep-response.json
@@ -16,6 +16,7 @@
     "applicant1LegalProceedings": "No",
     "applicant2FirstName": "test_first_name",
     "applicant2MiddleName": "test_middle_name",
+    "applicant2Offline": "No",
     "applicant2LastName": "test_last_name",
     "applicant2Email": "test@test.com",
     "applicant2LanguagePreferenceWelsh": "No",

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/service/ReIssueApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/service/ReIssueApplicationService.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.systemupdate.service.InvalidReissueOptionException;
 
 import static java.lang.String.format;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.ReissueOption.DIGITAL_AOS;
 import static uk.gov.hmcts.divorce.divorcecase.model.ReissueOption.OFFLINE_AOS;
@@ -77,6 +78,9 @@ public class ReIssueApplicationService {
     private CaseDetails<CaseData, State> updateCase(CaseDetails<CaseData, State> caseDetails, ReissueOption reissueOption) {
         if (DIGITAL_AOS.equals(reissueOption)) {
             log.info("For case id {} processing reissue for digital aos ", caseDetails.getId());
+
+            caseDetails.getData().getApplicant2().setOffline(NO);
+
             return caseTasks(
                 setPostIssueState,
                 setReIssueAndDueDate,

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/service/ReIssueApplicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/service/ReIssueApplicationServiceTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.ReissueOption.DIGITAL_AOS;
 import static uk.gov.hmcts.divorce.divorcecase.model.ReissueOption.OFFLINE_AOS;
@@ -80,6 +81,7 @@ class ReIssueApplicationServiceTest {
         caseDetails.setId(1L);
         caseDetails.setCreatedDate(LOCAL_DATE_TIME);
         caseData.getApplication().setReissueOption(DIGITAL_AOS);
+        caseData.getApplicant2().setOffline(NO);
 
         when(setPostIssueState.apply(caseDetails)).thenReturn(caseDetails);
         when(setReIssueAndDueDate.apply(caseDetails)).thenReturn(caseDetails);
@@ -91,6 +93,7 @@ class ReIssueApplicationServiceTest {
 
         var expectedCaseData = caseData();
         expectedCaseData.getApplication().setPreviousReissueOption(DIGITAL_AOS);
+        expectedCaseData.getApplicant2().setOffline(NO);
 
         assertThat(response.getData()).isEqualTo(expectedCaseData);
 
@@ -169,6 +172,7 @@ class ReIssueApplicationServiceTest {
         caseData.getApplicant2().setSolicitorRepresented(YES);
         caseData.getApplication().setSolSignStatementOfTruth(YES);
         caseData.getApplication().setReissueOption(DIGITAL_AOS);
+        caseData.getApplicant2().setOffline(NO);
 
         final Solicitor solicitor = Solicitor.builder()
             .name("testsol")
@@ -195,6 +199,7 @@ class ReIssueApplicationServiceTest {
         expectedCaseData.getApplicant2().setSolicitor(solicitor);
         expectedCaseData.getApplication().setSolSignStatementOfTruth(YES);
         expectedCaseData.getApplication().setPreviousReissueOption(DIGITAL_AOS);
+        expectedCaseData.getApplicant2().setOffline(NO);
 
         assertThat(response.getData()).isEqualTo(expectedCaseData);
 


### PR DESCRIPTION
### Change description ###

Currently when reissueOption was selected as offline and when it is changed to digital then the case can't progress due to the offline flag set to Yes. With the change, for digital AoS, the offline flag needs to be set to No so the case can progress. Also updated unit and integration tests.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2520

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

