### PR TITLE
Removed awaiting CO reminder notifications for app1 and app2 solicitors as they are not required

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/common/notification/AwaitingConditionalOrderReminderNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/notification/AwaitingConditionalOrderReminderNotification.java
@@ -19,10 +19,8 @@ import java.util.Map;
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.COVERSHEET_APPLICANT;
 import static uk.gov.hmcts.divorce.notification.CommonContent.IS_REMINDER;
-import static uk.gov.hmcts.divorce.notification.CommonContent.SOLICITOR_NAME;
 import static uk.gov.hmcts.divorce.notification.CommonContent.YES;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.CITIZEN_APPLY_FOR_CONDITIONAL_ORDER;
-import static uk.gov.hmcts.divorce.notification.EmailTemplateName.SOLICITOR_AWAITING_CONDITIONAL_ORDER;
 
 @Component
 @Slf4j
@@ -68,22 +66,6 @@ public class AwaitingConditionalOrderReminderNotification implements ApplicantNo
     }
 
     @Override
-    public void sendToApplicant1Solicitor(final CaseData caseData, final Long id) {
-        log.info("Sending reminder to applicant 1 solicitor that they can apply for a conditional order: {}", id);
-        final Applicant applicant1 = caseData.getApplicant1();
-
-        final Map<String, String> templateVars = commonContent.basicTemplateVars(caseData, id);
-        templateVars.put(SOLICITOR_NAME, applicant1.getSolicitor().getName());
-
-        notificationService.sendEmail(
-            applicant1.getSolicitor().getEmail(),
-            SOLICITOR_AWAITING_CONDITIONAL_ORDER,
-            templateVars,
-            applicant1.getLanguagePreference()
-        );
-    }
-
-    @Override
     public void sendToApplicant2(final CaseData caseData, final Long id) {
         if (!caseData.getApplicationType().isSole() && nonNull(caseData.getApplicant2().getEmail())) {
             log.info("Sending reminder applicant 2 that they can apply for a conditional order: {}", id);
@@ -97,24 +79,6 @@ public class AwaitingConditionalOrderReminderNotification implements ApplicantNo
             notificationService.sendEmail(
                 applicant2.getEmail(),
                 CITIZEN_APPLY_FOR_CONDITIONAL_ORDER,
-                templateVars,
-                applicant2.getLanguagePreference()
-            );
-        }
-    }
-
-    @Override
-    public void sendToApplicant2Solicitor(final CaseData caseData, final Long id) {
-        if (!caseData.getApplicationType().isSole()) {
-            log.info("Sending reminder applicant 2 solicitor that they can apply for a conditional order: {}", id);
-            final Applicant applicant2 = caseData.getApplicant2();
-
-            final Map<String, String> templateVars = commonContent.basicTemplateVars(caseData, id);
-            templateVars.put(SOLICITOR_NAME, applicant2.getSolicitor().getName());
-
-            notificationService.sendEmail(
-                applicant2.getSolicitor().getEmail(),
-                SOLICITOR_AWAITING_CONDITIONAL_ORDER,
                 templateVars,
                 applicant2.getLanguagePreference()
             );

--- a/src/test/java/uk/gov/hmcts/divorce/common/notification/AwaitingConditionalOrderReminderNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/notification/AwaitingConditionalOrderReminderNotificationTest.java
@@ -8,8 +8,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.divorce.caseworker.service.task.GenerateCoversheet;
 import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
-import uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrder;
-import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
 import uk.gov.hmcts.divorce.document.content.CoversheetApplicantTemplateContent;
 import uk.gov.hmcts.divorce.notification.CommonContent;
 import uk.gov.hmcts.divorce.notification.NotificationService;
@@ -37,12 +35,8 @@ import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_APPLICANT_2_USER_
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_FIRST_NAME;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_LAST_NAME;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_EMAIL;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_NAME;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_USER_EMAIL;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
-import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getApplicant;
-import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getConditionalOrderQuestions;
 
 @ExtendWith(MockitoExtension.class)
 class AwaitingConditionalOrderReminderNotificationTest {
@@ -180,22 +174,6 @@ class AwaitingConditionalOrderReminderNotificationTest {
         caseData.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
 
         awaitingConditionalOrderReminderNotification.sendToApplicant2(caseData, 1234567890123456L);
-
-        verifyNoInteractions(notificationService);
-    }
-
-    @Test
-    void shouldNotSendNotificationToApplicant2SolicitorIfSoleApplication() {
-        final Applicant applicant = getApplicant();
-        applicant.setSolicitor(Solicitor.builder().email(TEST_SOLICITOR_EMAIL).name(TEST_SOLICITOR_NAME).build());
-        applicant.setSolicitorRepresented(YES);
-        final var caseData = CaseData.builder().applicant2(applicant).build();
-        caseData.setApplicationType(SOLE_APPLICATION);
-        caseData.setConditionalOrder(ConditionalOrder.builder()
-            .conditionalOrderApplicant1Questions(getConditionalOrderQuestions())
-            .build());
-
-        awaitingConditionalOrderReminderNotification.sendToApplicant2Solicitor(caseData, 1234567890123456L);
 
         verifyNoInteractions(notificationService);
     }


### PR DESCRIPTION

### Change description ###

- Removing reminder notifications for solicitors for awaiting conditional as reminder notifications are no more required because of switch to sole notification being sent after 14 days.
- 

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2962

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [x] README and other documentation has been updated / added (if needed)
