### PR TITLE
Add migration for setting court hearing on bulk action cases

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemMigrateCaseWithCoEGeneration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemMigrateCaseWithCoEGeneration.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.divorce.systemupdate.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.divorce.systemupdate.service.task.GenerateCertificateOfEntitlement;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.State.STATES_NOT_WITHDRAWN_OR_REJECTED;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.task.CaseTaskRunner.caseTasks;
+
+@Slf4j
+@Component
+public class SystemMigrateCaseWithCoEGeneration implements CCDConfig<CaseData, State, UserRole> {
+
+    public static final String SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION = "system-migrate-case-and-generate-coe";
+
+    @Autowired
+    private GenerateCertificateOfEntitlement generateCertificateOfEntitlement;
+
+    @Override
+    public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
+        configBuilder
+            .event(SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION)
+            .forStates(STATES_NOT_WITHDRAWN_OR_REJECTED)
+            .name("Migrate case data")
+            .description("Migrate case data to the latest version and generate CoE")
+            .grant(CREATE_READ_UPDATE, SYSTEMUPDATE);
+    }
+
+    public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(final CaseDetails<CaseData, State> details,
+                                                                       final CaseDetails<CaseData, State> beforeDetails) {
+
+        log.info("{} about to submit callback invoked for case id: {}", SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION, details.getId());
+
+        final CaseDetails<CaseData, State> updatedDetails = caseTasks(generateCertificateOfEntitlement).run(details);
+
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(updatedDetails.getData())
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/CaseCourtHearingMigration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/CaseCourtHearingMigration.java
@@ -1,0 +1,93 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionCaseTypeConfig;
+import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
+import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
+import uk.gov.hmcts.reform.idam.client.models.User;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static org.springframework.util.CollectionUtils.isEmpty;
+
+@Component
+@Slf4j
+public class CaseCourtHearingMigration implements Migration {
+
+    @Value("${MIGRATE_CASE_COURT_HEARING:false}")
+    private boolean migrateCaseCourtHearing;
+
+    @Value("#{'${CASE_COURT_HEARING_REFERENCES:}'.split(',')}")
+    private List<Long> caseCourtHearingReferences;
+
+    @Autowired
+    private CoreCaseDataApi coreCaseDataApi;
+
+    @Autowired
+    private SetCaseCourtHearingBulkAction setCaseCourtHearingBulkAction;
+
+    @Override
+    public void apply(final User user, final String serviceAuthorization) {
+
+        final List<Long> allReferences = caseCourtHearingReferences.stream()
+            .filter(Objects::nonNull)
+            .toList();
+
+        if (migrateCaseCourtHearing && !isEmpty(allReferences)) {
+            log.info("Started CaseCourtHearingMigration with references: {}", caseCourtHearingReferences);
+            try {
+                final List<CaseDetails> caseDetails = searchForCaseCourtHearingCases(allReferences, user, serviceAuthorization);
+
+                log.info("CaseCourtHearingMigration Number of bulk cases {}", caseDetails.size());
+
+                caseDetails
+                    .parallelStream()
+                    .forEach(caseDetail -> setCaseCourtHearingBulkAction.setCaseCourtHearing(caseDetail, user, serviceAuthorization));
+
+            } catch (final CcdSearchCaseException e) {
+                log.error("Case schedule task(CaseCourtHearingMigration) stopped after search error", e);
+            }
+            log.info("Completed CaseCourtHearingMigration");
+        } else {
+            log.info("Skipping CaseCourtHearingMigration, MIGRATE_CASE_COURT_HEARING={}, references size: {}",
+                migrateCaseCourtHearing,
+                allReferences.size());
+        }
+    }
+
+    private List<CaseDetails> searchForCaseCourtHearingCases(final List<Long> references,
+                                                             final User user,
+                                                             final String serviceAuthorization) {
+
+        final BoolQueryBuilder referenceQuery = boolQuery();
+        references.forEach(reference -> referenceQuery.should(matchQuery("reference", reference)));
+
+        final SearchSourceBuilder sourceBuilder = SearchSourceBuilder
+            .searchSource()
+            .query(boolQuery().must(referenceQuery))
+            .from(0)
+            .size(100);
+
+        log.info("CaseCourtHearingMigration searching ES, {}", sourceBuilder);
+
+        final SearchResult searchResult = coreCaseDataApi.searchCases(
+            user.getAuthToken(),
+            serviceAuthorization,
+            BulkActionCaseTypeConfig.CASE_TYPE,
+            sourceBuilder.toString());
+
+        log.info("CaseCourtHearingMigration result ES, {}", searchResult);
+
+        return searchResult.getCases();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/SetAosIsDraftedToYesMigration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/SetAosIsDraftedToYesMigration.java
@@ -5,6 +5,7 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.predicate.HasAosDraftedEventPredicate;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/SetCaseCourtHearingBulkAction.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/SetCaseCourtHearingBulkAction.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkActionCaseData;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkListCaseDetails;
+import uk.gov.hmcts.divorce.bulkaction.service.CaseTriggerService;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+import uk.gov.hmcts.divorce.systemupdate.convert.CaseDetailsConverter;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.predicate.CaseCourtHearingPredicate;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.task.CaseCourtHearingTaskProvider;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.idam.client.models.User;
+
+import java.util.function.Predicate;
+
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCaseWithCoEGeneration.SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION;
+
+@Slf4j
+@Component
+public class SetCaseCourtHearingBulkAction {
+
+    @Autowired
+    private CaseCourtHearingPredicate caseCourtHearingPredicate;
+
+    @Autowired
+    private CaseDetailsConverter caseDetailsConverter;
+
+    @Autowired
+    private CaseTriggerService caseTriggerService;
+
+    @Autowired
+    private CaseCourtHearingTaskProvider caseCourtHearingTask;
+
+    public void setCaseCourtHearing(final CaseDetails bulkCaseDetails, final User user, final String serviceAuthorization) {
+
+        final uk.gov.hmcts.ccd.sdk.api.CaseDetails<BulkActionCaseData, BulkActionState> bulkActionDetails
+            = caseDetailsConverter.convertToBulkActionCaseDetailsFromReformModel(bulkCaseDetails);
+
+        final BulkActionCaseData bulkActionCaseData = bulkActionDetails.getData();
+        final Predicate<ListValue<BulkListCaseDetails>> caseHearingIsNotSet = caseCourtHearingPredicate
+            .caseHearingIsNotSet(bulkActionCaseData, user, serviceAuthorization);
+
+        final CaseTask caseTask = caseCourtHearingTask.getCaseTask(bulkActionDetails);
+
+        bulkActionCaseData.getBulkListCaseDetails().stream()
+            .filter(caseHearingIsNotSet)
+            .forEach(listValue -> {
+                caseTriggerService.caseTrigger(
+                    listValue,
+                    SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION,
+                    caseTask,
+                    user,
+                    serviceAuthorization);
+            });
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/predicate/CaseCourtHearingPredicate.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/predicate/CaseCourtHearingPredicate.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.predicate;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkActionCaseData;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkListCaseDetails;
+import uk.gov.hmcts.divorce.systemupdate.convert.CaseDetailsConverter;
+import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
+import uk.gov.hmcts.reform.idam.client.models.User;
+
+import java.util.function.Predicate;
+
+@Component
+@Slf4j
+public class CaseCourtHearingPredicate {
+
+    @Autowired
+    private CoreCaseDataApi coreCaseDataApi;
+
+    @Autowired
+    private CaseDetailsConverter caseDetailsConverter;
+
+    public Predicate<ListValue<BulkListCaseDetails>> caseHearingIsNotSet(final BulkActionCaseData bulkActionCaseData,
+                                                                         final User user,
+                                                                         final String serviceAuthorization) {
+        return listValue -> {
+            final var caseReference = listValue.getValue().getCaseReference().getCaseReference();
+
+            final var conditionalOrder = caseDetailsConverter
+                .convertToCaseDetailsFromReformModel(coreCaseDataApi
+                    .getCase(user.getAuthToken(), serviceAuthorization, caseReference))
+                .getData()
+                .getConditionalOrder();
+
+            return !bulkActionCaseData.getDateAndTimeOfHearing().equals(conditionalOrder.getDateAndTimeOfHearing())
+                || !bulkActionCaseData.getCourt().equals(conditionalOrder.getCourt());
+        };
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/predicate/HasAosDraftedEventPredicate.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/predicate/HasAosDraftedEventPredicate.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.divorce.systemupdate.schedule.migration;
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.predicate;
 
 import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/CaseCourtHearingTaskProvider.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/CaseCourtHearingTaskProvider.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkActionCaseData;
+import uk.gov.hmcts.divorce.bulkaction.task.BulkActionCaseTaskProvider;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCaseWithCoEGeneration.SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION;
+
+@Slf4j
+@Component
+public class CaseCourtHearingTaskProvider implements BulkActionCaseTaskProvider {
+
+    @Override
+    public String getEventId() {
+        return SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION;
+    }
+
+    @Override
+    public CaseTask getCaseTask(CaseDetails<BulkActionCaseData, BulkActionState> bulkCaseDetails) {
+        return caseDetails -> {
+
+            log.info("Updating case data for Case Id: {} Event: {}", caseDetails.getId(), SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION);
+
+            final BulkActionCaseData bulkActionCaseData = bulkCaseDetails.getData();
+
+            final var conditionalOrder = caseDetails.getData().getConditionalOrder();
+            conditionalOrder.setDateAndTimeOfHearing(
+                bulkActionCaseData.getDateAndTimeOfHearing()
+            );
+            conditionalOrder.setCourt(
+                bulkActionCaseData.getCourt()
+            );
+
+            return caseDetails;
+        };
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemMigrateCaseWithCoEGenerationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemMigrateCaseWithCoEGenerationTest.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.divorce.systemupdate.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.divorce.systemupdate.service.task.GenerateCertificateOfEntitlement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCaseWithCoEGeneration.SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+
+@ExtendWith(SpringExtension.class)
+class SystemMigrateCaseWithCoEGenerationTest {
+
+    @Mock
+    private GenerateCertificateOfEntitlement generateCertificateOfEntitlement;
+
+    @InjectMocks
+    private SystemMigrateCaseWithCoEGeneration systemMigrateCaseWithCoEGeneration;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() {
+        final ConfigBuilderImpl<CaseData, State, UserRole> configBuilder = createCaseDataConfigBuilder();
+
+        systemMigrateCaseWithCoEGeneration.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION);
+    }
+
+    @Test
+    void shouldGenerateCertificateOfEntitlementOnAboutToSubmit() {
+
+        final CaseData caseData = mock(CaseData.class);
+        final CaseData responseCaseData = mock(CaseData.class);
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setId(1L);
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> responseCaseDetails = new CaseDetails<>();
+        responseCaseDetails.setId(1L);
+        responseCaseDetails.setData(responseCaseData);
+
+        when(generateCertificateOfEntitlement.apply(caseDetails)).thenReturn(responseCaseDetails);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response =
+            systemMigrateCaseWithCoEGeneration.aboutToSubmit(caseDetails, caseDetails);
+
+        assertThat(response.getData()).isEqualTo(responseCaseData);
+
+        verify(generateCertificateOfEntitlement).apply(caseDetails);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/CaseCourtHearingMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/CaseCourtHearingMigrationTest.java
@@ -1,0 +1,123 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration;
+
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionCaseTypeConfig;
+import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
+import uk.gov.hmcts.reform.idam.client.models.User;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
+
+@ExtendWith(MockitoExtension.class)
+class CaseCourtHearingMigrationTest {
+
+    @Mock
+    private Logger logger;
+
+    @Mock
+    private CoreCaseDataApi coreCaseDataApi;
+    @Mock
+    private SetCaseCourtHearingBulkAction setCaseCourtHearingBulkAction;
+
+    @InjectMocks
+    private CaseCourtHearingMigration caseCourtHearingMigration;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(SYSTEM_UPDATE_AUTH_TOKEN, UserDetails.builder().build());
+        setField(caseCourtHearingMigration, "caseCourtHearingReferences", List.of(TEST_CASE_ID));
+    }
+
+    @Test
+    void shouldMigrateSelectedBulkCases() {
+
+        setField(caseCourtHearingMigration, "migrateCaseCourtHearing", true);
+
+        final CaseDetails caseDetails1 = CaseDetails.builder()
+            .id(1L)
+            .data(new HashMap<>())
+            .build();
+
+        final CaseDetails caseDetails2 = CaseDetails.builder()
+            .id(2L)
+            .data(new HashMap<>())
+            .build();
+
+        final List<CaseDetails> searchResponse = List.of(caseDetails1, caseDetails2);
+
+        final SearchResult searchResult = SearchResult.builder()
+            .cases(searchResponse)
+            .build();
+
+        when(coreCaseDataApi
+            .searchCases(
+                user.getAuthToken(),
+                SERVICE_AUTHORIZATION,
+                BulkActionCaseTypeConfig.CASE_TYPE,
+                getSearchSource()))
+            .thenReturn(searchResult);
+
+        caseCourtHearingMigration.apply(user, SERVICE_AUTHORIZATION);
+
+        verify(setCaseCourtHearingBulkAction).setCaseCourtHearing(caseDetails1, user, SERVICE_AUTHORIZATION);
+        verify(setCaseCourtHearingBulkAction).setCaseCourtHearing(caseDetails2, user, SERVICE_AUTHORIZATION);
+    }
+
+    @Test
+    void shouldSkipProcessingIfEnvironmentSwitchIsSetToFalse() {
+
+        setField(caseCourtHearingMigration, "migrateCaseCourtHearing", false);
+
+        caseCourtHearingMigration.apply(user, SERVICE_AUTHORIZATION);
+
+        verify(logger).info("Skipping CaseCourtHearingMigration, MIGRATE_CASE_COURT_HEARING={}, references size: {}", false, 1);
+        verifyNoInteractions(coreCaseDataApi, setCaseCourtHearingBulkAction);
+    }
+
+    @Test
+    void shouldSkipProcessingIfEnvironmentReferencesIsEmpty() {
+
+        final List<Long> references = new ArrayList<>();
+        references.add(null);
+
+        setField(caseCourtHearingMigration, "migrateCaseCourtHearing", true);
+        setField(caseCourtHearingMigration, "caseCourtHearingReferences", references);
+
+        caseCourtHearingMigration.apply(user, SERVICE_AUTHORIZATION);
+
+        verify(logger).info("Skipping CaseCourtHearingMigration, MIGRATE_CASE_COURT_HEARING={}, references size: {}", true, 0);
+        verifyNoInteractions(coreCaseDataApi, setCaseCourtHearingBulkAction);
+    }
+
+    private String getSearchSource() {
+        return SearchSourceBuilder
+            .searchSource()
+            .query(boolQuery().must(boolQuery().should(matchQuery("reference", TEST_CASE_ID))))
+            .from(0)
+            .size(100)
+            .toString();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/SetAosIsDraftedToYesMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/SetAosIsDraftedToYesMigrationTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.predicate.HasAosDraftedEventPredicate;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/SetCaseCourtHearingBulkActionTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/SetCaseCourtHearingBulkActionTest.java
@@ -1,0 +1,109 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.type.CaseLink;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkActionCaseData;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkListCaseDetails;
+import uk.gov.hmcts.divorce.bulkaction.service.CaseTriggerService;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+import uk.gov.hmcts.divorce.systemupdate.convert.CaseDetailsConverter;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.predicate.CaseCourtHearingPredicate;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.task.CaseCourtHearingTaskProvider;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.idam.client.models.User;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCaseWithCoEGeneration.SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
+
+@ExtendWith(MockitoExtension.class)
+class SetCaseCourtHearingBulkActionTest {
+
+    @Mock
+    private CaseCourtHearingPredicate caseCourtHearingPredicate;
+
+    @Mock
+    private CaseDetailsConverter caseDetailsConverter;
+
+    @Mock
+    private CaseTriggerService caseTriggerService;
+
+    @Mock
+    private CaseCourtHearingTaskProvider caseCourtHearingTask;
+
+    @InjectMocks
+    private SetCaseCourtHearingBulkAction setCaseCourtHearingBulkAction;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(SYSTEM_UPDATE_AUTH_TOKEN, UserDetails.builder().build());
+    }
+
+    @Test
+    void shouldMigrateAllCasesInBulkCaseThatDoNotHaveHearingSet() {
+
+        final AtomicInteger predicateIndex = new AtomicInteger(0);
+        final List<Boolean> predicateValues = List.of(TRUE, FALSE, TRUE);
+
+        final ListValue<BulkListCaseDetails> bulkListCaseDetails1 = ListValue.<BulkListCaseDetails>builder()
+            .value(BulkListCaseDetails.builder().caseReference(CaseLink.builder().caseReference("1").build()).build())
+            .build();
+        final ListValue<BulkListCaseDetails> bulkListCaseDetails2 = ListValue.<BulkListCaseDetails>builder()
+            .value(BulkListCaseDetails.builder().caseReference(CaseLink.builder().caseReference("2").build()).build())
+            .build();
+        final ListValue<BulkListCaseDetails> bulkListCaseDetails3 = ListValue.<BulkListCaseDetails>builder()
+            .value(BulkListCaseDetails.builder().caseReference(CaseLink.builder().caseReference("3").build()).build())
+            .build();
+
+        final List<ListValue<BulkListCaseDetails>> listValues = List.of(bulkListCaseDetails1, bulkListCaseDetails2, bulkListCaseDetails3);
+
+        final CaseDetails reformCaseDetails = CaseDetails.builder().build();
+        final BulkActionCaseData bulkActionCaseData = BulkActionCaseData.builder()
+            .bulkListCaseDetails(listValues)
+            .build();
+
+        final uk.gov.hmcts.ccd.sdk.api.CaseDetails<BulkActionCaseData, BulkActionState> bulkCaseDetails
+            = new uk.gov.hmcts.ccd.sdk.api.CaseDetails<>();
+        bulkCaseDetails.setData(bulkActionCaseData);
+        final CaseTask caseTask = caseDetails -> caseDetails;
+
+        when(caseDetailsConverter.convertToBulkActionCaseDetailsFromReformModel(reformCaseDetails)).thenReturn(bulkCaseDetails);
+        when(caseCourtHearingPredicate.caseHearingIsNotSet(bulkActionCaseData, user, SERVICE_AUTHORIZATION))
+            .thenReturn(listValue -> predicateValues.get(predicateIndex.getAndAdd(1)));
+        when(caseCourtHearingTask.getCaseTask(bulkCaseDetails)).thenReturn(caseTask);
+
+        setCaseCourtHearingBulkAction.setCaseCourtHearing(reformCaseDetails, user, SERVICE_AUTHORIZATION);
+
+        verify(caseTriggerService).caseTrigger(
+            bulkListCaseDetails1,
+            SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION,
+            caseTask,
+            user,
+            SERVICE_AUTHORIZATION);
+        verify(caseTriggerService).caseTrigger(
+            bulkListCaseDetails3,
+            SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION,
+            caseTask,
+            user,
+            SERVICE_AUTHORIZATION);
+        verifyNoMoreInteractions(caseTriggerService);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/predicate/CaseCourtHearingPredicateTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/predicate/CaseCourtHearingPredicateTest.java
@@ -1,0 +1,126 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.predicate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.type.CaseLink;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkActionCaseData;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkListCaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrder;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.systemupdate.convert.CaseDetailsConverter;
+import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.idam.client.models.User;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+
+import java.time.LocalDateTime;
+
+import static java.time.LocalDateTime.now;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
+
+@ExtendWith(MockitoExtension.class)
+class CaseCourtHearingPredicateTest {
+
+    @Mock
+    private CoreCaseDataApi coreCaseDataApi;
+
+    @Mock
+    private CaseDetailsConverter caseDetailsConverter;
+
+    @InjectMocks
+    private CaseCourtHearingPredicate caseCourtHearingPredicate;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(SYSTEM_UPDATE_AUTH_TOKEN, UserDetails.builder().build());
+    }
+
+    @Test
+    void shouldReturnTrueIfCourtHearingDateIsNotTheSameAsBulkCase() {
+
+        final LocalDateTime localDateTime = now();
+        final LocalDateTime dateAndTimeOfHearing = now().plusDays(1);
+        final CaseDetails reformCaseDetails = CaseDetails.builder()
+            .id(TEST_CASE_ID)
+            .build();
+
+        final CaseData caseData = CaseData.builder()
+            .conditionalOrder(ConditionalOrder.builder()
+                .dateAndTimeOfHearing(dateAndTimeOfHearing)
+                .build())
+            .build();
+
+        final uk.gov.hmcts.ccd.sdk.api.CaseDetails<CaseData, State> caseDetails = new uk.gov.hmcts.ccd.sdk.api.CaseDetails<>();
+        caseDetails.setId(TEST_CASE_ID);
+        caseDetails.setData(caseData);
+
+        final ListValue<BulkListCaseDetails> listValue = new ListValue<BulkListCaseDetails>("1", BulkListCaseDetails.builder()
+            .caseReference(CaseLink.builder()
+                .caseReference(TEST_CASE_ID.toString())
+                .build())
+            .build());
+
+        final BulkActionCaseData bulkActionCaseData = BulkActionCaseData.builder()
+            .dateAndTimeOfHearing(localDateTime)
+            .build();
+
+        when(coreCaseDataApi.getCase(user.getAuthToken(), SERVICE_AUTHORIZATION, TEST_CASE_ID.toString()))
+            .thenReturn(reformCaseDetails);
+        when(caseDetailsConverter.convertToCaseDetailsFromReformModel(reformCaseDetails)).thenReturn(caseDetails);
+
+        assertThat(caseCourtHearingPredicate
+            .caseHearingIsNotSet(bulkActionCaseData, user, SERVICE_AUTHORIZATION)
+            .test(listValue))
+            .isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueIfCourtHearingDateIsNull() {
+
+        final LocalDateTime localDateTime = now();
+        final LocalDateTime dateAndTimeOfHearing = now().plusDays(1);
+        final CaseDetails reformCaseDetails = CaseDetails.builder()
+            .id(TEST_CASE_ID)
+            .build();
+
+        final CaseData caseData = CaseData.builder()
+            .conditionalOrder(ConditionalOrder.builder()
+                .build())
+            .build();
+
+        final uk.gov.hmcts.ccd.sdk.api.CaseDetails<CaseData, State> caseDetails = new uk.gov.hmcts.ccd.sdk.api.CaseDetails<>();
+        caseDetails.setId(TEST_CASE_ID);
+        caseDetails.setData(caseData);
+
+        final ListValue<BulkListCaseDetails> listValue = new ListValue<BulkListCaseDetails>("1", BulkListCaseDetails.builder()
+            .caseReference(CaseLink.builder()
+                .caseReference(TEST_CASE_ID.toString())
+                .build())
+            .build());
+
+        final BulkActionCaseData bulkActionCaseData = BulkActionCaseData.builder()
+            .dateAndTimeOfHearing(localDateTime)
+            .build();
+
+        when(coreCaseDataApi.getCase(user.getAuthToken(), SERVICE_AUTHORIZATION, TEST_CASE_ID.toString()))
+            .thenReturn(reformCaseDetails);
+        when(caseDetailsConverter.convertToCaseDetailsFromReformModel(reformCaseDetails)).thenReturn(caseDetails);
+
+        assertThat(caseCourtHearingPredicate
+            .caseHearingIsNotSet(bulkActionCaseData, user, SERVICE_AUTHORIZATION)
+            .test(listValue))
+            .isTrue();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/predicate/CaseCourtHearingPredicateTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/predicate/CaseCourtHearingPredicateTest.java
@@ -24,6 +24,8 @@ import java.time.LocalDateTime;
 import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrderCourt.BIRMINGHAM;
+import static uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrderCourt.BURY_ST_EDMUNDS;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
@@ -90,7 +92,6 @@ class CaseCourtHearingPredicateTest {
     void shouldReturnTrueIfCourtHearingDateIsNull() {
 
         final LocalDateTime localDateTime = now();
-        final LocalDateTime dateAndTimeOfHearing = now().plusDays(1);
         final CaseDetails reformCaseDetails = CaseDetails.builder()
             .id(TEST_CASE_ID)
             .build();
@@ -122,5 +123,124 @@ class CaseCourtHearingPredicateTest {
             .caseHearingIsNotSet(bulkActionCaseData, user, SERVICE_AUTHORIZATION)
             .test(listValue))
             .isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueIfCourtIsNotTheSameAsBulkCase() {
+
+        final LocalDateTime localDateTime = now();
+        final CaseDetails reformCaseDetails = CaseDetails.builder()
+            .id(TEST_CASE_ID)
+            .build();
+
+        final CaseData caseData = CaseData.builder()
+            .conditionalOrder(ConditionalOrder.builder()
+                .dateAndTimeOfHearing(localDateTime)
+                .court(BIRMINGHAM)
+                .build())
+            .build();
+
+        final uk.gov.hmcts.ccd.sdk.api.CaseDetails<CaseData, State> caseDetails = new uk.gov.hmcts.ccd.sdk.api.CaseDetails<>();
+        caseDetails.setId(TEST_CASE_ID);
+        caseDetails.setData(caseData);
+
+        final ListValue<BulkListCaseDetails> listValue = new ListValue<BulkListCaseDetails>("1", BulkListCaseDetails.builder()
+            .caseReference(CaseLink.builder()
+                .caseReference(TEST_CASE_ID.toString())
+                .build())
+            .build());
+
+        final BulkActionCaseData bulkActionCaseData = BulkActionCaseData.builder()
+            .dateAndTimeOfHearing(localDateTime)
+            .court(BURY_ST_EDMUNDS)
+            .build();
+
+        when(coreCaseDataApi.getCase(user.getAuthToken(), SERVICE_AUTHORIZATION, TEST_CASE_ID.toString()))
+            .thenReturn(reformCaseDetails);
+        when(caseDetailsConverter.convertToCaseDetailsFromReformModel(reformCaseDetails)).thenReturn(caseDetails);
+
+        assertThat(caseCourtHearingPredicate
+            .caseHearingIsNotSet(bulkActionCaseData, user, SERVICE_AUTHORIZATION)
+            .test(listValue))
+            .isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueIfCourtIsNull() {
+
+        final LocalDateTime localDateTime = now();
+        final CaseDetails reformCaseDetails = CaseDetails.builder()
+            .id(TEST_CASE_ID)
+            .build();
+
+        final CaseData caseData = CaseData.builder()
+            .conditionalOrder(ConditionalOrder.builder()
+                .dateAndTimeOfHearing(localDateTime)
+                .build())
+            .build();
+
+        final uk.gov.hmcts.ccd.sdk.api.CaseDetails<CaseData, State> caseDetails = new uk.gov.hmcts.ccd.sdk.api.CaseDetails<>();
+        caseDetails.setId(TEST_CASE_ID);
+        caseDetails.setData(caseData);
+
+        final ListValue<BulkListCaseDetails> listValue = new ListValue<BulkListCaseDetails>("1", BulkListCaseDetails.builder()
+            .caseReference(CaseLink.builder()
+                .caseReference(TEST_CASE_ID.toString())
+                .build())
+            .build());
+
+        final BulkActionCaseData bulkActionCaseData = BulkActionCaseData.builder()
+            .dateAndTimeOfHearing(localDateTime)
+            .court(BIRMINGHAM)
+            .build();
+
+        when(coreCaseDataApi.getCase(user.getAuthToken(), SERVICE_AUTHORIZATION, TEST_CASE_ID.toString()))
+            .thenReturn(reformCaseDetails);
+        when(caseDetailsConverter.convertToCaseDetailsFromReformModel(reformCaseDetails)).thenReturn(caseDetails);
+
+        assertThat(caseCourtHearingPredicate
+            .caseHearingIsNotSet(bulkActionCaseData, user, SERVICE_AUTHORIZATION)
+            .test(listValue))
+            .isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseIfCourtHearingDateAndCourtAreTheSameAsBulkCase() {
+
+        final LocalDateTime localDateTime = now();
+        final CaseDetails reformCaseDetails = CaseDetails.builder()
+            .id(TEST_CASE_ID)
+            .build();
+
+        final CaseData caseData = CaseData.builder()
+            .conditionalOrder(ConditionalOrder.builder()
+                .dateAndTimeOfHearing(localDateTime)
+                .court(BIRMINGHAM)
+                .build())
+            .build();
+
+        final uk.gov.hmcts.ccd.sdk.api.CaseDetails<CaseData, State> caseDetails = new uk.gov.hmcts.ccd.sdk.api.CaseDetails<>();
+        caseDetails.setId(TEST_CASE_ID);
+        caseDetails.setData(caseData);
+
+        final ListValue<BulkListCaseDetails> listValue = new ListValue<BulkListCaseDetails>("1", BulkListCaseDetails.builder()
+            .caseReference(CaseLink.builder()
+                .caseReference(TEST_CASE_ID.toString())
+                .build())
+            .build());
+
+        final BulkActionCaseData bulkActionCaseData = BulkActionCaseData.builder()
+            .dateAndTimeOfHearing(localDateTime)
+            .court(BIRMINGHAM)
+            .build();
+
+        when(coreCaseDataApi.getCase(user.getAuthToken(), SERVICE_AUTHORIZATION, TEST_CASE_ID.toString()))
+            .thenReturn(reformCaseDetails);
+        when(caseDetailsConverter.convertToCaseDetailsFromReformModel(reformCaseDetails)).thenReturn(caseDetails);
+
+        assertThat(caseCourtHearingPredicate
+            .caseHearingIsNotSet(bulkActionCaseData, user, SERVICE_AUTHORIZATION)
+            .test(listValue))
+            .isFalse();
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/predicate/HasAosDraftedEventPredicateTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/predicate/HasAosDraftedEventPredicateTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.divorce.systemupdate.schedule.migration;
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.predicate;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.predicate.HasAosDraftedEventPredicate;
 import uk.gov.hmcts.reform.ccd.client.CaseEventsApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.CaseEventDetail;

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/CaseCourtHearingTaskProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/CaseCourtHearingTaskProviderTest.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkActionCaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrder;
+import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrderCourt.BIRMINGHAM;
+import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCaseWithCoEGeneration.SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION;
+import static uk.gov.hmcts.divorce.testutil.ClockTestUtil.getExpectedLocalDateTime;
+
+@ExtendWith(MockitoExtension.class)
+class CaseCourtHearingTaskProviderTest {
+
+    @InjectMocks
+    private CaseCourtHearingTaskProvider caseCourtHearingTaskProvider;
+
+    @Test
+    void shouldReturnSystemUpdateCaseCourtHearingEventId() {
+        assertThat(caseCourtHearingTaskProvider.getEventId()).isEqualTo(SYSTEM_MIGRATE_CASE_WITH_COE_GENERATION);
+    }
+
+    @Test
+    void shouldSetCourtHearingDateAndCourt() {
+
+        final var localDateTime = getExpectedLocalDateTime();
+        final var bulkActionCaseData = BulkActionCaseData
+            .builder()
+            .dateAndTimeOfHearing(localDateTime)
+            .court(BIRMINGHAM)
+            .build();
+
+        final CaseDetails<BulkActionCaseData, BulkActionState> bulkCaseDetails = new CaseDetails<>();
+        bulkCaseDetails.setData(bulkActionCaseData);
+
+        final var caseData = CaseData.builder()
+            .finalOrder(FinalOrder.builder().build())
+            .build();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseTask caseTask = caseCourtHearingTaskProvider.getCaseTask(bulkCaseDetails);
+
+        final CaseDetails<CaseData, State> resultCaseDetails = caseTask.apply(caseDetails);
+        final ConditionalOrder resultConditionalOrder = resultCaseDetails.getData().getConditionalOrder();
+
+        assertThat(resultConditionalOrder.getDateAndTimeOfHearing()).isEqualTo(localDateTime);
+        assertThat(resultConditionalOrder.getCourt()).isEqualTo(BIRMINGHAM);
+    }
+}


### PR DESCRIPTION
### Change description ###

Add cron migration for setting court hearing info on bulk action cases.
Uses: 
MIGRATE_AOS_IS_DRAFTED=true
AOS_IS_DRAFTED_REFERENCES={comma delimited list of case references}

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3125

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

