### PR TITLE
NFDIV-3091 - Add AwaitingJointFinalOrder to allowed states for Final Order tab

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
@@ -16,6 +16,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingClarification
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingDocuments;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingFinalOrder;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingHWFDecision;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingJointFinalOrder;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingLegalAdvisorReferral;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingPayment;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingService;
@@ -395,6 +396,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
             .forRoles(CASE_WORKER, LEGAL_ADVISOR, APPLICANT_1_SOLICITOR, APPLICANT_2_SOLICITOR, SUPER_USER)
             .showCondition(showForState(
                 AwaitingFinalOrder,
+                AwaitingJointFinalOrder,
                 FinalOrderRequested,
                 FinalOrderPending,
                 FinalOrderOverdue,


### PR DESCRIPTION
### Change description ###

Add AwaitingJointFinalOrder to allowed states for Final Order tab.
<img width="1792" alt="Screenshot 2022-10-19 at 08 27 58" src="https://user-images.githubusercontent.com/95974886/196625350-4398ed31-9860-4ff0-addc-2df4218223d5.png">


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3091

**Before merging a pull request make sure that:**

- [X] tests have been updated / new tests has been added (if needed)
- [X] README and other documentation has been updated / added (if needed)