### PR TITLE
Enable idam token caching for preview and AAT

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/idam/IdamService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/idam/IdamService.java
@@ -3,14 +3,19 @@ package uk.gov.hmcts.divorce.idam;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.User;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
+import java.util.stream.Stream;
+
 import static uk.gov.hmcts.divorce.common.config.ControllerConstants.BEARER_PREFIX;
 
 @Service
+@EnableCaching
 public class IdamService {
     @Value("${idam.systemupdate.username}")
     private String systemUpdateUserName;
@@ -29,7 +34,18 @@ public class IdamService {
     }
 
     public User retrieveSystemUpdateUserDetails() {
+        String environment = System.getenv().getOrDefault("CLUSTER_NAME", null);
+
+        if (null != environment && Stream.of("preview", "aat").anyMatch(environment::contains)) {
+            retrieveUser(getCachedIdamOauth2Token(systemUpdateUserName, systemUpdatePassword));
+        }
+
         return retrieveUser(getIdamOauth2Token(systemUpdateUserName, systemUpdatePassword));
+    }
+
+    @Cacheable(value = "idamToken", key = "#root.args[0]")
+    public String getCachedIdamOauth2Token(String username, String password) {
+        return idamClient.getAccessToken(username, password);
     }
 
     private String getIdamOauth2Token(String username, String password) {


### PR DESCRIPTION
- Currently Idam token are cached when running functional tests but when functional tests are executed they are executed against main app which also generates system user token.

- This PR conditionally only does caching for Idam token in AAT and preview as for production we don't intent to do caching as of now.
