### PR TITLE
update jackson-databind to fix CVE and suppress new CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,7 +232,7 @@ repositories {
 }
 
 def versions = [
-  jackson           : '2.13.3',
+  jackson           : '2.13.4',
   junit             : '5.9.1',
   junitPlatform     : '1.9.1',
   lombok            : '1.18.22',

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,6 +8,10 @@
         <notes>spring-security-crypto 5.7.2 release brought in by service-auth-provider-java-client</notes>
         <cve>CVE-2020-5408</cve>
     </suppress>
+  <suppress>
+    <notes>jackson-databind exploit will be fixed in v2.14.0 - Not yet released</notes>
+    <cve>CVE-2022-42003</cve>
+  </suppress>
     <suppress>
         <notes>no updates yet for tomcat-embed-core and tomcat-embed-websocket</notes>
         <cve>CVE-2022-34305</cve>


### PR DESCRIPTION
### Change description ###

Currently there is no fix live for CVE-2022-42003, so adding a suppression to fix our pipelines. Fix for this will be live in 2.14

Also update to 2.13.4 to fix another known CVE

### JIRA link (if applicable) ###
N/A

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

