### PR TITLE
NFDIV-2705 - Withdraw notification wrongly sent to app2

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerWithdrawnIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerWithdrawnIT.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.config.WebMvcConfig;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseInvite;
 import uk.gov.hmcts.divorce.divorcecase.model.Court;
 import uk.gov.hmcts.divorce.notification.NotificationService;
 import uk.gov.hmcts.divorce.solicitor.service.CcdAccessService;
@@ -41,6 +42,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CREATOR;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.CITIZEN_APPLICATION_WITHDRAWN;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.ABOUT_TO_SUBMIT_URL;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.APP_2_CITIZEN_USER_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.AUTHORIZATION;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_APPLICANT_2_USER_EMAIL;
@@ -98,6 +100,7 @@ public class CaseworkerWithdrawnIT {
         caseData.getApplicant1().setSolicitorRepresented(YesOrNo.NO);
         caseData.getApplicant2().setSolicitorRepresented(YesOrNo.NO);
         caseData.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
+        caseData.setCaseInvite(new CaseInvite(TEST_APPLICANT_2_USER_EMAIL, null, APP_2_CITIZEN_USER_ID));
 
         mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
             .contentType(APPLICATION_JSON)

--- a/src/main/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotification.java
@@ -53,7 +53,7 @@ public class ApplicationWithdrawnNotification implements ApplicantNotification {
 
             if (caseData.getApplicationType().isSole()) {
                 templateVars.put(IS_RESPONDENT, YES);
-                templateVars.put(RESPONDENT_PARTNER, commonContent.getPartner(caseData, caseData.getApplicant2()));
+                templateVars.put(RESPONDENT_PARTNER, commonContent.getPartner(caseData, caseData.getApplicant1()));
             } else {
                 templateVars.put(IS_RESPONDENT, NO);
                 templateVars.put(RESPONDENT_PARTNER, "");

--- a/src/main/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotification.java
@@ -48,10 +48,9 @@ public class ApplicationWithdrawnNotification implements ApplicantNotification {
     @Override
     public void sendToApplicant2(final CaseData caseData, final Long id) {
         CaseInvite caseInvite = caseData.getCaseInvite();
-        boolean applicant2IsLinked = ObjectUtils.isNotEmpty(caseData.getApplicant2().getEmail())
+        boolean applicant2IsLinked = ObjectUtils.isNotEmpty(caseData.getApplicant2EmailAddress())
                 && !isNull(caseInvite)
-                && isNull(caseInvite.accessCode())
-                && !isNull(caseInvite.applicant2UserId());
+                && isNull(caseInvite.accessCode());
 
         if (applicant2IsLinked) {
             log.info("Sending application withdrawn notification to applicant 2 for: {}", id);
@@ -67,7 +66,7 @@ public class ApplicationWithdrawnNotification implements ApplicantNotification {
             }
 
             notificationService.sendEmail(
-                caseData.getApplicant2().getEmail(),
+                caseData.getApplicant2EmailAddress(),
                 CITIZEN_APPLICATION_WITHDRAWN,
                 templateVars,
                 caseData.getApplicant2().getLanguagePreference()

--- a/src/main/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotification.java
@@ -1,9 +1,11 @@
 package uk.gov.hmcts.divorce.common.notification;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseInvite;
 import uk.gov.hmcts.divorce.notification.ApplicantNotification;
 import uk.gov.hmcts.divorce.notification.CommonContent;
 import uk.gov.hmcts.divorce.notification.NotificationService;
@@ -45,9 +47,12 @@ public class ApplicationWithdrawnNotification implements ApplicantNotification {
 
     @Override
     public void sendToApplicant2(final CaseData caseData, final Long id) {
-        boolean applicant2IsLinked = !isNull(caseData.getCaseInvite())
-                && isNull(caseData.getCaseInvite().accessCode())
-                && !isNull(caseData.getCaseInvite().applicant2UserId());
+        CaseInvite caseInvite = caseData.getCaseInvite();
+        boolean applicant2IsLinked = ObjectUtils.isNotEmpty(caseData.getApplicant2().getEmail())
+                && !isNull(caseInvite)
+                && isNull(caseInvite.accessCode())
+                && !isNull(caseInvite.applicant2UserId());
+
         if (applicant2IsLinked) {
             log.info("Sending application withdrawn notification to applicant 2 for: {}", id);
             final Map<String, String> templateVars =

--- a/src/main/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotification.java
@@ -45,7 +45,9 @@ public class ApplicationWithdrawnNotification implements ApplicantNotification {
 
     @Override
     public void sendToApplicant2(final CaseData caseData, final Long id) {
-        boolean applicant2IsLinked = !isNull(caseData.getCaseInvite()) && isNull(caseData.getCaseInvite().accessCode());
+        boolean applicant2IsLinked = !isNull(caseData.getCaseInvite())
+                && isNull(caseData.getCaseInvite().accessCode())
+                && !isNull(caseData.getCaseInvite().applicant2UserId());
         if (applicant2IsLinked) {
             log.info("Sending application withdrawn notification to applicant 2 for: {}", id);
             final Map<String, String> templateVars =

--- a/src/main/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotification.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.divorce.common.notification;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
@@ -11,6 +10,7 @@ import uk.gov.hmcts.divorce.notification.NotificationService;
 
 import java.util.Map;
 
+import static java.util.Objects.isNull;
 import static uk.gov.hmcts.divorce.notification.CommonContent.NO;
 import static uk.gov.hmcts.divorce.notification.CommonContent.YES;
 import static uk.gov.hmcts.divorce.notification.EmailTemplateName.CITIZEN_APPLICATION_WITHDRAWN;
@@ -45,7 +45,8 @@ public class ApplicationWithdrawnNotification implements ApplicantNotification {
 
     @Override
     public void sendToApplicant2(final CaseData caseData, final Long id) {
-        if (ObjectUtils.isNotEmpty(caseData.getApplicant2().getEmail())) {
+        boolean applicant2IsLinked = !isNull(caseData.getCaseInvite()) && isNull(caseData.getCaseInvite().accessCode());
+        if (applicant2IsLinked) {
             log.info("Sending application withdrawn notification to applicant 2 for: {}", id);
             final Map<String, String> templateVars =
                 commonContent.mainTemplateVars(caseData, id, caseData.getApplicant2(), caseData.getApplicant1());

--- a/src/test/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotificationTest.java
@@ -113,7 +113,7 @@ public class ApplicationWithdrawnNotificationTest {
         Map<String, String> divorceTemplateVars = new HashMap<>(getMainTemplateVars());
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
             .thenReturn(divorceTemplateVars);
-        when(commonContent.getPartner(data, data.getApplicant2())).thenReturn("husband");
+        when(commonContent.getPartner(data, data.getApplicant1())).thenReturn("husband");
 
         applicationWithdrawnNotification.sendToApplicant2(data, 1234567890123456L);
 
@@ -130,7 +130,7 @@ public class ApplicationWithdrawnNotificationTest {
             eq(ENGLISH)
         );
         verify(commonContent).mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1());
-        verify(commonContent).getPartner(data, data.getApplicant2());
+        verify(commonContent).getPartner(data, data.getApplicant1());
     }
 
     @Test
@@ -143,7 +143,7 @@ public class ApplicationWithdrawnNotificationTest {
         dissolutionTemplateVars.putAll(Map.of(IS_DIVORCE, NO, IS_DISSOLUTION, YES));
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
             .thenReturn(dissolutionTemplateVars);
-        when(commonContent.getPartner(data, data.getApplicant2())).thenReturn("husband");
+        when(commonContent.getPartner(data, data.getApplicant1())).thenReturn("husband");
 
         applicationWithdrawnNotification.sendToApplicant2(data, 1234567890123456L);
 
@@ -160,7 +160,7 @@ public class ApplicationWithdrawnNotificationTest {
             eq(ENGLISH)
         );
         verify(commonContent).mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1());
-        verify(commonContent).getPartner(data, data.getApplicant2());
+        verify(commonContent).getPartner(data, data.getApplicant1());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotificationTest.java
@@ -282,19 +282,4 @@ public class ApplicationWithdrawnNotificationTest {
 
         verifyNoInteractions(notificationService);
     }
-
-    @Test
-    void shouldNotSendEmailToApplicant2IfNoApplicant2UserIdAssociatedWithCase() {
-        CaseData data = validApplicant1CaseData();
-        data.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
-        data.setCaseInvite(CaseInvite.builder()
-            .applicant2InviteEmailAddress(TEST_APPLICANT_2_USER_EMAIL)
-            .applicant2UserId(null)
-            .accessCode(null)
-            .build());
-
-        applicationWithdrawnNotification.sendToApplicant2(data, 1234567890123456L);
-
-        verifyNoInteractions(notificationService);
-    }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotificationTest.java
@@ -109,6 +109,11 @@ public class ApplicationWithdrawnNotificationTest {
     void shouldSendEmailToSoleRespondentWithDivorceContent() {
         CaseData data = validCaseDataForIssueApplication();
         data.setApplicationType(ApplicationType.SOLE_APPLICATION);
+        data.setCaseInvite(CaseInvite.builder()
+            .applicant2InviteEmailAddress(TEST_APPLICANT_2_USER_EMAIL)
+            .applicant2UserId(APP_2_CITIZEN_USER_ID)
+            .accessCode(null)
+            .build());
 
         Map<String, String> divorceTemplateVars = new HashMap<>(getMainTemplateVars());
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
@@ -138,6 +143,11 @@ public class ApplicationWithdrawnNotificationTest {
         CaseData data = validCaseDataForIssueApplication();
         data.setApplicationType(ApplicationType.SOLE_APPLICATION);
         data.setDivorceOrDissolution(DISSOLUTION);
+        data.setCaseInvite(CaseInvite.builder()
+            .applicant2InviteEmailAddress(TEST_APPLICANT_2_USER_EMAIL)
+            .applicant2UserId(APP_2_CITIZEN_USER_ID)
+            .accessCode(null)
+            .build());
 
         Map<String, String> dissolutionTemplateVars = new HashMap<>(getMainTemplateVars());
         dissolutionTemplateVars.putAll(Map.of(IS_DIVORCE, NO, IS_DISSOLUTION, YES));
@@ -167,6 +177,11 @@ public class ApplicationWithdrawnNotificationTest {
     void shouldSendEmailToJointApplicant2WithDivorceContent() {
         CaseData data = validCaseDataForIssueApplication();
         data.setApplicationType(ApplicationType.JOINT_APPLICATION);
+        data.setCaseInvite(CaseInvite.builder()
+            .applicant2InviteEmailAddress(TEST_APPLICANT_2_USER_EMAIL)
+            .applicant2UserId(APP_2_CITIZEN_USER_ID)
+            .accessCode(null)
+            .build());
 
         Map<String, String> divorceTemplateVars = new HashMap<>(getMainTemplateVars());
         when(commonContent.mainTemplateVars(data, 1234567890123456L, data.getApplicant2(), data.getApplicant1()))
@@ -194,6 +209,11 @@ public class ApplicationWithdrawnNotificationTest {
         CaseData data = validCaseDataForIssueApplication();
         data.setApplicationType(ApplicationType.JOINT_APPLICATION);
         data.setDivorceOrDissolution(DISSOLUTION);
+        data.setCaseInvite(CaseInvite.builder()
+            .applicant2InviteEmailAddress(TEST_APPLICANT_2_USER_EMAIL)
+            .applicant2UserId(APP_2_CITIZEN_USER_ID)
+            .accessCode(null)
+            .build());
 
         Map<String, String> dissolutionTemplateVars = new HashMap<>(getMainTemplateVars());
         dissolutionTemplateVars.putAll(Map.of(IS_DIVORCE, NO, IS_DISSOLUTION, YES));

--- a/src/test/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/notification/ApplicationWithdrawnNotificationTest.java
@@ -262,4 +262,19 @@ public class ApplicationWithdrawnNotificationTest {
 
         verifyNoInteractions(notificationService);
     }
+
+    @Test
+    void shouldNotSendEmailToApplicant2IfNoApplicant2UserIdAssociatedWithCase() {
+        CaseData data = validApplicant1CaseData();
+        data.getApplicant2().setEmail(TEST_APPLICANT_2_USER_EMAIL);
+        data.setCaseInvite(CaseInvite.builder()
+            .applicant2InviteEmailAddress(TEST_APPLICANT_2_USER_EMAIL)
+            .applicant2UserId(null)
+            .accessCode(null)
+            .build());
+
+        applicationWithdrawnNotification.sendToApplicant2(data, 1234567890123456L);
+
+        verifyNoInteractions(notificationService);
+    }
 }


### PR DESCRIPTION
### Change description ###

- App2 should only receive withdraw notification if they have already been linked.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2705

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

