### PR TITLE
Retrieve respondent answers documents based on applicant 2 offline status

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/common/SubmitAosIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/common/SubmitAosIT.java
@@ -439,6 +439,7 @@ public class SubmitAosIT {
         caseData.getDocuments().setScannedDocuments(singletonList(aosScannedDocument()));
         caseData.getApplicant2().setLegalProceedings(YES);
         caseData.getApplicant1().setOffline(YES);
+        caseData.getApplicant2().setOffline(YES);
         caseData.getApplicant2().setLegalProceedingsDetails("some description");
 
         when(serviceTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);

--- a/src/integrationTest/resources/solicitor-submit-aos-disputed-offline-response.json
+++ b/src/integrationTest/resources/solicitor-submit-aos-disputed-offline-response.json
@@ -10,6 +10,7 @@
     "applicant1ContactDetailsType": "public",
     "applicant1FinancialOrder": "No",
     "applicant1Offline": "Yes",
+    "applicant2Offline": "Yes",
     "applicant2LegalProceedings": "Yes",
     "applicant2LegalProceedingsDetails": "some description",
     "solServiceTruthStatement": "I believe that the facts stated in the application are true.",

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/AosPackPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/AosPackPrinter.java
@@ -31,6 +31,7 @@ public class AosPackPrinter {
     private static final String LETTER_TYPE_RESPONDENT_PACK = "respondent-aos-pack";
     private static final String LETTER_TYPE_APPLICANT_PACK = "applicant-aos-pack";
     private static final String LETTER_TYPE_AOS_RESPONSE_PACK = "aos-response-pack";
+    private static final int AOS_RESPONSE_LETTERS_COUNT = 2;
 
     @Autowired
     private BulkPrintService bulkPrintService;
@@ -106,7 +107,15 @@ public class AosPackPrinter {
             caseData.getDocuments().getDocumentsGenerated(),
             AOS_RESPONSE_LETTER);
 
-        final List<Letter> aosLetters = lettersWithDocumentType(caseData.getDocuments().getDocumentsUploaded(), RESPONDENT_ANSWERS);
+        List<Letter> aosLetters;
+        if (caseData.getApplicant2().isOffline()) {
+            // When respondent is offline respondent answers doc is reclassified and added to docs uploaded list
+            aosLetters = lettersWithDocumentType(caseData.getDocuments().getDocumentsUploaded(), RESPONDENT_ANSWERS);
+
+        } else {
+            // When respondent is online respondent answers doc is generated and added to docs generated list
+            aosLetters = lettersWithDocumentType(caseData.getDocuments().getDocumentsGenerated(), RESPONDENT_ANSWERS);
+        }
 
         final Letter aosResponseLetter = firstElement(aosResponseLetters);
 
@@ -121,7 +130,7 @@ public class AosPackPrinter {
             aosResponseLetterWithAos.add(aosLetter);
         }
 
-        if (!isEmpty(aosResponseLetterWithAos)) {
+        if (!isEmpty(aosResponseLetterWithAos) && aosResponseLetterWithAos.size() == AOS_RESPONSE_LETTERS_COUNT) {
 
             final String caseIdString = caseId.toString();
             final Print print = new Print(aosResponseLetterWithAos, caseIdString, caseIdString, LETTER_TYPE_AOS_RESPONSE_PACK);


### PR DESCRIPTION
### Change description ###

- Currently respondent answers is always retrieved from documents uploaded section but if it was a paper case and now respondent has replied online using NOP details then respondent answers needs to be retrieved from documents generated list.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2793

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [x] README and other documentation has been updated / added (if needed)
