### PR TITLE
NFDIV-2660 - Add HandleWelshFinalOrder task to FO events

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/common/Applicant2ApplyForFinalOrderIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/common/Applicant2ApplyForFinalOrderIT.java
@@ -11,12 +11,12 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.divorce.common.config.WebMvcConfig;
+import uk.gov.hmcts.divorce.common.service.task.ProgressFinalOrderState;
 import uk.gov.hmcts.divorce.divorcecase.model.ApplicationType;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
 import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
 import uk.gov.hmcts.divorce.notification.NotificationService;
-import uk.gov.hmcts.divorce.solicitor.service.task.ProgressFinalOrderState;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 
 import java.time.Clock;

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/common/ApplyForFinalOrderIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/common/ApplyForFinalOrderIT.java
@@ -12,12 +12,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.config.WebMvcConfig;
+import uk.gov.hmcts.divorce.common.service.task.ProgressFinalOrderState;
 import uk.gov.hmcts.divorce.divorcecase.model.ApplicationType;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
 import uk.gov.hmcts.divorce.divorcecase.model.Solicitor;
 import uk.gov.hmcts.divorce.notification.NotificationService;
-import uk.gov.hmcts.divorce.solicitor.service.task.ProgressFinalOrderState;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 
 import java.time.Clock;

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenFinalOrderDelayReason.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenFinalOrderDelayReason.java
@@ -68,18 +68,10 @@ public class CitizenFinalOrderDelayReason implements CCDConfig<CaseData, State, 
         log.info("Citizen final order delay reason about to submit callback invoked for Case Id: {}", details.getId());
 
         CaseData data = details.getData();
-        State endState = FinalOrderRequested;
-
-        if (data.isWelshApplication()) {
-            data.getApplication().setWelshPreviousState(endState);
-            endState = WelshTranslationReview;
-            log.info("State set to WelshTranslationReview, WelshPreviousState set to {}, CaseID {}",
-                data.getApplication().getWelshPreviousState(), details.getId());
-        }
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(data)
-            .state(endState)
+            .state(FinalOrderRequested)
             .build();
     }
 

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/Applicant2ApplyForFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/Applicant2ApplyForFinalOrder.java
@@ -12,21 +12,16 @@ import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
 import uk.gov.hmcts.divorce.common.event.page.Applicant2ApplyForFinalOrderDetails;
 import uk.gov.hmcts.divorce.common.notification.Applicant2AppliedForFinalOrderNotification;
 import uk.gov.hmcts.divorce.common.notification.FinalOrderRequestedNotification;
+import uk.gov.hmcts.divorce.common.service.SubmitFinalOrderService;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
-import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
-import uk.gov.hmcts.divorce.solicitor.service.task.ProgressFinalOrderState;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
 import java.time.Clock;
-import java.time.LocalDateTime;
 import java.util.List;
 
-import static java.util.Objects.isNull;
-import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
-import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingFinalOrder;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingJointFinalOrder;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.FinalOrderOverdue;
@@ -58,7 +53,7 @@ public class Applicant2ApplyForFinalOrder implements CCDConfig<CaseData, State, 
     private NotificationDispatcher notificationDispatcher;
 
     @Autowired
-    private ProgressFinalOrderState progressFinalOrderState;
+    private SubmitFinalOrderService submitFinalOrderService;
 
     @Autowired
     private Clock clock;
@@ -99,18 +94,7 @@ public class Applicant2ApplyForFinalOrder implements CCDConfig<CaseData, State, 
 
         data.getApplication().setPreviousState(beforeDetails.getState());
 
-        if (AwaitingFinalOrder.equals(details.getState())) {
-            FinalOrder finalOrder = details.getData().getFinalOrder();
-
-            if (isNull(finalOrder.getApplicant1AppliedForFinalOrderFirst())
-                    && isNull(finalOrder.getApplicant2AppliedForFinalOrderFirst())) {
-                finalOrder.setApplicant2AppliedForFinalOrderFirst(YES);
-                finalOrder.setApplicant1AppliedForFinalOrderFirst(NO);
-                finalOrder.setDateFinalOrderSubmitted(LocalDateTime.now(clock));
-            }
-        }
-
-        var updatedDetails = progressFinalOrderState.apply(details);
+        CaseDetails<CaseData, State> updatedDetails = submitFinalOrderService.submitFinalOrderAsApplicant2(details);
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(updatedDetails.getData())

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/ApplyForFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/ApplyForFinalOrder.java
@@ -12,21 +12,16 @@ import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
 import uk.gov.hmcts.divorce.common.event.page.ApplyForFinalOrderDetails;
 import uk.gov.hmcts.divorce.common.notification.Applicant1AppliedForFinalOrderNotification;
 import uk.gov.hmcts.divorce.common.notification.FinalOrderRequestedNotification;
+import uk.gov.hmcts.divorce.common.service.SubmitFinalOrderService;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
-import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
-import uk.gov.hmcts.divorce.solicitor.service.task.ProgressFinalOrderState;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
 import java.time.Clock;
-import java.time.LocalDateTime;
 import java.util.List;
 
-import static java.util.Objects.isNull;
-import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
-import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingFinalOrder;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingJointFinalOrder;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.FinalOrderOverdue;
@@ -58,7 +53,7 @@ public class ApplyForFinalOrder implements CCDConfig<CaseData, State, UserRole> 
     private NotificationDispatcher notificationDispatcher;
 
     @Autowired
-    private ProgressFinalOrderState progressFinalOrderState;
+    private SubmitFinalOrderService submitFinalOrderService;
 
     @Autowired
     private Clock clock;
@@ -99,18 +94,7 @@ public class ApplyForFinalOrder implements CCDConfig<CaseData, State, UserRole> 
 
         data.getApplication().setPreviousState(beforeDetails.getState());
 
-        if (AwaitingFinalOrder.equals(details.getState())) {
-            FinalOrder finalOrder = details.getData().getFinalOrder();
-
-            if (isNull(finalOrder.getApplicant1AppliedForFinalOrderFirst())
-                && isNull(finalOrder.getApplicant2AppliedForFinalOrderFirst())) {
-                finalOrder.setApplicant2AppliedForFinalOrderFirst(NO);
-                finalOrder.setApplicant1AppliedForFinalOrderFirst(YES);
-                finalOrder.setDateFinalOrderSubmitted(LocalDateTime.now(clock));
-            }
-        }
-
-        var updatedDetails = progressFinalOrderState.apply(details);
+        CaseDetails<CaseData, State> updatedDetails = submitFinalOrderService.submitFinalOrder(details);
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(updatedDetails.getData())

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/SubmitFinalOrderService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/SubmitFinalOrderService.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.divorce.common.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.common.service.task.HandleWelshFinalOrder;
+import uk.gov.hmcts.divorce.common.service.task.ProgressFinalOrderState;
+import uk.gov.hmcts.divorce.common.service.task.SetFinalOrderFields;
+import uk.gov.hmcts.divorce.common.service.task.SetFinalOrderFieldsAsApplicant2;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTaskRunner;
+
+@Service
+public class SubmitFinalOrderService {
+
+    @Autowired
+    private SetFinalOrderFields setFinalOrderFields;
+
+    @Autowired
+    private SetFinalOrderFieldsAsApplicant2 setFinalOrderFieldsAsApplicant2;
+
+    @Autowired
+    private ProgressFinalOrderState progressFinalOrderState;
+
+    @Autowired
+    private HandleWelshFinalOrder handleWelshFinalOrder;
+
+    public CaseDetails<CaseData, State> submitFinalOrder(final CaseDetails<CaseData, State> caseDetails) {
+
+        return CaseTaskRunner.caseTasks(
+            setFinalOrderFields,
+            progressFinalOrderState,
+            handleWelshFinalOrder
+        ).run(caseDetails);
+    }
+
+    public CaseDetails<CaseData, State> submitFinalOrderAsApplicant2(final CaseDetails<CaseData, State> caseDetails) {
+
+        return CaseTaskRunner.caseTasks(
+            setFinalOrderFieldsAsApplicant2,
+            progressFinalOrderState,
+            handleWelshFinalOrder
+        ).run(caseDetails);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/HandleWelshFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/HandleWelshFinalOrder.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.divorce.common.service.task;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.FinalOrderRequested;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.WelshTranslationReview;
+
+@Slf4j
+@Component
+public class HandleWelshFinalOrder implements CaseTask {
+
+    @Override
+    public CaseDetails<CaseData, State> apply(CaseDetails<CaseData, State> details) {
+        log.info("Running HandleWelshFinalOrder task for CaseID {}", details.getId());
+        CaseData data = details.getData();
+
+        if (FinalOrderRequested.equals(details.getState()) && data.isWelshApplication() && isFinalOrderFreeTextPresent(data)) {
+            data.getApplication().setWelshPreviousState(details.getState());
+            details.setState(WelshTranslationReview);
+            log.info("State set to WelshTranslationReview, WelshPreviousState set to {}, CaseID {}",
+                data.getApplication().getWelshPreviousState(), details.getId());
+        }
+
+        return details;
+    }
+
+
+    private boolean isFinalOrderFreeTextPresent(CaseData data) {
+        return !isEmpty(data.getFinalOrder().getApplicant1FinalOrderLateExplanation())
+            || !isEmpty(data.getFinalOrder().getApplicant2FinalOrderLateExplanation());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/HandleWelshFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/HandleWelshFinalOrder.java
@@ -7,8 +7,8 @@ import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
 
+import static java.util.Objects.isNull;
 import static org.apache.commons.lang.StringUtils.isEmpty;
-import static uk.gov.hmcts.divorce.divorcecase.model.State.FinalOrderRequested;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.WelshTranslationReview;
 
 @Slf4j
@@ -20,7 +20,7 @@ public class HandleWelshFinalOrder implements CaseTask {
         log.info("Running HandleWelshFinalOrder task for CaseID {}", details.getId());
         CaseData data = details.getData();
 
-        if (FinalOrderRequested.equals(details.getState()) && data.isWelshApplication() && isFinalOrderFreeTextPresent(data)) {
+        if (data.isWelshApplication() && !isNull(data.getFinalOrder().getDateFinalOrderSubmitted()) && isFinalOrderFreeTextPresent(data)) {
             data.getApplication().setWelshPreviousState(details.getState());
             details.setState(WelshTranslationReview);
             log.info("State set to WelshTranslationReview, WelshPreviousState set to {}, CaseID {}",

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/ProgressFinalOrderState.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/ProgressFinalOrderState.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.divorce.solicitor.service.task;
+package uk.gov.hmcts.divorce.common.service.task;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -17,6 +17,7 @@ public class ProgressFinalOrderState implements CaseTask {
 
     @Override
     public CaseDetails<CaseData, State> apply(CaseDetails<CaseData, State> details) {
+        log.info("Running ProgressFinalOrderState task for CaseID {}", details.getId());
 
         CaseData data = details.getData();
         State state = details.getState();

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/SetFinalOrderFields.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/SetFinalOrderFields.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.divorce.common.service.task;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static java.util.Objects.isNull;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingFinalOrder;
+
+@Slf4j
+@Component
+public class SetFinalOrderFields implements CaseTask {
+
+    @Autowired
+    private Clock clock;
+
+    @Override
+    public CaseDetails<CaseData, State> apply(CaseDetails<CaseData, State> details) {
+        log.info("Running SetFinalOrderFields task for CaseID {}", details.getId());
+
+        if (AwaitingFinalOrder.equals(details.getState())) {
+            log.info("Updating final order fields for CaseID {} (SetFinalOrderFields)", details.getId());
+            FinalOrder finalOrder = details.getData().getFinalOrder();
+
+            if (isNull(finalOrder.getApplicant1AppliedForFinalOrderFirst())
+                && isNull(finalOrder.getApplicant2AppliedForFinalOrderFirst())) {
+                finalOrder.setApplicant2AppliedForFinalOrderFirst(NO);
+                finalOrder.setApplicant1AppliedForFinalOrderFirst(YES);
+                finalOrder.setDateFinalOrderSubmitted(LocalDateTime.now(clock));
+            }
+        }
+
+        return details;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/SetFinalOrderFieldsAsApplicant2.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/SetFinalOrderFieldsAsApplicant2.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.divorce.common.service.task;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static java.util.Objects.isNull;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingFinalOrder;
+
+@Slf4j
+@Component
+public class SetFinalOrderFieldsAsApplicant2 implements CaseTask {
+
+    @Autowired
+    private Clock clock;
+
+    @Override
+    public CaseDetails<CaseData, State> apply(CaseDetails<CaseData, State> details) {
+        log.info("Running SetFinalOrderFieldsAsApplicant2 task for CaseID {}", details.getId());
+
+        if (AwaitingFinalOrder.equals(details.getState())) {
+            log.info("Updating final order fields for CaseID {} (SetFinalOrderFieldsAsApplicant2)", details.getId());
+            FinalOrder finalOrder = details.getData().getFinalOrder();
+
+            if (isNull(finalOrder.getApplicant1AppliedForFinalOrderFirst())
+                && isNull(finalOrder.getApplicant2AppliedForFinalOrderFirst())) {
+                finalOrder.setApplicant2AppliedForFinalOrderFirst(YES);
+                finalOrder.setApplicant1AppliedForFinalOrderFirst(NO);
+                finalOrder.setDateFinalOrderSubmitted(LocalDateTime.now(clock));
+            }
+        }
+
+        return details;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/FinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/FinalOrder.java
@@ -117,24 +117,44 @@ public class FinalOrder {
     private LocalDate dateFinalOrderEligibleToRespondent;
 
     @CCD(
-        label = "Final order late explanation",
+        label = "${labelContentApplicantOrApplicant1} final order late explanation",
         access = {DefaultAccess.class}
     )
     private String applicant1FinalOrderLateExplanation;
 
     @CCD(
-        label = "Final order late explanation",
+        label = "${labelContentApplicantOrApplicant1} final order late explanation (translated)",
         access = {DefaultAccess.class}
     )
     private String applicant1FinalOrderLateExplanationTranslated;
 
     @CCD(
-        label = "Translated To?",
+        label = "${labelContentApplicantOrApplicant1} final order late explanation translated to?",
         typeOverride = FixedRadioList,
         typeParameterOverride = "TranslatedToLanguage",
         access = {SystemUpdateAndSuperUserAccess.class}
     )
     private TranslatedToLanguage applicant1FinalOrderLateExplanationTranslatedTo;
+
+    @CCD(
+        label = "${labelContentTheApplicant2UC} final order late explanation",
+        access = {DefaultAccess.class}
+    )
+    private String applicant2FinalOrderLateExplanation;
+
+    @CCD(
+        label = "${labelContentTheApplicant2UC} final order late explanation (translated)",
+        access = {DefaultAccess.class}
+    )
+    private String applicant2FinalOrderLateExplanationTranslated;
+
+    @CCD(
+        label = "${labelContentTheApplicant2UC} final order late explanation translated to?",
+        typeOverride = FixedRadioList,
+        typeParameterOverride = "TranslatedToLanguage",
+        access = {SystemUpdateAndSuperUserAccess.class}
+    )
+    private TranslatedToLanguage applicant2FinalOrderLateExplanationTranslatedTo;
 
 
     @CCD(

--- a/src/test/java/uk/gov/hmcts/divorce/common/event/Applicant2ApplyForFinalOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/event/Applicant2ApplyForFinalOrderTest.java
@@ -12,12 +12,12 @@ import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.notification.Applicant2AppliedForFinalOrderNotification;
 import uk.gov.hmcts.divorce.common.notification.FinalOrderRequestedNotification;
+import uk.gov.hmcts.divorce.common.service.task.ProgressFinalOrderState;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
-import uk.gov.hmcts.divorce.solicitor.service.task.ProgressFinalOrderState;
 
 import java.time.Clock;
 import java.time.LocalDate;

--- a/src/test/java/uk/gov/hmcts/divorce/common/event/ApplyForFinalOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/event/ApplyForFinalOrderTest.java
@@ -12,12 +12,12 @@ import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.notification.Applicant1AppliedForFinalOrderNotification;
 import uk.gov.hmcts.divorce.common.notification.FinalOrderRequestedNotification;
+import uk.gov.hmcts.divorce.common.service.task.ProgressFinalOrderState;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
-import uk.gov.hmcts.divorce.solicitor.service.task.ProgressFinalOrderState;
 
 import java.time.Clock;
 import java.time.LocalDate;

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/service/task/ProgressFinalOrderStateTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/service/task/ProgressFinalOrderStateTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.common.service.task.ProgressFinalOrderState;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 


### PR DESCRIPTION
### Change description ###

- Refactor FO events.
- Add HandleWelshFinalOrder to FO events that only sets the state to WelshTranslationReview when FO is finished (submitted by both apps in joint, or app in sole) and free text needs translating.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-2660

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

