### PR TITLE
Use system user creds for pronounce case and add retry event for pronounce list

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/bulkaction/service/CasePronouncementServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/bulkaction/service/CasePronouncementServiceIT.java
@@ -44,13 +44,13 @@ import static uk.gov.hmcts.divorce.divorcecase.NoFaultDivorce.JURISDICTION;
 import static uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrderCourt.BURY_ST_EDMUNDS;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingPronouncement;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemPronounceCase.SYSTEM_PRONOUNCE_CASE;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.CASEWORKER_AUTH_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.CASEWORKER_USER_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_USER_USER_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SERVICE_AUTH_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SYSTEM_AUTHORISATION_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getBulkListCaseDetailsListValue;
 
 @ExtendWith(SpringExtension.class)
@@ -111,12 +111,12 @@ public class CasePronouncementServiceIT {
             .size(50);
 
         var userDetails = UserDetails.builder().id(CASEWORKER_USER_ID).build();
-        var user = new User(CASEWORKER_AUTH_TOKEN, userDetails);
-        when(idamService.retrieveUser(CASEWORKER_AUTH_TOKEN)).thenReturn(user);
+        var user = new User(TEST_SYSTEM_AUTHORISATION_TOKEN, userDetails);
+        when(idamService.retrieveSystemUpdateUserDetails()).thenReturn(user);
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
 
         when(coreCaseDataApi.searchCases(
-            CASEWORKER_AUTH_TOKEN,
+            TEST_SYSTEM_AUTHORISATION_TOKEN,
             TEST_SERVICE_AUTH_TOKEN,
             CASE_TYPE,
             searchQuery.toString()))
@@ -138,7 +138,7 @@ public class CasePronouncementServiceIT {
 
         when(coreCaseDataApi
             .startEventForCaseWorker(
-                CASEWORKER_AUTH_TOKEN,
+                TEST_SYSTEM_AUTHORISATION_TOKEN,
                 TEST_SERVICE_AUTH_TOKEN,
                 CASEWORKER_USER_ID,
                 JURISDICTION,
@@ -168,11 +168,11 @@ public class CasePronouncementServiceIT {
             caseDataContent
         )).thenReturn(getCaseDetails());
 
-        casePronouncementService.pronounceCases(bulkActionCaseDetails, CASEWORKER_AUTH_TOKEN);
+        casePronouncementService.pronounceCases(bulkActionCaseDetails);
 
         verify(coreCaseDataApi)
             .startEventForCaseWorker(
-                CASEWORKER_AUTH_TOKEN,
+                TEST_SYSTEM_AUTHORISATION_TOKEN,
                 TEST_SERVICE_AUTH_TOKEN,
                 CASEWORKER_USER_ID,
                 JURISDICTION,
@@ -189,7 +189,7 @@ public class CasePronouncementServiceIT {
                 any(CaseData.class));
 
         verify(coreCaseDataApi).submitEventForCaseWorker(
-            CASEWORKER_AUTH_TOKEN,
+            TEST_SYSTEM_AUTHORISATION_TOKEN,
             TEST_SERVICE_AUTH_TOKEN,
             CASEWORKER_USER_ID,
             JURISDICTION,

--- a/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/CaseworkerPronounceList.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/CaseworkerPronounceList.java
@@ -17,11 +17,9 @@ import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
-import javax.servlet.http.HttpServletRequest;
 
 import static java.time.LocalDateTime.now;
 import static java.util.Collections.singletonList;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
 import static uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState.Listed;
 import static uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState.Pronounced;
@@ -40,9 +38,6 @@ public class CaseworkerPronounceList implements CCDConfig<BulkActionCaseData, Bu
 
     @Autowired
     private CasePronouncementService casePronouncementService;
-
-    @Autowired
-    private HttpServletRequest request;
 
     @Autowired
     private Clock clock;
@@ -112,8 +107,7 @@ public class CaseworkerPronounceList implements CCDConfig<BulkActionCaseData, Bu
     ) {
 
         log.info("{} submitted callback invoked for Case Id: {}", CASEWORKER_PRONOUNCE_LIST, details.getId());
-
-        casePronouncementService.pronounceCases(details, request.getHeader(AUTHORIZATION));
+        casePronouncementService.pronounceCases(details);
         return SubmittedCallbackResponse.builder().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/CaseworkerRetryPronounceList.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/CaseworkerRetryPronounceList.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.divorce.bulkaction.ccd.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionPageBuilder;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkActionCaseData;
+import uk.gov.hmcts.divorce.bulkaction.service.CasePronouncementService;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
+
+import static uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState.Pronounced;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CITIZEN;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+
+@Component
+@Slf4j
+public class CaseworkerRetryPronounceList implements CCDConfig<BulkActionCaseData, BulkActionState, UserRole> {
+
+    public static final String CASEWORKER_RETRY_PRONOUNCE_LIST = "caseworker-retry-pronounce-list";
+
+    @Autowired
+    private CasePronouncementService casePronouncementService;
+
+    @Override
+    public void configure(final ConfigBuilder<BulkActionCaseData, BulkActionState, UserRole> configBuilder) {
+        new BulkActionPageBuilder(configBuilder
+            .event(CASEWORKER_RETRY_PRONOUNCE_LIST)
+            .forStates(Pronounced)
+            .name("Retry Pronounce list")
+            .description("Retry Pronounce list")
+            .showSummary()
+            .showEventNotes()
+            .submittedCallback(this::submitted)
+            .grant(CREATE_READ_UPDATE, SUPER_USER)
+            .grantHistoryOnly(CASE_WORKER, LEGAL_ADVISOR, SOLICITOR, CITIZEN));
+    }
+
+    public SubmittedCallbackResponse submitted(
+        CaseDetails<BulkActionCaseData, BulkActionState> details,
+        CaseDetails<BulkActionCaseData, BulkActionState> beforeDetails
+    ) {
+        log.info("{} Retry pronounce list submitted callback invoked for Case Id: {}", CASEWORKER_RETRY_PRONOUNCE_LIST, details.getId());
+        casePronouncementService.pronounceCases(details);
+        return SubmittedCallbackResponse.builder().build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkaction/service/CasePronouncementService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkaction/service/CasePronouncementService.java
@@ -66,11 +66,11 @@ public class CasePronouncementService {
                 user,
                 serviceAuth);
 
-        log.info("Error bulk case details list size {}", unprocessedBulkCases.size());
+        log.info("Error bulk case details list size {} and bulk case id {}", unprocessedBulkCases.size(), details.getId());
 
         List<ListValue<BulkListCaseDetails>> processedBulkCases = bulkActionCaseData.calculateProcessedCases(unprocessedBulkCases);
 
-        log.info("Successfully processed bulk case details list size {}", processedBulkCases.size());
+        log.info("Successfully processed bulk case details list size {} and bulk case id {}", processedBulkCases.size(), details.getId());
 
         bulkActionCaseData.getErroredCaseDetails().addAll(unprocessedBulkCases);
         bulkActionCaseData.getProcessedCaseDetails().addAll(processedBulkCases);

--- a/src/main/java/uk/gov/hmcts/divorce/bulkaction/service/CasePronouncementService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkaction/service/CasePronouncementService.java
@@ -49,11 +49,11 @@ public class CasePronouncementService {
     private BulkCaseCaseTaskFactory bulkCaseCaseTaskFactory;
 
     @Async
-    public void pronounceCases(final CaseDetails<BulkActionCaseData, BulkActionState> details,
-                               final String authorization) {
+    public void pronounceCases(final CaseDetails<BulkActionCaseData, BulkActionState> details
+    ) {
         final BulkActionCaseData bulkActionCaseData = details.getData();
 
-        final User user = idamService.retrieveUser(authorization);
+        final User user = idamService.retrieveSystemUpdateUserDetails();
         final String serviceAuth = authTokenGenerator.generate();
 
         filterCasesNotInCorrectState(bulkActionCaseData, user, serviceAuth);

--- a/src/test/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/CaseworkerPronounceListTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/CaseworkerPronounceListTest.java
@@ -16,13 +16,10 @@ import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
-import javax.servlet.http.HttpServletRequest;
 
-import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.bulkaction.ccd.event.CaseworkerPronounceList.CASEWORKER_PRONOUNCE_LIST;
@@ -30,16 +27,12 @@ import static uk.gov.hmcts.divorce.testutil.ClockTestUtil.getExpectedLocalDateTi
 import static uk.gov.hmcts.divorce.testutil.ClockTestUtil.setMockClock;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createBulkActionConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.CASEWORKER_AUTH_TOKEN;
 
 @ExtendWith(MockitoExtension.class)
 class CaseworkerPronounceListTest {
 
     @Mock
     private CasePronouncementService casePronouncementService;
-
-    @Mock
-    private HttpServletRequest request;
 
     @Mock
     private Clock clock;
@@ -152,12 +145,11 @@ class CaseworkerPronounceListTest {
         details.setData(BulkActionCaseData.builder().build());
         details.setId(1L);
 
-        when(request.getHeader(AUTHORIZATION)).thenReturn(CASEWORKER_AUTH_TOKEN);
-        doNothing().when(casePronouncementService).pronounceCases(details, CASEWORKER_AUTH_TOKEN);
+        doNothing().when(casePronouncementService).pronounceCases(details);
 
         SubmittedCallbackResponse submittedCallbackResponse = caseworkerPronounceList.submitted(details, details);
 
         assertThat(submittedCallbackResponse).isNotNull();
-        verify(casePronouncementService).pronounceCases(details, CASEWORKER_AUTH_TOKEN);
+        verify(casePronouncementService).pronounceCases(details);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/CaseworkerRetryPronounceListTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/CaseworkerRetryPronounceListTest.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.divorce.bulkaction.ccd.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkActionCaseData;
+import uk.gov.hmcts.divorce.bulkaction.service.CasePronouncementService;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.divorce.bulkaction.ccd.event.CaseworkerRetryPronounceList.CASEWORKER_RETRY_PRONOUNCE_LIST;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createBulkActionConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+
+@ExtendWith(MockitoExtension.class)
+class CaseworkerRetryPronounceListTest {
+
+    @Mock
+    private CasePronouncementService casePronouncementService;
+
+    @InjectMocks
+    private CaseworkerRetryPronounceList caseworkerRetryPronounceList;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() {
+
+        final ConfigBuilderImpl<BulkActionCaseData, BulkActionState, UserRole> configBuilder = createBulkActionConfigBuilder();
+
+        caseworkerRetryPronounceList.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(CASEWORKER_RETRY_PRONOUNCE_LIST);
+    }
+
+
+    @Test
+    void shouldUpdateBulkCaseAfterBulkTriggerForSubmittedCallback() {
+        final CaseDetails<BulkActionCaseData, BulkActionState> details = new CaseDetails<>();
+        details.setData(BulkActionCaseData.builder().build());
+        details.setId(1L);
+
+        doNothing().when(casePronouncementService).pronounceCases(details);
+
+        SubmittedCallbackResponse submittedCallbackResponse = caseworkerRetryPronounceList.submitted(details, details);
+
+        assertThat(submittedCallbackResponse).isNotNull();
+        verify(casePronouncementService).pronounceCases(details);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/bulkaction/service/CasePronouncementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkaction/service/CasePronouncementServiceTest.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.reform.idam.client.models.User;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import javax.servlet.http.HttpServletRequest;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,7 +35,6 @@ import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingPronouncement
 import static uk.gov.hmcts.divorce.divorcecase.model.State.IssuedToBailiff;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemPronounceCase.SYSTEM_PRONOUNCE_CASE;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SYSTEM_AUTHORISATION_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.feignException;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getBulkListCaseDetailsListValue;
 
@@ -48,9 +46,6 @@ public class CasePronouncementServiceTest {
 
     @Mock
     private IdamService idamService;
-
-    @Mock
-    private HttpServletRequest request;
 
     @Mock
     private AuthTokenGenerator authTokenGenerator;
@@ -81,7 +76,7 @@ public class CasePronouncementServiceTest {
         var user = mock(User.class);
 
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION);
-        when(idamService.retrieveUser(TEST_SYSTEM_AUTHORISATION_TOKEN)).thenReturn(user);
+        when(idamService.retrieveSystemUpdateUserDetails()).thenReturn(user);
         when(ccdSearchService.searchForCases(List.of("1"), user, SERVICE_AUTHORIZATION))
             .thenReturn(List.of(
                 uk.gov.hmcts.reform.ccd.client.model.CaseDetails.builder()
@@ -106,7 +101,7 @@ public class CasePronouncementServiceTest {
             SERVICE_AUTHORIZATION
         )).thenReturn(emptyList());
 
-        casePronouncementService.pronounceCases(bulkActionCaseDetails, TEST_SYSTEM_AUTHORISATION_TOKEN);
+        casePronouncementService.pronounceCases(bulkActionCaseDetails);
 
         verify(bulkTriggerService).bulkTrigger(
             eq(bulkActionCaseData.getBulkListCaseDetails()),
@@ -148,7 +143,7 @@ public class CasePronouncementServiceTest {
         var user = mock(User.class);
 
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION);
-        when(idamService.retrieveUser(TEST_SYSTEM_AUTHORISATION_TOKEN)).thenReturn(user);
+        when(idamService.retrieveSystemUpdateUserDetails()).thenReturn(user);
         when(ccdSearchService.searchForCases(List.of("1", "2"), user, SERVICE_AUTHORIZATION))
             .thenReturn(List.of(
                 uk.gov.hmcts.reform.ccd.client.model.CaseDetails.builder()
@@ -181,7 +176,7 @@ public class CasePronouncementServiceTest {
             SERVICE_AUTHORIZATION
         );
 
-        casePronouncementService.pronounceCases(bulkActionCaseDetails, TEST_SYSTEM_AUTHORISATION_TOKEN);
+        casePronouncementService.pronounceCases(bulkActionCaseDetails);
 
         verify(bulkTriggerService).bulkTrigger(
             eq(bulkActionCaseData.getBulkListCaseDetails()),
@@ -223,7 +218,7 @@ public class CasePronouncementServiceTest {
         var user = mock(User.class);
 
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION);
-        when(idamService.retrieveUser(TEST_SYSTEM_AUTHORISATION_TOKEN)).thenReturn(user);
+        when(idamService.retrieveSystemUpdateUserDetails()).thenReturn(user);
         when(ccdSearchService.searchForCases(List.of("1", "2"), user, SERVICE_AUTHORIZATION))
             .thenReturn(List.of(
                 uk.gov.hmcts.reform.ccd.client.model.CaseDetails.builder()
@@ -254,7 +249,7 @@ public class CasePronouncementServiceTest {
             SERVICE_AUTHORIZATION
         );
 
-        casePronouncementService.pronounceCases(bulkActionCaseDetails, TEST_SYSTEM_AUTHORISATION_TOKEN);
+        casePronouncementService.pronounceCases(bulkActionCaseDetails);
 
         assertThat(bulkActionCaseDetails.getData().getBulkListCaseDetails()).hasSize(0);
         assertThat(bulkActionCaseDetails.getData().getErroredCaseDetails()).hasSize(2);
@@ -284,7 +279,7 @@ public class CasePronouncementServiceTest {
         var user = mock(User.class);
 
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION);
-        when(idamService.retrieveUser(TEST_SYSTEM_AUTHORISATION_TOKEN)).thenReturn(user);
+        when(idamService.retrieveSystemUpdateUserDetails()).thenReturn(user);
         when(ccdSearchService.searchForCases(List.of("1", "2"), user, SERVICE_AUTHORIZATION))
             .thenReturn(List.of(
                 uk.gov.hmcts.reform.ccd.client.model.CaseDetails.builder()
@@ -318,7 +313,7 @@ public class CasePronouncementServiceTest {
                 SERVICE_AUTHORIZATION
             );
 
-        casePronouncementService.pronounceCases(bulkActionCaseDetails, TEST_SYSTEM_AUTHORISATION_TOKEN);
+        casePronouncementService.pronounceCases(bulkActionCaseDetails);
 
         verify(bulkTriggerService).bulkTrigger(
             eq(bulkActionCaseData.getBulkListCaseDetails()),


### PR DESCRIPTION
### Change description ###

-  I had a look at the issue and it is due to incorrect credentials used in the code(instead of system user it is using caseworker credentials) and hence it is failing to trigger system pronounce case on individual cases.

- For cases on which Pronounce list is already triggered bulk case state has moved to pronounced so we need a backward fix. For this I created retry event where it allows superusers to retry "Pronounce List" event on bulk case in Pronounced state. 
- This will only retry system pronounce case event on NFD cases within the bulk list and no dates9hearing and final order eligible from) will be updated.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3037

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [x] README and other documentation has been updated / added (if needed)
