### PR TITLE
NFDIV-2757 - Don't send notifications if personal service on reissue

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/service/task/SendApplicationIssueNotifications.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/service/task/SendApplicationIssueNotifications.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 
+import static uk.gov.hmcts.divorce.divorcecase.model.ServiceMethod.PERSONAL_SERVICE;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingService;
 
 @Component
@@ -30,15 +31,15 @@ public class SendApplicationIssueNotifications implements CaseTask {
         final CaseData caseData = caseDetails.getData();
         final Long caseId = caseDetails.getId();
 
-        notificationDispatcher.send(applicationIssuedNotification, caseData, caseId);
+        if (!caseData.getApplication().getServiceMethod().equals(PERSONAL_SERVICE)) {
+            notificationDispatcher.send(applicationIssuedNotification, caseData, caseId);
 
-        if (caseDetails.getState() == AwaitingService
-            && caseData.getApplicationType().isSole()
-            && (caseData.getApplicant2().isBasedOverseas()
-            || caseData.getApplication().isPersonalServiceMethod())) {
-            notificationDispatcher.send(applicationIssuedOverseasNotification, caseData, caseId);
+            if (caseDetails.getState() == AwaitingService
+                && caseData.getApplicationType().isSole()
+                && caseData.getApplicant2().isBasedOverseas()) {
+                notificationDispatcher.send(applicationIssuedOverseasNotification, caseData, caseId);
+            }
         }
-
         return caseDetails;
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/service/ReIssueApplicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/service/ReIssueApplicationServiceTest.java
@@ -31,6 +31,8 @@ import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.ReissueOption.DIGITAL_AOS;
 import static uk.gov.hmcts.divorce.divorcecase.model.ReissueOption.OFFLINE_AOS;
 import static uk.gov.hmcts.divorce.divorcecase.model.ReissueOption.REISSUE_CASE;
+import static uk.gov.hmcts.divorce.divorcecase.model.ServiceMethod.COURT_SERVICE;
+import static uk.gov.hmcts.divorce.divorcecase.model.ServiceMethod.PERSONAL_SERVICE;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.LOCAL_DATE_TIME;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
@@ -355,9 +357,11 @@ class ReIssueApplicationServiceTest {
     }
 
     @Test
-    public void shouldSendEmailAndBulkPrintNotificationsWhenReissueOptionIsReissueCase() {
+    public void shouldSendEmailAndBulkPrintNotificationsWhenReissueOptionIsReissueCaseAndNotPersonalService() {
         final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
-        caseDetails.setData(caseData());
+        CaseData caseData = caseData();
+        caseData.getApplication().setServiceMethod(COURT_SERVICE);
+        caseDetails.setData(caseData);
         caseDetails.setId(1L);
         caseDetails.setCreatedDate(LOCAL_DATE_TIME);
 

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/service/task/SendApplicationIssueNotificationsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/service/task/SendApplicationIssueNotificationsTest.java
@@ -15,9 +15,11 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.hmcts.divorce.divorcecase.model.ApplicationType.JOINT_APPLICATION;
 import static uk.gov.hmcts.divorce.divorcecase.model.ApplicationType.SOLE_APPLICATION;
+import static uk.gov.hmcts.divorce.divorcecase.model.ServiceMethod.COURT_SERVICE;
 import static uk.gov.hmcts.divorce.divorcecase.model.ServiceMethod.PERSONAL_SERVICE;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingAos;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingService;
@@ -42,6 +44,7 @@ class SendApplicationIssueNotificationsTest {
     void shouldSendAllNotifications() {
         CaseData caseData = caseData();
         caseData.setApplicationType(SOLE_APPLICATION);
+        caseData.getApplication().setServiceMethod(COURT_SERVICE);
         caseData.getApplicant2().setAddress(AddressGlobalUK.builder().country("Spain").build());
         caseData.setCaseInvite(new CaseInvite("applicant2Invite@email.com", null, null));
         CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder().data(caseData).build();
@@ -57,6 +60,7 @@ class SendApplicationIssueNotificationsTest {
     void shouldNotSendOverseasNotificationIfNotAwaitingServiceState() {
         CaseData caseData = caseData();
         caseData.setApplicationType(SOLE_APPLICATION);
+        caseData.getApplication().setServiceMethod(COURT_SERVICE);
         caseData.getApplicant2().setAddress(AddressGlobalUK.builder().country("Spain").build());
         caseData.setCaseInvite(new CaseInvite("", null, null));
         CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder().data(caseData).build();
@@ -72,6 +76,7 @@ class SendApplicationIssueNotificationsTest {
     void shouldNotSendOverseasNotificationIfNotOverseas() {
         CaseData caseData = caseData();
         caseData.setApplicationType(SOLE_APPLICATION);
+        caseData.getApplication().setServiceMethod(COURT_SERVICE);
         caseData.getApplicant2().setAddress(AddressGlobalUK.builder().country("UK").build());
         caseData.setCaseInvite(new CaseInvite("", null, null));
         CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder().data(caseData).build();
@@ -87,6 +92,7 @@ class SendApplicationIssueNotificationsTest {
     void shouldNotSendOverseasNotificationIfJointApplication() {
         CaseData caseData = caseData();
         caseData.setApplicationType(JOINT_APPLICATION);
+        caseData.getApplication().setServiceMethod(COURT_SERVICE);
         caseData.getApplicant2().setAddress(AddressGlobalUK.builder().country("Spain").build());
         caseData.setCaseInvite(new CaseInvite("", null, null));
         CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder().data(caseData).build();
@@ -99,7 +105,7 @@ class SendApplicationIssueNotificationsTest {
     }
 
     @Test
-    void shouldSendOverseasNotificationIfPersonalService() {
+    void shouldNotSendNotificationsIfPersonalService() {
         CaseData caseData = caseData();
         caseData.setApplicationType(SOLE_APPLICATION);
         caseData.getApplicant2().setAddress(AddressGlobalUK.builder().country("UK").build());
@@ -110,7 +116,7 @@ class SendApplicationIssueNotificationsTest {
 
         underTest.apply(caseDetails);
 
-        verify(notificationDispatcher).send(applicationIssuedNotification, caseData, caseDetails.getId());
-        verify(notificationDispatcher).send(applicationIssuedOverseasNotification, caseData, caseDetails.getId());
+        verifyNoInteractions(notificationDispatcher);
+        verifyNoInteractions(notificationDispatcher);
     }
 }


### PR DESCRIPTION
### Change description ###

If a caseworker uses the re-issue application event, and selects reissue as an option and personal service as an option then skip sending notifications

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2757

**Before merging a pull request make sure that:**

- [X] tests have been updated / new tests has been added (if needed)
- [X] README and other documentation has been updated / added (if needed)