### PR TITLE
Added solicitor notification when app2 switches to sole and app1 is represented

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenSwitchedToSoleCoIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenSwitchedToSoleCoIT.java
@@ -14,10 +14,8 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.caseworker.service.print.SwitchToSoleCoPrinter;
 import uk.gov.hmcts.divorce.common.config.WebMvcConfig;
-import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.ApplicationType;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
@@ -236,14 +234,13 @@ public class CitizenSwitchedToSoleCoIT {
     }
 
     @Test
-    public void shouldSwitchApplicationTypeToSoleAndSendApplicant2SolicitorNotifications() throws Exception {
+    public void shouldSwitchApplicationTypeToSoleAndSendApplicant1SolicitorNotifications() throws Exception {
         CaseData data = validJointApplicant1CaseData();
 
         final LocalDate issueDate = getExpectedLocalDate();
         data.getApplication().setIssueDate(issueDate);
-
-        data.getApplicant2().setSolicitorRepresented(YesOrNo.YES);
-        data.getApplicant2().setSolicitor(Solicitor
+        data.getApplicant1().setSolicitorRepresented(YES);
+        data.getApplicant1().setSolicitor(Solicitor
             .builder()
             .email(TEST_SOLICITOR_EMAIL)
             .build());
@@ -290,7 +287,7 @@ public class CitizenSwitchedToSoleCoIT {
             .hasSize(1);
 
         verify(notificationService)
-            .sendEmail(eq(TEST_USER_EMAIL), eq(PARTNER_SWITCHED_TO_SOLE_CO), anyMap(), eq(ENGLISH));
+            .sendEmail(eq(TEST_APPLICANT_2_USER_EMAIL), eq(CITIZEN_APPLIED_FOR_CONDITIONAL_ORDER), anyMap(), eq(ENGLISH));
         verify(notificationService)
             .sendEmail(
                 eq(TEST_SOLICITOR_EMAIL),

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2SwitchToSoleCoNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2SwitchToSoleCoNotification.java
@@ -42,6 +42,24 @@ public class Applicant2SwitchToSoleCoNotification implements ApplicantNotificati
     }
 
     @Override
+    public void sendToApplicant1Solicitor(final CaseData caseData, final Long id) {
+
+        log.info("Notifying applicant 1 solicitor that the other party made a sole application for a conditional order: {}", id);
+
+        final Applicant applicant = caseData.getApplicant1();
+
+        final Map<String, String> templateVars = commonContent.solicitorTemplateVars(caseData, id, applicant);
+        templateVars.put(APPLICANT_NAME, applicant.getFullName());
+
+        notificationService.sendEmail(
+            applicant.getSolicitor().getEmail(),
+            SOLICITOR_OTHER_PARTY_MADE_SOLE_APPLICATION_FOR_CONDITIONAL_ORDER,
+            templateVars,
+            applicant.getLanguagePreference()
+        );
+    }
+
+    @Override
     public void sendToApplicant2(CaseData data, Long id) {
         log.info("Notifying applicant 1 of CO application for case : {}", id);
 
@@ -62,21 +80,4 @@ public class Applicant2SwitchToSoleCoNotification implements ApplicantNotificati
         );
     }
 
-    @Override
-    public void sendToApplicant2Solicitor(final CaseData caseData, final Long id) {
-
-        log.info("Notifying applicant 2 solicitor that the other party made a sole application for a conditional order: {}", id);
-
-        final Applicant applicant = caseData.getApplicant2();
-
-        final Map<String, String> templateVars = commonContent.solicitorTemplateVars(caseData, id, applicant);
-        templateVars.put(APPLICANT_NAME, applicant.getFullName());
-
-        notificationService.sendEmail(
-            applicant.getSolicitor().getEmail(),
-            SOLICITOR_OTHER_PARTY_MADE_SOLE_APPLICATION_FOR_CONDITIONAL_ORDER,
-            templateVars,
-            applicant.getLanguagePreference()
-        );
-    }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2SwitchToSoleCoNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2SwitchToSoleCoNotification.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.divorce.citizen.notification;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.notification.ApplicantNotification;
 import uk.gov.hmcts.divorce.notification.CommonContent;
@@ -10,10 +11,12 @@ import uk.gov.hmcts.divorce.notification.NotificationService;
 
 import java.util.Map;
 
+import static uk.gov.hmcts.divorce.notification.CommonContent.APPLICANT_NAME;
 import static uk.gov.hmcts.divorce.notification.CommonContent.CO_SUBMISSION_DATE_PLUS_DAYS;
 import static uk.gov.hmcts.divorce.notification.CommonContent.PRONOUNCE_BY_DATE;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.CITIZEN_APPLIED_FOR_CONDITIONAL_ORDER;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.PARTNER_SWITCHED_TO_SOLE_CO;
+import static uk.gov.hmcts.divorce.notification.EmailTemplateName.SOLICITOR_OTHER_PARTY_MADE_SOLE_APPLICATION_FOR_CONDITIONAL_ORDER;
 import static uk.gov.hmcts.divorce.notification.FormatUtil.DATE_TIME_FORMATTER;
 
 @Component
@@ -56,6 +59,24 @@ public class Applicant2SwitchToSoleCoNotification implements ApplicantNotificati
             CITIZEN_APPLIED_FOR_CONDITIONAL_ORDER,
             templateVars,
             data.getApplicant2().getLanguagePreference()
+        );
+    }
+
+    @Override
+    public void sendToApplicant2Solicitor(final CaseData caseData, final Long id) {
+
+        log.info("Notifying applicant 2 solicitor that the other party made a sole application for a conditional order: {}", id);
+
+        final Applicant applicant = caseData.getApplicant2();
+
+        final Map<String, String> templateVars = commonContent.solicitorTemplateVars(caseData, id, applicant);
+        templateVars.put(APPLICANT_NAME, applicant.getFullName());
+
+        notificationService.sendEmail(
+            applicant.getSolicitor().getEmail(),
+            SOLICITOR_OTHER_PARTY_MADE_SOLE_APPLICATION_FOR_CONDITIONAL_ORDER,
+            templateVars,
+            applicant.getLanguagePreference()
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2SwitchToSoleCoNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2SwitchToSoleCoNotificationTest.java
@@ -5,13 +5,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrder;
 import uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrderQuestions;
+import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
 import uk.gov.hmcts.divorce.notification.CommonContent;
 import uk.gov.hmcts.divorce.notification.NotificationService;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.allOf;
@@ -22,6 +25,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DISSOLUTION;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
+import static uk.gov.hmcts.divorce.notification.CommonContent.APPLICANT_NAME;
 import static uk.gov.hmcts.divorce.notification.CommonContent.IS_DISSOLUTION;
 import static uk.gov.hmcts.divorce.notification.CommonContent.IS_DIVORCE;
 import static uk.gov.hmcts.divorce.notification.CommonContent.NO;
@@ -29,12 +33,16 @@ import static uk.gov.hmcts.divorce.notification.CommonContent.PRONOUNCE_BY_DATE;
 import static uk.gov.hmcts.divorce.notification.CommonContent.YES;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.CITIZEN_APPLIED_FOR_CONDITIONAL_ORDER;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.PARTNER_SWITCHED_TO_SOLE_CO;
+import static uk.gov.hmcts.divorce.notification.EmailTemplateName.SOLICITOR_OTHER_PARTY_MADE_SOLE_APPLICATION_FOR_CONDITIONAL_ORDER;
 import static uk.gov.hmcts.divorce.notification.FormatUtil.DATE_TIME_FORMATTER;
 import static uk.gov.hmcts.divorce.testutil.ClockTestUtil.getExpectedLocalDateTime;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_APPLICANT_2_USER_EMAIL;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_USER_EMAIL;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getMainTemplateVars;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.validApplicant2CaseData;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.validJointApplicant1CaseData;
 
 @ExtendWith(SpringExtension.class)
 class Applicant2SwitchToSoleCoNotificationTest {
@@ -76,7 +84,7 @@ class Applicant2SwitchToSoleCoNotificationTest {
     }
 
     @Test
-    void shouldSendNotificationToApplican21WithDissolutionContent() {
+    void shouldSendNotificationToApplicant21WithDissolutionContent() {
         CaseData data = validApplicant2CaseData();
         data.setDivorceOrDissolution(DISSOLUTION);
         data.getApplicant2().setEmail(null);
@@ -145,5 +153,32 @@ class Applicant2SwitchToSoleCoNotificationTest {
             eq(ENGLISH)
         );
         verify(commonContent).mainTemplateVars(data, CASE_ID, data.getApplicant1(), data.getApplicant2());
+    }
+
+    @Test
+    void shouldSendNotificationToApplicant2Solicitor() {
+        final CaseData caseData = validJointApplicant1CaseData();
+        caseData.getApplicant2().setSolicitorRepresented(YesOrNo.YES);
+        caseData.getApplicant2().setSolicitor(Solicitor
+            .builder()
+            .email(TEST_SOLICITOR_EMAIL)
+            .build());
+
+        final Map<String, String> templateVars = new HashMap<>();
+        when(commonContent.solicitorTemplateVars(caseData, TEST_CASE_ID, caseData.getApplicant2()))
+            .thenReturn(templateVars);
+
+        notification.sendToApplicant2Solicitor(caseData, TEST_CASE_ID);
+
+        verify(notificationService).sendEmail(
+            eq(TEST_SOLICITOR_EMAIL),
+            eq(SOLICITOR_OTHER_PARTY_MADE_SOLE_APPLICATION_FOR_CONDITIONAL_ORDER),
+            argThat(allOf(
+                hasEntry(APPLICANT_NAME, caseData.getApplicant2().getFullName())
+            )),
+            eq(ENGLISH)
+        );
+
+        verify(commonContent).solicitorTemplateVars(caseData, TEST_CASE_ID, caseData.getApplicant2());
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2SwitchToSoleCoNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/notification/Applicant2SwitchToSoleCoNotificationTest.java
@@ -156,10 +156,10 @@ class Applicant2SwitchToSoleCoNotificationTest {
     }
 
     @Test
-    void shouldSendNotificationToApplicant2Solicitor() {
+    void shouldSendNotificationToApplicant1Solicitor() {
         final CaseData caseData = validJointApplicant1CaseData();
-        caseData.getApplicant2().setSolicitorRepresented(YesOrNo.YES);
-        caseData.getApplicant2().setSolicitor(Solicitor
+        caseData.getApplicant1().setSolicitorRepresented(YesOrNo.YES);
+        caseData.getApplicant1().setSolicitor(Solicitor
             .builder()
             .email(TEST_SOLICITOR_EMAIL)
             .build());
@@ -168,17 +168,17 @@ class Applicant2SwitchToSoleCoNotificationTest {
         when(commonContent.solicitorTemplateVars(caseData, TEST_CASE_ID, caseData.getApplicant2()))
             .thenReturn(templateVars);
 
-        notification.sendToApplicant2Solicitor(caseData, TEST_CASE_ID);
+        notification.sendToApplicant1Solicitor(caseData, TEST_CASE_ID);
 
         verify(notificationService).sendEmail(
             eq(TEST_SOLICITOR_EMAIL),
             eq(SOLICITOR_OTHER_PARTY_MADE_SOLE_APPLICATION_FOR_CONDITIONAL_ORDER),
             argThat(allOf(
-                hasEntry(APPLICANT_NAME, caseData.getApplicant2().getFullName())
+                hasEntry(APPLICANT_NAME, caseData.getApplicant1().getFullName())
             )),
             eq(ENGLISH)
         );
 
-        verify(commonContent).solicitorTemplateVars(caseData, TEST_CASE_ID, caseData.getApplicant2());
+        verify(commonContent).solicitorTemplateVars(caseData, TEST_CASE_ID, caseData.getApplicant1());
     }
 }


### PR DESCRIPTION
### Change description ###

> Currently when applicant 2 is citizen and applicant 1 is represented and if applicant 2 switches to sole then no notification is sent to applicant 2 solicitor(previously applicant 1 solicitor). This PR add notification to applicant 2 solicitor.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2811

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [x] README and other documentation has been updated / added (if needed)

