### PR TITLE
Allow superusers to trigger system pronounce case in case pronounce case events fails when triggered by system

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemPronounceCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemPronounceCase.java
@@ -21,7 +21,6 @@ import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
 import java.util.EnumSet;
 
-import static uk.gov.hmcts.divorce.common.ccd.CcdPageConfiguration.NEVER_SHOW;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingPronouncement;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.ConditionalOrderPronounced;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.OfflineDocumentReceived;
@@ -57,11 +56,10 @@ public class SystemPronounceCase implements CCDConfig<CaseData, State, UserRole>
             configBuilder
                 .event(SYSTEM_PRONOUNCE_CASE)
                 .forStateTransition(EnumSet.of(AwaitingPronouncement, OfflineDocumentReceived), ConditionalOrderPronounced)
-                .showCondition(NEVER_SHOW)
                 .name("System pronounce case")
                 .description("System pronounce case")
-                .grant(CREATE_READ_UPDATE, SYSTEMUPDATE)
-                .grantHistoryOnly(SOLICITOR, CASE_WORKER, SUPER_USER, LEGAL_ADVISOR)
+                .grant(CREATE_READ_UPDATE, SYSTEMUPDATE, SUPER_USER)
+                .grantHistoryOnly(SOLICITOR, CASE_WORKER, LEGAL_ADVISOR)
                 .aboutToSubmitCallback(this::aboutToSubmit)
                 .submittedCallback(this::submitted)
         );


### PR DESCRIPTION
### Change description ###

- Currently if the system trigger for pronounce case fails and if it also fails to update bulk case with failed list there is no way to retry the pronounce case on NFD case.
- This PR allows super user to trigger pronounce case so that appropriate documents can be generated and case can be updated.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3139

**Before merging a pull request make sure that:**

- [x] tests have been updated / new tests has been added (if needed)
- [x] README and other documentation has been updated / added (if needed)

