### PR TITLE
Use expiring caffeine cache to remove expired tokens

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -289,6 +289,7 @@ dependencies {
   implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.19.0-RELEASE'
   implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
   implementation group: 'commons-validator', name: 'commons-validator', version: '1.7'
+  implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.1.1'
 
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 

--- a/src/functionalTest/java/uk/gov/hmcts/divorce/testutil/IdamTokenGenerator.java
+++ b/src/functionalTest/java/uk/gov/hmcts/divorce/testutil/IdamTokenGenerator.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.divorce.testutil;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -9,6 +11,7 @@ import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 @TestPropertySource("classpath:application.yaml")
 @Service
@@ -31,15 +34,19 @@ public class IdamTokenGenerator {
     @Autowired
     private IdamClient idamClient;
 
+    private final Cache<String, String> cache = Caffeine.newBuilder().expireAfterWrite(2, TimeUnit.HOURS).build();
+
     public String generateIdamTokenForSolicitor() {
         return tokensMap.computeIfAbsent(solicitorUsername, token -> idamClient.getAccessToken(solicitorUsername, solicitorPassword));
     }
 
     public String generateIdamTokenForSystem() {
-        return tokensMap.computeIfAbsent(
-            systemUpdateUsername,
-            token -> idamClient.getAccessToken(systemUpdateUsername, systemUpdatePassword)
-        );
+        String systemUserToken = cache.getIfPresent(systemUpdateUsername);
+        if (systemUserToken == null) {
+            systemUserToken = idamClient.getAccessToken(systemUpdateUsername, systemUpdatePassword);
+            cache.put(systemUpdateUsername, systemUserToken);
+        }
+        return systemUserToken;
     }
 
     public UserDetails getUserDetailsFor(final String token) {

--- a/src/main/java/uk/gov/hmcts/divorce/idam/IdamService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/idam/IdamService.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.divorce.idam;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,8 +10,7 @@ import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.User;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import static uk.gov.hmcts.divorce.common.config.ControllerConstants.BEARER_PREFIX;
 
@@ -24,7 +25,7 @@ public class IdamService {
     @Autowired
     private IdamClient idamClient;
 
-    private final Map<String, String> tokensMap = new ConcurrentHashMap<>();
+    private final Cache<String, String> cache = Caffeine.newBuilder().expireAfterWrite(2, TimeUnit.HOURS).build();
 
     public User retrieveUser(String authorisation) {
         final String bearerToken = getBearerToken(authorisation);
@@ -44,7 +45,12 @@ public class IdamService {
     }
 
     private String getCachedIdamOauth2Token(String username, String password) {
-        return tokensMap.computeIfAbsent(username, token -> idamClient.getAccessToken(username, password));
+        String userToken = cache.getIfPresent(username);
+        if (userToken == null) {
+            userToken = idamClient.getAccessToken(username, password);
+            cache.put(username, userToken);
+        }
+        return userToken;
     }
 
     private String getIdamOauth2Token(String username, String password) {


### PR DESCRIPTION
### Change description ###

- Currently if AAT or preview pods are not refreshed due to new commits not being added and if pods are up for more than 8 hours then existing implementation will return expired tokens which is causing front end pipeline to fail.
- This implementation removes expires token after 2 hours or adding token.



