### PR TITLE
NFDIV-3200: Update code to have one reference to the email address

### DIFF
--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -111,7 +111,7 @@ court:
       town: 'Harlow'
       poBox: 'PO Box 13226'
       postCode: 'CM20 9UG'
-      email: 'divorcecase@justice.gov.uk'
+      email: 'contactdivorce@justice.gov.uk'
       phoneNumber: '0300 303 0642'
 
 pba:

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerReIssueApplicationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerReIssueApplicationIT.java
@@ -630,7 +630,7 @@ public class CaseworkerReIssueApplicationIT {
 
         stubForDocAssemblyWith(AOS_COVER_LETTER_ID, "NFD_CP_Dummy_Template.docx");
         stubForDocAssemblyWith(DIVORCE_APPLICATION_TEMPLATE_ID, TEST_DIVORCE_APPLICATION_JOINT_TEMPLATE_ID);
-        stubForDocAssemblyWith(NOTICE_OF_PROCEEDING_ID, "NFD_Notice_Of_Proceedings_Joint_V3.docx");
+        stubForDocAssemblyWith(NOTICE_OF_PROCEEDING_ID, "FL-NFD-GOR-ENG-Notice-Of-Proceedings-Joint-V3.docx");
         stubForDocAssemblyWith(NOTICE_OF_PROCEEDING_TEMPLATE_ID, "FL-NFD-GOR-ENG-Notice-Of-Proceedings-AS1-V3.docx");
 
         stubForIdamDetails(TEST_AUTHORIZATION_TOKEN, CASEWORKER_USER_ID, CASEWORKER_ROLE);

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/notification/conditionalorder/AppliedForConditionalOrderNotificationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/notification/conditionalorder/AppliedForConditionalOrderNotificationIT.java
@@ -19,7 +19,7 @@ import static uk.gov.hmcts.divorce.citizen.notification.conditionalorder.Applied
 import static uk.gov.hmcts.divorce.citizen.notification.conditionalorder.AppliedForConditionalOrderNotification.APPLICANT2;
 import static uk.gov.hmcts.divorce.citizen.notification.conditionalorder.AppliedForConditionalOrderNotification.PLUS_14_DUE_DATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.Gender.FEMALE;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.notification.CommonContent.APPLICANT_NAME;
 import static uk.gov.hmcts.divorce.notification.CommonContent.APPLICATION_REFERENCE;
 import static uk.gov.hmcts.divorce.notification.CommonContent.COURT_EMAIL;
@@ -74,7 +74,7 @@ public class AppliedForConditionalOrderNotificationIT {
             entry(FIRST_NAME, "Bob"),
             entry(LAST_NAME, "Smith"),
             entry(PARTNER, "wife"),
-            entry(COURT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK),
+            entry(COURT_EMAIL, CONTACT_DIVORCE_EMAIL),
             entry(PLUS_14_DUE_DATE, submittedDate.plusDays(14).format(DATE_TIME_FORMATTER)),
             entry(SIGN_IN_URL, "https://nfdiv-apply-for-divorce.aat.platform.hmcts.net")
         );
@@ -103,7 +103,7 @@ public class AppliedForConditionalOrderNotificationIT {
             entry(FIRST_NAME, "Bob"),
             entry(LAST_NAME, "Smith"),
             entry(PARTNER, "gwraig"),
-            entry(COURT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK),
+            entry(COURT_EMAIL, CONTACT_DIVORCE_EMAIL),
             entry(PLUS_14_DUE_DATE, submittedDate.plusDays(14).format(DATE_TIME_FORMATTER)),
             entry(SIGN_IN_URL, "https://nfdiv-apply-for-divorce.aat.platform.hmcts.net")
         );
@@ -140,7 +140,7 @@ public class AppliedForConditionalOrderNotificationIT {
             entry(ISSUE_DATE, date.format(DATE_TIME_FORMATTER)),
             entry(SOLICITOR_NAME, TEST_SOLICITOR_NAME),
             entry(SOLICITOR_REFERENCE, "REF01"),
-            entry(COURT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK)
+            entry(COURT_EMAIL, CONTACT_DIVORCE_EMAIL)
         );
     }
 
@@ -166,7 +166,7 @@ public class AppliedForConditionalOrderNotificationIT {
             entry(FIRST_NAME, "Bob"),
             entry(LAST_NAME, "Smith"),
             entry(PARTNER, "wife"),
-            entry(COURT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK),
+            entry(COURT_EMAIL, CONTACT_DIVORCE_EMAIL),
             entry(PLUS_14_DUE_DATE, submittedDate.plusDays(14).format(DATE_TIME_FORMATTER)),
             entry(SIGN_IN_URL, "https://nfdiv-apply-for-divorce.aat.platform.hmcts.net")
         );
@@ -196,7 +196,7 @@ public class AppliedForConditionalOrderNotificationIT {
             entry(FIRST_NAME, "Bob"),
             entry(LAST_NAME, "Smith"),
             entry(PARTNER, "gwraig"),
-            entry(COURT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK),
+            entry(COURT_EMAIL, CONTACT_DIVORCE_EMAIL),
             entry(PLUS_14_DUE_DATE, submittedDate.plusDays(14).format(DATE_TIME_FORMATTER)),
             entry(SIGN_IN_URL, "https://nfdiv-apply-for-divorce.aat.platform.hmcts.net")
         );

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/common/Applicant2RequestChangesNotificationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/common/Applicant2RequestChangesNotificationIT.java
@@ -42,7 +42,7 @@ import static uk.gov.hmcts.divorce.citizen.notification.Applicant2RequestChanges
 import static uk.gov.hmcts.divorce.common.event.Applicant2RequestChanges.APPLICANT_2_REQUEST_CHANGES;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.WELSH;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.notification.CommonContent.APPLICATION_REFERENCE;
 import static uk.gov.hmcts.divorce.notification.CommonContent.COURT_EMAIL;
 import static uk.gov.hmcts.divorce.notification.CommonContent.FIRST_NAME;
@@ -149,7 +149,7 @@ public class Applicant2RequestChangesNotificationIT {
                 hasEntry(APPLICATION_REFERENCE, FORMATTED_TEST_CASE_ID),
                 hasEntry(FIRST_NAME, TEST_FIRST_NAME),
                 hasEntry(LAST_NAME, TEST_LAST_NAME),
-                hasEntry(COURT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK),
+                hasEntry(COURT_EMAIL, CONTACT_DIVORCE_EMAIL),
                 hasEntry(PARTNER, "gŵr")
             )),
             eq(WELSH)

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/common/GeneralApplicationReceivedNotificationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/common/GeneralApplicationReceivedNotificationIT.java
@@ -23,7 +23,7 @@ import static uk.gov.hmcts.divorce.citizen.notification.GeneralApplicationReceiv
 import static uk.gov.hmcts.divorce.divorcecase.model.AlternativeServiceType.DEEMED;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.WELSH;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.notification.CommonContent.APPLICATION_REFERENCE;
 import static uk.gov.hmcts.divorce.notification.CommonContent.COURT_EMAIL;
 import static uk.gov.hmcts.divorce.notification.CommonContent.FIRST_NAME;
@@ -68,7 +68,7 @@ public class GeneralApplicationReceivedNotificationIT {
             argThat(allOf(
                 hasEntry(SIGN_IN_URL, "https://nfdiv-apply-for-divorce.aat.platform.hmcts.net"),
                 hasEntry(IS_BAILIFF_SERVICE, NO),
-                hasEntry(COURT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK),
+                hasEntry(COURT_EMAIL, CONTACT_DIVORCE_EMAIL),
                 hasEntry(LAST_NAME, TEST_LAST_NAME),
                 hasEntry(FIRST_NAME, TEST_FIRST_NAME),
                 hasEntry(PARTNER, "husband"),
@@ -97,7 +97,7 @@ public class GeneralApplicationReceivedNotificationIT {
             argThat(allOf(
                 hasEntry(SIGN_IN_URL, "https://nfdiv-apply-for-divorce.aat.platform.hmcts.net"),
                 hasEntry(IS_BAILIFF_SERVICE, NO),
-                hasEntry(COURT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK),
+                hasEntry(COURT_EMAIL, CONTACT_DIVORCE_EMAIL),
                 hasEntry(LAST_NAME, TEST_LAST_NAME),
                 hasEntry(FIRST_NAME, TEST_FIRST_NAME),
                 hasEntry(PARTNER, "gŵr"),

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/common/SoleApplicationDisputedNotificationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/common/SoleApplicationDisputedNotificationIT.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.WELSH;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.notification.CommonContent.APPLICATION_REFERENCE;
 import static uk.gov.hmcts.divorce.notification.CommonContent.COURT_EMAIL;
 import static uk.gov.hmcts.divorce.notification.CommonContent.FIRST_NAME;
@@ -70,7 +70,7 @@ public class SoleApplicationDisputedNotificationIT {
                 hasEntry(FIRST_NAME, TEST_FIRST_NAME),
                 hasEntry(LAST_NAME, TEST_LAST_NAME),
                 hasEntry(PARTNER, "husband"),
-                hasEntry(COURT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK),
+                hasEntry(COURT_EMAIL, CONTACT_DIVORCE_EMAIL),
                 hasEntry(SIGN_IN_URL, "https://nfdiv-apply-for-divorce.aat.platform.hmcts.net")
             )),
             eq(ENGLISH)
@@ -96,7 +96,7 @@ public class SoleApplicationDisputedNotificationIT {
                 hasEntry(FIRST_NAME, TEST_FIRST_NAME),
                 hasEntry(LAST_NAME, TEST_LAST_NAME),
                 hasEntry(PARTNER, "gŵr"),
-                hasEntry(COURT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK),
+                hasEntry(COURT_EMAIL, CONTACT_DIVORCE_EMAIL),
                 hasEntry(SIGN_IN_URL, "https://nfdiv-apply-for-divorce.aat.platform.hmcts.net")
             )),
             eq(WELSH)

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/common/SoleApplicationNotDisputedNotificationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/common/SoleApplicationNotDisputedNotificationIT.java
@@ -19,7 +19,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.WELSH;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.notification.CommonContent.APPLICATION_REFERENCE;
 import static uk.gov.hmcts.divorce.notification.CommonContent.COURT_EMAIL;
 import static uk.gov.hmcts.divorce.notification.CommonContent.FIRST_NAME;
@@ -68,7 +68,7 @@ public class SoleApplicationNotDisputedNotificationIT {
                 hasEntry(FIRST_NAME, TEST_FIRST_NAME),
                 hasEntry(LAST_NAME, TEST_LAST_NAME),
                 hasEntry(PARTNER, "gŵr"),
-                hasEntry(COURT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK),
+                hasEntry(COURT_EMAIL, CONTACT_DIVORCE_EMAIL),
                 hasEntry(SIGN_IN_URL, "https://nfdiv-apply-for-divorce.aat.platform.hmcts.net")
             )),
             eq(WELSH)

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/document/content/CertificateOfEntitlementContentIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/document/content/CertificateOfEntitlementContentIT.java
@@ -82,7 +82,7 @@ class CertificateOfEntitlementContentIT {
         final ConditionalOrderCourtDetails expectedDetails = new ConditionalOrderCourtDetails();
         expectedDetails.setName("Bury St. Edmunds Regional Divorce Centre");
         expectedDetails.setAddress("2nd Floor\nTriton House\nSt. Andrews Street North\nBury St. Edmunds\nIP33 1TR");
-        expectedDetails.setEmail("divorcecase@justice.gov.uk");
+        expectedDetails.setEmail("contactdivorce@justice.gov.uk");
         expectedDetails.setPhone("0300 303 0642");
 
         final Map<String, Object> contentMap = certificateOfEntitlementContent.apply(caseData, TEST_CASE_ID);
@@ -137,7 +137,7 @@ class CertificateOfEntitlementContentIT {
         final ConditionalOrderCourtDetails expectedDetails = new ConditionalOrderCourtDetails();
         expectedDetails.setName("Bury St. Edmunds Regional Divorce Centre");
         expectedDetails.setAddress("2nd Floor\nTriton House\nSt. Andrews Street North\nBury St. Edmunds\nIP33 1TR");
-        expectedDetails.setEmail("divorcecase@justice.gov.uk");
+        expectedDetails.setEmail("contactdivorce@justice.gov.uk");
         expectedDetails.setPhone("0300 303 0642");
 
         final Map<String, Object> contentMap = certificateOfEntitlementContent.apply(caseData, TEST_CASE_ID);

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/document/content/GeneralOrderTemplateContentIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/document/content/GeneralOrderTemplateContentIT.java
@@ -67,7 +67,7 @@ public class GeneralOrderTemplateContentIT {
         var ctscContactDetails = CtscContactDetails
             .builder()
             .centreName("HMCTS Digital Divorce and Dissolution")
-            .emailAddress("divorcecase@justice.gov.uk")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .serviceCentre("Courts and Tribunals Service Centre")
             .phoneNumber("0300 303 0642")
             .poBox("PO Box 13226")
@@ -112,7 +112,7 @@ public class GeneralOrderTemplateContentIT {
         var ctscContactDetails = CtscContactDetails
             .builder()
             .centreName("HMCTS Digital Divorce and Dissolution")
-            .emailAddress("divorcecase@justice.gov.uk")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .serviceCentre("Courts and Tribunals Service Centre")
             .phoneNumber("0300 303 0642")
             .poBox("PO Box 13226")

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingContentIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingContentIT.java
@@ -37,9 +37,14 @@ import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.AP
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_2_FIRST_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_2_LAST_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CASE_REFERENCE;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_JUSTICE_GOV_UK_CY;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_EMAIL;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_AND_DISSOLUTION_HEADER;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_AND_DISSOLUTION_HEADER_TEXT;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_AND_DISSOLUTION_HEADER_TEXT_CY;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_APPLICATION;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_APPLICATION_CY;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_PROCESS;
@@ -48,6 +53,9 @@ import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.FO
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.ISSUE_DATE;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.NOT_PROVIDED;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.NOT_REPRESENTED;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.PHONE_AND_OPENING_TIMES;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.PHONE_AND_OPENING_TIMES_TEXT;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.PHONE_AND_OPENING_TIMES_TEXT_CY;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.PROCESS_TO_END_YOUR_CIVIL_PARTNERSHIP;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.RESPONDENT_SOLICITOR_REGISTERED;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.RESPOND_BY_DATE;
@@ -186,6 +194,7 @@ public class NoticeOfProceedingContentIT {
             .town("Harlow")
             .postcode("CM20 9UG")
             .phoneNumber("0300 303 0642")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .build();
 
         Map<String, Object> expectedEntries = new LinkedHashMap<>();
@@ -194,7 +203,7 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(APPLICANT_1_LAST_NAME, TEST_LAST_NAME);
         expectedEntries.put(ISSUE_DATE, "18 June 2021");
         expectedEntries.put(DUE_DATE, "19 June 2021");
-        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, DIVORCE_PROCEEDINGS);
         expectedEntries.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, FOR_A_DIVORCE);
         expectedEntries.put(RELATION, "wife");
@@ -231,6 +240,10 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(IS_DIVORCE, true);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_DOCUMENTS, DIVORCE_DOCUMENTS);
         expectedEntries.put(IS_OFFLINE, false);
+        expectedEntries.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
+        expectedEntries.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
+        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
+        expectedEntries.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
 
         Map<String, Object> templateContent = noticeOfProceedingContent.apply(
             caseData,
@@ -280,6 +293,7 @@ public class NoticeOfProceedingContentIT {
             .town("Harlow")
             .postcode("CM20 9UG")
             .phoneNumber("0300 303 0642")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .build();
 
         Map<String, Object> expectedEntries = new LinkedHashMap<>();
@@ -288,7 +302,7 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(APPLICANT_1_LAST_NAME, TEST_LAST_NAME);
         expectedEntries.put(ISSUE_DATE, "18 June 2021");
         expectedEntries.put(DUE_DATE, "19 June 2021");
-        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_JUSTICE_GOV_UK_CY);
+        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, DIVORCE_PROCEEDINGS_CY);
         expectedEntries.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, FOR_A_DIVORCE_CY);
         expectedEntries.put(RELATION, "gwraig");
@@ -325,6 +339,10 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(IS_DIVORCE, true);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_DOCUMENTS, DIVORCE_DOCUMENTS);
         expectedEntries.put(IS_OFFLINE, false);
+        expectedEntries.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT_CY);
+        expectedEntries.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY);
+        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
+        expectedEntries.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT_CY);
 
         Map<String, Object> templateContent = noticeOfProceedingContent.apply(
             caseData,
@@ -374,6 +392,7 @@ public class NoticeOfProceedingContentIT {
             .town("Harlow")
             .postcode("CM20 9UG")
             .phoneNumber("0300 303 0642")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .build();
 
         Map<String, Object> expectedEntries = new LinkedHashMap<>();
@@ -382,7 +401,7 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(APPLICANT_1_LAST_NAME, TEST_LAST_NAME);
         expectedEntries.put(ISSUE_DATE, "18 June 2021");
         expectedEntries.put(DUE_DATE, "19 June 2021");
-        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, DIVORCE_PROCEEDINGS);
         expectedEntries.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, FOR_A_DIVORCE);
         expectedEntries.put(RELATION, "wife");
@@ -426,6 +445,10 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(IS_DIVORCE, true);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_DOCUMENTS, DIVORCE_DOCUMENTS);
         expectedEntries.put(IS_OFFLINE, false);
+        expectedEntries.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
+        expectedEntries.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
+        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
+        expectedEntries.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
 
         Map<String, Object> templateContent = noticeOfProceedingContent.apply(
             caseData,
@@ -478,6 +501,7 @@ public class NoticeOfProceedingContentIT {
             .town("Harlow")
             .postcode("CM20 9UG")
             .phoneNumber("0300 303 0642")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .build();
 
         Map<String, Object> expectedEntries = new LinkedHashMap<>();
@@ -486,7 +510,7 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(APPLICANT_1_LAST_NAME, TEST_LAST_NAME);
         expectedEntries.put(ISSUE_DATE, "18 June 2021");
         expectedEntries.put(DUE_DATE, "19 June 2021");
-        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, DIVORCE_PROCEEDINGS);
         expectedEntries.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, FOR_A_DIVORCE);
         expectedEntries.put(RELATION, "wife");
@@ -523,6 +547,10 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(IS_DIVORCE, true);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_DOCUMENTS, DIVORCE_DOCUMENTS);
         expectedEntries.put(IS_OFFLINE, false);
+        expectedEntries.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
+        expectedEntries.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
+        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
+        expectedEntries.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
 
         Map<String, Object> templateContent = noticeOfProceedingContent.apply(
             caseData,
@@ -573,6 +601,7 @@ public class NoticeOfProceedingContentIT {
             .town("Harlow")
             .postcode("CM20 9UG")
             .phoneNumber("0300 303 0642")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .build();
 
         Map<String, Object> expectedEntries = new LinkedHashMap<>();
@@ -581,7 +610,7 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(APPLICANT_1_LAST_NAME, TEST_LAST_NAME);
         expectedEntries.put(ISSUE_DATE, "18 June 2021");
         expectedEntries.put(DUE_DATE, "19 June 2021");
-        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK);
+        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, PROCEEDINGS_TO_END_YOUR_CIVIL_PARTNERSHIP);
         expectedEntries.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, TO_END_YOUR_CIVIL_PARTNERSHIP);
         expectedEntries.put(RELATION, CIVIL_PARTNER);
@@ -618,6 +647,10 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(IS_DIVORCE, false);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_DOCUMENTS, CIVIL_PARTNERSHIP_DOCUMENTS);
         expectedEntries.put(IS_OFFLINE, false);
+        expectedEntries.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
+        expectedEntries.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
+        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
+        expectedEntries.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
 
         Map<String, Object> templateContent = noticeOfProceedingContent.apply(
             caseData,
@@ -668,6 +701,7 @@ public class NoticeOfProceedingContentIT {
             .town("Harlow")
             .postcode("CM20 9UG")
             .phoneNumber("0300 303 0642")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .build();
 
         Map<String, Object> expectedEntries = new LinkedHashMap<>();
@@ -676,7 +710,7 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(APPLICANT_1_LAST_NAME, TEST_LAST_NAME);
         expectedEntries.put(ISSUE_DATE, "18 June 2021");
         expectedEntries.put(DUE_DATE, "19 June 2021");
-        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_JUSTICE_GOV_UK_CY);
+        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, PROCEEDINGS_TO_END_YOUR_CIVIL_PARTNERSHIP_CY);
         expectedEntries.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, TO_END_YOUR_CIVIL_PARTNERSHIP_CY);
         expectedEntries.put(RELATION, "partner sifil");
@@ -713,6 +747,10 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(IS_DIVORCE, false);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_DOCUMENTS, CIVIL_PARTNERSHIP_DOCUMENTS);
         expectedEntries.put(IS_OFFLINE, false);
+        expectedEntries.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT_CY);
+        expectedEntries.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY);
+        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
+        expectedEntries.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT_CY);
 
         Map<String, Object> templateContent = noticeOfProceedingContent.apply(
             caseData,
@@ -774,6 +812,7 @@ public class NoticeOfProceedingContentIT {
             .town("Harlow")
             .postcode("CM20 9UG")
             .phoneNumber("0300 303 0642")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .build();
 
         Map<String, Object> expectedEntries = new LinkedHashMap<>();
@@ -782,7 +821,7 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(APPLICANT_1_LAST_NAME, TEST_LAST_NAME);
         expectedEntries.put(ISSUE_DATE, "18 June 2021");
         expectedEntries.put(DUE_DATE, "19 June 2021");
-        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, DIVORCE_PROCEEDINGS);
         expectedEntries.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, FOR_A_DIVORCE);
         expectedEntries.put(RELATION, "wife");
@@ -825,6 +864,10 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(IS_DIVORCE, true);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_DOCUMENTS, DIVORCE_DOCUMENTS);
         expectedEntries.put(IS_OFFLINE, false);
+        expectedEntries.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
+        expectedEntries.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
+        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
+        expectedEntries.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
 
         Map<String, Object> templateContent = noticeOfProceedingContent.apply(
             caseData,
@@ -886,6 +929,7 @@ public class NoticeOfProceedingContentIT {
             .poBox("PO Box 13226")
             .town("Harlow")
             .postcode("CM20 9UG")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .phoneNumber("0300 303 0642")
             .build();
 
@@ -896,7 +940,7 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(APPLICANT_1_LAST_NAME, TEST_LAST_NAME);
         expectedEntries.put(ISSUE_DATE, "18 June 2021");
         expectedEntries.put(DUE_DATE, "19 June 2021");
-        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, DIVORCE_PROCEEDINGS);
         expectedEntries.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, FOR_A_DIVORCE);
         expectedEntries.put(RELATION, "wife");
@@ -942,6 +986,10 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(IS_DIVORCE, true);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_DOCUMENTS, DIVORCE_DOCUMENTS);
         expectedEntries.put(IS_OFFLINE, false);
+        expectedEntries.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
+        expectedEntries.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
+        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
+        expectedEntries.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
 
         Map<String, Object> templateContent = noticeOfProceedingContent.apply(
             caseData,
@@ -997,6 +1045,7 @@ public class NoticeOfProceedingContentIT {
             .town("Harlow")
             .postcode("CM20 9UG")
             .phoneNumber("0300 303 0642")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .build();
 
         Map<String, Object> expectedEntries = new LinkedHashMap<>();
@@ -1005,7 +1054,7 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(APPLICANT_1_LAST_NAME, TEST_LAST_NAME);
         expectedEntries.put(ISSUE_DATE, "18 June 2021");
         expectedEntries.put(DUE_DATE, "19 June 2021");
-        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, DIVORCE_PROCEEDINGS);
         expectedEntries.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, FOR_A_DIVORCE);
         expectedEntries.put(RELATION, "wife");
@@ -1048,6 +1097,10 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(IS_DIVORCE, true);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_DOCUMENTS, DIVORCE_DOCUMENTS);
         expectedEntries.put(IS_OFFLINE, false);
+        expectedEntries.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
+        expectedEntries.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
+        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
+        expectedEntries.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
 
         Map<String, Object> templateContent = noticeOfProceedingContent.apply(
             caseData,
@@ -1215,7 +1268,7 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(CAN_SERVE_BY_EMAIL, true);
         expectedEntries.put("hasCaseBeenReissued", true);
         expectedEntries.put("reissueDate", "19 June 2021");
-        expectedEntries.put("divorceOrCivilPartnershipEmail", "ymholiadaucymraeg@justice.gov.uk");
+        expectedEntries.put("divorceOrCivilPartnershipEmail", CONTACT_DIVORCE_EMAIL);
         expectedEntries.put("divorceOrCivilPartnershipUrl", "https://www.gov.uk/divorce");
         expectedEntries.put(IS_RESPONDENT_SOLICITOR_PERSONAL_SERVICE, true);
         expectedEntries.put(RELATIONS_SOLICITOR, "cyfreithiwr eich gwraig");
@@ -1270,7 +1323,7 @@ public class NoticeOfProceedingContentIT {
         expectedEntries.put(ISSUE_DATE, "18 June 2021");
         expectedEntries.put(SERVE_PAPERS_BEFORE_DATE, "16 July 2021");
         expectedEntries.put(CAN_SERVE_BY_EMAIL, true);
-        expectedEntries.put("divorceOrCivilPartnershipEmail", "ymholiadaucymraeg@justice.gov.uk");
+        expectedEntries.put("divorceOrCivilPartnershipEmail", CONTACT_DIVORCE_EMAIL);
         expectedEntries.put("divorceOrCivilPartnershipUrl", "https://www.gov.uk/end-civil-partnership");
         expectedEntries.put(IS_RESPONDENT_SOLICITOR_PERSONAL_SERVICE, false);
         expectedEntries.put(RELATION, "partner sifil");

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingJointContentIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingJointContentIT.java
@@ -21,11 +21,8 @@ import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DISSOL
 import static uk.gov.hmcts.divorce.divorcecase.model.Gender.FEMALE;
 import static uk.gov.hmcts.divorce.divorcecase.model.Gender.MALE;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CASE_REFERENCE;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_EMAIL;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_JUSTICE_GOV_UK_CY;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY;
@@ -141,7 +138,7 @@ public class NoticeOfProceedingJointContentIT {
         expectedEntries.put(ISSUE_DATE, "18 June 2021");
         expectedEntries.put(DUE_DATE, "19 June 2021");
         expectedEntries.put(ADDRESS, "line 1\ntown\npostcode");
-        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, DIVORCE_PROCEEDINGS);
         expectedEntries.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, FOR_A_DIVORCE);
         expectedEntries.put(RELATION, "wife");
@@ -210,7 +207,7 @@ public class NoticeOfProceedingJointContentIT {
         expectedEntries.put(ISSUE_DATE, "18 June 2021");
         expectedEntries.put(DUE_DATE, "19 June 2021");
         expectedEntries.put(ADDRESS, "line 1\ntown\npostcode");
-        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK);
+        expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, PROCEEDINGS_TO_END_YOUR_CIVIL_PARTNERSHIP);
         expectedEntries.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP, TO_END_YOUR_CIVIL_PARTNERSHIP);
         expectedEntries.put(RELATION, CIVIL_PARTNER);
@@ -380,7 +377,7 @@ public class NoticeOfProceedingJointContentIT {
         expectedEntries.put(RELATION, "partner sifil");
         expectedEntries.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT_CY);
         expectedEntries.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY);
-        expectedEntries.put(CONTACT_EMAIL, CONTACT_JUSTICE_GOV_UK_CY);
+        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT_CY);
         expectedEntries.put(CTSC_CONTACT_DETAILS, ctscContactDetails);
 

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/document/content/ServiceOrderTemplateContentIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/document/content/ServiceOrderTemplateContentIT.java
@@ -96,7 +96,7 @@ public class ServiceOrderTemplateContentIT {
         caseData.getAlternativeService().setServiceApplicationRefusalReason("refusal reasons");
 
         var ctscContactDetails = buildCtscContactDetails();
-        ctscContactDetails.setEmailAddress("divorcecase@justice.gov.uk");
+        ctscContactDetails.setEmailAddress("contactdivorce@justice.gov.uk");
 
         Map<String, Object> expectedEntries = new LinkedHashMap<>();
         expectedEntries.put(CASE_REFERENCE, "1616-5914-0147-3378");
@@ -123,7 +123,7 @@ public class ServiceOrderTemplateContentIT {
         caseData.getAlternativeService().setServiceApplicationRefusalReason("refusal reasons");
 
         var ctscContactDetails = buildCtscContactDetails();
-        ctscContactDetails.setEmailAddress("divorcecase@justice.gov.uk");
+        ctscContactDetails.setEmailAddress("contactdivorce@justice.gov.uk");
 
         Map<String, Object> expectedEntries = new LinkedHashMap<>();
         expectedEntries.put(CASE_REFERENCE, "1616-5914-0147-3378");
@@ -149,7 +149,7 @@ public class ServiceOrderTemplateContentIT {
         caseData.getAlternativeService().setServiceApplicationRefusalReason("refusal reasons");
 
         var ctscContactDetails = buildCtscContactDetails();
-        ctscContactDetails.setEmailAddress("divorcecase@justice.gov.uk");
+        ctscContactDetails.setEmailAddress("contactdivorce@justice.gov.uk");
 
         Map<String, Object> expectedEntries = new LinkedHashMap<>();
         expectedEntries.put(CASE_REFERENCE, "1616-5914-0147-3378");
@@ -176,7 +176,7 @@ public class ServiceOrderTemplateContentIT {
         caseData.getAlternativeService().setServiceApplicationRefusalReason("refusal reasons");
 
         var ctscContactDetails = buildCtscContactDetails();
-        ctscContactDetails.setEmailAddress("divorcecase@justice.gov.uk");
+        ctscContactDetails.setEmailAddress("contactdivorce@justice.gov.uk");
 
         Map<String, Object> expectedEntries = new LinkedHashMap<>();
         expectedEntries.put(CASE_REFERENCE, "1616-5914-0147-3378");
@@ -205,11 +205,11 @@ public class ServiceOrderTemplateContentIT {
         Map<String, Object> templateContent = serviceOrderTemplateContent.apply(caseData, TEST_CASE_ID);
 
         var ctscContactDetails = buildCtscContactDetails();
-        ctscContactDetails.setEmailAddress("divorcecase@justice.gov.uk");
 
         assertThat(templateContent).contains(
             entry(PARTNER, "priod"),
-            entry(DIVORCE_OR_DISSOLUTION, DIVORCE_PROCESS_CY)
+            entry(DIVORCE_OR_DISSOLUTION, DIVORCE_PROCESS_CY),
+            entry("ctscContactDetails", ctscContactDetails)
         );
     }
 
@@ -223,11 +223,11 @@ public class ServiceOrderTemplateContentIT {
         Map<String, Object> templateContent = serviceOrderTemplateContent.apply(caseData, TEST_CASE_ID);
 
         var ctscContactDetails = buildCtscContactDetails();
-        ctscContactDetails.setEmailAddress("divorcecase@justice.gov.uk");
 
         assertThat(templateContent).contains(
             entry(PARTNER, "partner sifil"),
-            entry(DIVORCE_OR_DISSOLUTION, PROCESS_TO_END_YOUR_CIVIL_PARTNERSHIP_CY)
+            entry(DIVORCE_OR_DISSOLUTION, PROCESS_TO_END_YOUR_CIVIL_PARTNERSHIP_CY),
+            entry("ctscContactDetails", ctscContactDetails)
         );
     }
 
@@ -255,7 +255,7 @@ public class ServiceOrderTemplateContentIT {
     private CtscContactDetails buildCtscContactDetails() {
         return CtscContactDetails
             .builder()
-            .emailAddress("divorcecase@justice.gov.uk")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .phoneNumber("0300 303 0642")
             .build();
     }

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -21,8 +21,8 @@ uk:
           signInDissolutionUrl: ${NOTIFY_TEMPLATE_SIGN_IN_DISSOLUTION_URL:https://nfdiv-end-civil-partnership.aat.platform.hmcts.net}
           applicant2SignInDissolutionUrl: ${NOTIFY_TEMPLATE_APPLICANT2_SIGN_IN_DISSOLUTION_URL:https://nfdiv-end-civil-partnership.aat.platform.hmcts.net/applicant2}
           signInProfessionalUsersUrl: ${NOTIFY_TEMPLATE_SIGN_IN_PROFESSIONAL_USERS_URL:https://manage-case.aat.platform.hmcts.net/cases/case-details/}
-          divorceCourtEmail: divorcecase@justice.gov.uk
-          dissolutionCourtEmail: endcivilpartnership@justice.gov.uk
+          divorceCourtEmail: contactdivorce@justice.gov.uk
+          dissolutionCourtEmail: contactdivorce@justice.gov.uk
         templates:
           english:
             SAVE_SIGN_OUT: '70dd0a1e-047f-4baa-993a-e722db17d8ac'
@@ -231,12 +231,12 @@ conditional-order-court:
     birmingham:
       name: "Birmingham Civil and Family Justice Centre"
       address: "Priory Courts\n33 Bull Street\nBirmingham\nB4 6DS"
-      email: "divorcecase@justice.gov.uk"
+      email: "contactdivorce@justice.gov.uk"
       phone: "0300 303 0642"
     buryStEdmunds:
       name: "Bury St. Edmunds Regional Divorce Centre"
       address: "2nd Floor\nTriton House\nSt. Andrews Street North\nBury St. Edmunds\nIP33 1TR"
-      email: "divorcecase@justice.gov.uk"
+      email: "contactdivorce@justice.gov.uk"
       phone: "0300 303 0642"
 
 pba:

--- a/src/main/java/uk/gov/hmcts/divorce/document/content/AosResponseLetterTemplateContent.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/content/AosResponseLetterTemplateContent.java
@@ -12,8 +12,7 @@ import java.util.Map;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_1_FIRST_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_1_LAST_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CASE_REFERENCE;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_OR_CIVIL_PARTNERSHIP_SERVICE_HEADER;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_PROCESS;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_SERVICE;
@@ -72,14 +71,14 @@ public class AosResponseLetterTemplateContent {
         if (caseData.isDivorce()) {
             templateContent.put(RELATION, commonContent.getPartner(caseData, caseData.getApplicant2()));
             templateContent.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP_APPLICATION, DIVORCE_APPLICATION);
-            templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+            templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
             templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, DIVORCE_PROCEEDINGS);
             templateContent.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP_PROCESS, DIVORCE_PROCESS);
             templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_SERVICE_HEADER, DIVORCE_SERVICE);
         } else {
             templateContent.put(RELATION, CIVIL_PARTNER);
             templateContent.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP_APPLICATION, APPLICATION_TO_END_YOUR_CIVIL_PARTNERSHIP);
-            templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK);
+            templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
             templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, PROCEEDINGS_TO_END_YOUR_CIVIL_PARTNERSHIP);
             templateContent.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP_PROCESS, PROCESS_TO_END_YOUR_CIVIL_PARTNERSHIP);
             templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_SERVICE_HEADER, END_CP_SERVICE);

--- a/src/main/java/uk/gov/hmcts/divorce/document/content/DocmosisCommonContent.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/content/DocmosisCommonContent.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_EMAIL;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_JUSTICE_GOV_UK_CY;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY;
@@ -58,7 +57,7 @@ public class DocmosisCommonContent {
         } else {
             templateContent.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT_CY);
             templateContent.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY);
-            templateContent.put(CONTACT_EMAIL, CONTACT_JUSTICE_GOV_UK_CY);
+            templateContent.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
             templateContent.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT_CY);
         }
 

--- a/src/main/java/uk/gov/hmcts/divorce/document/content/DocmosisTemplateConstants.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/content/DocmosisTemplateConstants.java
@@ -91,9 +91,6 @@ public final class DocmosisTemplateConstants {
     public static final String RESPONDENT_SOLICITOR_ADDRESS = "respondentSolicitorAddress";
     public static final String NOT_GIVEN = "not given";
     public static final String REFUSAL_REASON = "refusalReasons";
-    public static final String CONTACT_DIVORCE_JUSTICE_GOV_UK = "divorcecase@justice.gov.uk";
-    public static final String CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK = "divorcecase@justice.gov.uk";
-    public static final String CONTACT_JUSTICE_GOV_UK_CY = "ymholiadaucymraeg@justice.gov.uk";
 
     public static final String SOLICITOR_NAME = "solicitorName";
     public static final String SOLICITOR_ADDRESS = "solicitorAddress";

--- a/src/main/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingContent.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingContent.java
@@ -24,9 +24,7 @@ import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.AP
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_2_FIRST_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_2_LAST_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CASE_REFERENCE;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_JUSTICE_GOV_UK_CY;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_APPLICATION_CY;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.FOR_A_DIVORCE;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.FOR_A_DIVORCE_CY;
@@ -229,8 +227,7 @@ public class NoticeOfProceedingContent {
         templateContent.put(RELATION, commonContent.getPartner(caseData, partner, languagePreference));
 
         if (caseData.getDivorceOrDissolution().isDivorce()) {
-            templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL,
-                WELSH.equals(languagePreference) ? CONTACT_JUSTICE_GOV_UK_CY : CONTACT_DIVORCE_JUSTICE_GOV_UK);
+            templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
             templateContent.put(CommonContent.IS_DIVORCE, true);
             templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS,
                 WELSH.equals(languagePreference) ? DIVORCE_PROCEEDINGS_CY : DIVORCE_PROCEEDINGS);
@@ -255,8 +252,7 @@ public class NoticeOfProceedingContent {
             templateContent.put(MARRIAGE_OR_CIVIL_PARTNER, MARRIAGE);
             templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_DOCUMENTS, DIVORCE_DOCUMENTS);
         } else {
-            templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL,
-                WELSH.equals(languagePreference) ? CONTACT_JUSTICE_GOV_UK_CY : CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK);
+            templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
             templateContent.put(CommonContent.IS_DIVORCE, false);
             templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS,
                 WELSH.equals(languagePreference)

--- a/src/main/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingJointContent.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingJointContent.java
@@ -14,8 +14,7 @@ import java.util.Map;
 
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.WELSH;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CASE_REFERENCE;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_APPLICATION_CY;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.FOR_A_DIVORCE;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.FOR_A_DIVORCE_CY;
@@ -112,7 +111,7 @@ public class NoticeOfProceedingJointContent {
         );
 
         if (caseData.getDivorceOrDissolution().isDivorce()) {
-            templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+            templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
             templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS,
                 WELSH.equals(applicantLanguagePreference) ? DIVORCE_PROCEEDINGS_CY : DIVORCE_PROCEEDINGS);
             templateContent.put(DIVORCE_OR_END_CIVIL_PARTNERSHIP,
@@ -133,7 +132,7 @@ public class NoticeOfProceedingJointContent {
             templateContent.put(DIVORCE_OR_END_YOUR_CIVIL_PARTNERSHIP, DIVORCE);
             templateContent.put(MARRIAGE_OR_CIVIL_PARTNER, MARRIAGE);
         } else {
-            templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK);
+            templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
             templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS,
                 WELSH.equals(applicantLanguagePreference)
                     ? PROCEEDINGS_TO_END_YOUR_CIVIL_PARTNERSHIP_CY

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,8 +44,8 @@ uk:
           respondentSignInDissolutionUrl: ${NOTIFY_TEMPLATE_RESPONDENT_SIGN_IN_DISSOLUTION_URL:https://nfdiv-end-civil-partnership.aat.platform.hmcts.net/respondent}
           signInDissolutionUrl: ${NOTIFY_TEMPLATE_SIGN_IN_DISSOLUTION_URL:https://nfdiv-end-civil-partnership.aat.platform.hmcts.net/}
           signInProfessionalUsersUrl: ${NOTIFY_TEMPLATE_SIGN_IN_PROFESSIONAL_USERS_URL:https://manage-case.aat.platform.hmcts.net/cases/case-details/}
-          divorceCourtEmail: divorcecase@justice.gov.uk
-          dissolutionCourtEmail: divorcecase@justice.gov.uk
+          divorceCourtEmail: contactdivorce@justice.gov.uk
+          dissolutionCourtEmail: contactdivorce@justice.gov.uk
         templates:
           english:
             SAVE_SIGN_OUT: '3aff9dc0-0188-42f6-a0be-fc5daa404d9a'
@@ -487,12 +487,12 @@ conditional-order-court:
     birmingham:
       name: "Birmingham Civil and Family Justice Centre"
       address: "Priory Courts\n33 Bull Street\nBirmingham\nB4 6DS"
-      email: "divorcecase@justice.gov.uk"
+      email: "contactdivorce@justice.gov.uk"
       phone: "0300 303 0642"
     buryStEdmunds:
       name: "Bury St. Edmunds Regional Divorce Centre"
       address: "2nd Floor\nTriton House\nSt. Andrews Street North\nBury St. Edmunds\nIP33 1TR"
-      email: "divorcecase@justice.gov.uk"
+      email: "contactdivorce@justice.gov.uk"
       phone: "0300 303 0642"
 
 pba:

--- a/src/test/java/uk/gov/hmcts/divorce/document/content/AosResponseLetterTemplateContentTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/document/content/AosResponseLetterTemplateContentTest.java
@@ -23,7 +23,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.ApplicationType.SOLE_APPLIC
 import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DISSOLUTION;
 import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DIVORCE;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT;
@@ -93,7 +93,7 @@ public class AosResponseLetterTemplateContentTest {
         expectedEntries.put("applicant1FirstName", TEST_FIRST_NAME);
         expectedEntries.put("applicant1LastName", TEST_LAST_NAME);
         expectedEntries.put("applicant1Address", "Correspondence Address\nLine 2\nLine 3\nPost Town\nPost Code");
-        expectedEntries.put("divorceOrCivilPartnershipEmail", "divorcecase@justice.gov.uk");
+        expectedEntries.put("divorceOrCivilPartnershipEmail", "contactdivorce@justice.gov.uk");
         expectedEntries.put("divorceOrEndCivilPartnershipApplication", "divorce application");
         expectedEntries.put("issueDate", "1 January 2020");
         expectedEntries.put("relation", "husband");
@@ -104,7 +104,7 @@ public class AosResponseLetterTemplateContentTest {
         expectedEntries.put("divorceOrCivilPartnershipServiceHeader", "The Divorce Service");
         expectedEntries.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
         expectedEntries.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
-        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
 
         assertThat(result).containsExactlyInAnyOrderEntriesOf(expectedEntries);
@@ -151,7 +151,7 @@ public class AosResponseLetterTemplateContentTest {
         expectedEntries.put("applicant1FirstName", TEST_FIRST_NAME);
         expectedEntries.put("applicant1LastName", TEST_LAST_NAME);
         expectedEntries.put("applicant1Address", "Correspondence Address\nLine 2\nLine 3\nPost Town\nPost Code");
-        expectedEntries.put("divorceOrCivilPartnershipEmail", "divorcecase@justice.gov.uk");
+        expectedEntries.put("divorceOrCivilPartnershipEmail", "contactdivorce@justice.gov.uk");
         expectedEntries.put("divorceOrEndCivilPartnershipApplication", "application to end your civil partnership");
         expectedEntries.put("issueDate", "1 January 2020");
         expectedEntries.put("relation", "civil partner");
@@ -162,7 +162,7 @@ public class AosResponseLetterTemplateContentTest {
         expectedEntries.put("divorceOrCivilPartnershipServiceHeader", "End A Civil Partnership Service");
         expectedEntries.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
         expectedEntries.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
-        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        expectedEntries.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
         expectedEntries.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
 
         assertThat(result).containsExactlyInAnyOrderEntriesOf(expectedEntries);

--- a/src/test/java/uk/gov/hmcts/divorce/document/content/CertificateOfEntitlementContentTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/document/content/CertificateOfEntitlementContentTest.java
@@ -232,7 +232,7 @@ public class CertificateOfEntitlementContentTest {
         final ConditionalOrderCourtDetails expectedDetails = new ConditionalOrderCourtDetails();
         expectedDetails.setName("Bury St. Edmunds Regional Divorce Centre");
         expectedDetails.setAddress("2nd Floor\nTriton House\nSt. Andrews Street North\nBury St. Edmunds\nIP33 1TR");
-        expectedDetails.setEmail("divorcecase@justice.gov.uk");
+        expectedDetails.setEmail("contactdivorce@justice.gov.uk");
         expectedDetails.setPhone("0300 303 0642");
 
         when(conditionalOrderCourtDetailsConfig.get(BURY_ST_EDMUNDS.getCourtId())).thenReturn(expectedDetails);

--- a/src/test/java/uk/gov/hmcts/divorce/document/content/ConditionalOrderPronouncedTemplateContentTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/document/content/ConditionalOrderPronouncedTemplateContentTest.java
@@ -31,9 +31,8 @@ import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.WELSH;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_1_FULL_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_2_FULL_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CASE_REFERENCE;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_EMAIL;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_JUSTICE_GOV_UK_CY;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COUNTRY_OF_MARRIAGE;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT;
@@ -87,7 +86,7 @@ class ConditionalOrderPronouncedTemplateContentTest {
         Map<String, Object> basicDocmosisTemplateContent = new HashMap<>();
         basicDocmosisTemplateContent.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
         basicDocmosisTemplateContent.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
-        basicDocmosisTemplateContent.put(CONTACT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        basicDocmosisTemplateContent.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
         basicDocmosisTemplateContent.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
 
         when(commonContent.getPartner(any(), any(), eq(ENGLISH))).thenReturn("husband");
@@ -146,7 +145,7 @@ class ConditionalOrderPronouncedTemplateContentTest {
             entry(DATE_FO_ELIGIBLE_FROM, "23 July 2022"),
             entry(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT),
             entry(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT),
-            entry(CONTACT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK),
+            entry(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL),
             entry(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT));
     }
 
@@ -156,7 +155,7 @@ class ConditionalOrderPronouncedTemplateContentTest {
         Map<String, Object> basicDocmosisTemplateContent = new HashMap<>();
         basicDocmosisTemplateContent.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT_CY);
         basicDocmosisTemplateContent.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY);
-        basicDocmosisTemplateContent.put(CONTACT_EMAIL, CONTACT_JUSTICE_GOV_UK_CY);
+        basicDocmosisTemplateContent.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
         basicDocmosisTemplateContent.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT_CY);
 
         when(commonContent.getPartner(any(), any(), eq(WELSH))).thenReturn("gŵr");
@@ -215,7 +214,7 @@ class ConditionalOrderPronouncedTemplateContentTest {
             entry(DATE_FO_ELIGIBLE_FROM, "23 July 2022"),
             entry(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT_CY),
             entry(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY),
-            entry(CONTACT_EMAIL, CONTACT_JUSTICE_GOV_UK_CY),
+            entry(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL),
             entry(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT_CY));
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/document/content/DocmosisCommonContentTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/document/content/DocmosisCommonContentTest.java
@@ -15,7 +15,6 @@ import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_EMAIL;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_JUSTICE_GOV_UK_CY;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY;
@@ -80,7 +79,7 @@ class DocmosisCommonContentTest {
             .contains(
                 entry(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT_CY),
                 entry(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY),
-                entry(CONTACT_EMAIL, CONTACT_JUSTICE_GOV_UK_CY),
+                entry(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL),
                 entry(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT_CY),
                 entry(CTSC_CONTACT_DETAILS, CTSC_CONTACT));
     }

--- a/src/test/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingContentTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingContentTest.java
@@ -32,8 +32,7 @@ import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.AP
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_2_FIRST_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_2_LAST_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CASE_REFERENCE;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_APPLICATION;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_PROCESS;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.FOR_A_DIVORCE;
@@ -188,7 +187,7 @@ public class NoticeOfProceedingContentTest {
                 entry(ISSUE_DATE, "18 June 2021"),
                 entry(DUE_DATE, "19 June 2021"),
                 entry(RELATIONS_SOLICITOR, "wife's solicitor"),
-                entry(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK),
+                entry(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL),
                 entry(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, DIVORCE_PROCEEDINGS),
                 entry(DIVORCE_OR_END_CIVIL_PARTNERSHIP, FOR_A_DIVORCE),
                 entry(DIVORCE_OR_END_CIVIL_PARTNERSHIP_APPLICATION, DIVORCE_APPLICATION),
@@ -289,7 +288,7 @@ public class NoticeOfProceedingContentTest {
                 entry(APPLICANT_1_LAST_NAME, TEST_LAST_NAME),
                 entry(ISSUE_DATE, "18 June 2021"),
                 entry(DUE_DATE, "19 June 2021"),
-                entry(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CIVIL_PARTNERSHIP_CASE_JUSTICE_GOV_UK),
+                entry(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL),
                 entry(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, PROCEEDINGS_TO_END_YOUR_CIVIL_PARTNERSHIP),
                 entry(DIVORCE_OR_END_CIVIL_PARTNERSHIP, TO_END_YOUR_CIVIL_PARTNERSHIP),
                 entry(RELATION, CIVIL_PARTNER),

--- a/src/test/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingJointContentTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingJointContentTest.java
@@ -1,0 +1,258 @@
+package uk.gov.hmcts.divorce.document.content;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.type.AddressGlobalUK;
+import uk.gov.hmcts.divorce.common.config.DocmosisTemplatesConfig;
+import uk.gov.hmcts.divorce.common.service.HoldingPeriodService;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.CtscContactDetails;
+import uk.gov.hmcts.divorce.notification.CommonContent;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DISSOLUTION;
+import static uk.gov.hmcts.divorce.divorcecase.model.Gender.MALE;
+import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
+import static uk.gov.hmcts.divorce.divorcecase.model.ServiceMethod.PERSONAL_SERVICE;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_1_FIRST_NAME;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_1_LAST_NAME;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CASE_REFERENCE;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_APPLICATION;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_PROCESS;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.FIRST_NAME;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.FOR_A_DIVORCE;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.ISSUE_DATE;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.LAST_NAME;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.PROCESS_TO_END_YOUR_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.APPLICANT_1_ADDRESS;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.APPLICANT_2_ADDRESS;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.APPLICATION_TO_END_YOUR_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.BEEN_MARRIED_OR_ENTERED_INTO_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.CIVIL_PARTNER;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.CIVIL_PARTNERSHIP_EMAIL;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DISPLAY_EMAIL_CONFIRMATION;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_APPLICATION;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_PAPERS;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_SERVICE;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_SERVICE_HEADER;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_URL;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_END_A_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_END_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_END_CIVIL_PARTNERSHIP_APPLICATION;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_END_CIVIL_PARTNERSHIP_PROCESS;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_END_YOUR_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_PROCEEDINGS;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_SERVICE;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_URL;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DUE_DATE;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.ENDING_A_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.ENDING_YOUR_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.END_A_CIVIL_PARTNERSHIP_SERVICE;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.ENTERED_INTO_A_CIVIL_PARTNERSHIP_WITH;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.MARRIAGE;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.MARRIAGE_OR_CIVIL_PARTNER;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.PAPERS_TO_END_YOUR_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.PROCEEDINGS_TO_END_YOUR_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.RELATION;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.SERVE_PAPERS_BEFORE_DATE;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.SUBMISSION_RESPONSE_DATE;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.THE_DIVORCE_SERVICE;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.TO_END_YOUR_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.YOUR_APPLICATION_TO_END_YOUR_CIVIL_PARTNERSHIP;
+import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.YOUR_DIVORCE;
+import static uk.gov.hmcts.divorce.notification.CommonContent.ADDRESS;
+import static uk.gov.hmcts.divorce.notification.FormatUtil.formatId;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_FIRST_NAME;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_LAST_NAME;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_USER_EMAIL;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getBasicDocmosisTemplateContentWithCtscContactDetails;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeOfProceedingJointContentTest {
+
+    @Mock
+    private HoldingPeriodService holdingPeriodService;
+
+    @Mock
+    private CommonContent commonContent;
+
+    @Mock
+    private DocmosisTemplatesConfig config;
+
+    @Mock
+    private DocmosisCommonContent docmosisCommonContent;
+
+    @InjectMocks
+    private NoticeOfProceedingJointContent noticeOfProceedingJointContent;
+
+    @Test
+    public void shouldSuccessfullyApplyDivorceContentForJointNoticeOfProceedings() {
+        CaseData caseData = caseData();
+        caseData.getApplicant1().setFirstName(TEST_FIRST_NAME);
+        caseData.getApplicant1().setLastName(TEST_LAST_NAME);
+        caseData.getApplicant1().setAddress(
+                AddressGlobalUK
+                        .builder()
+                        .addressLine1("line1")
+                        .addressLine2("line2")
+                        .country("UK")
+                        .build()
+        );
+
+        caseData.getApplication().setServiceMethod(PERSONAL_SERVICE);
+        caseData.getApplication().setIssueDate(LocalDate.of(2021, 6, 18));
+        caseData.setDueDate(LocalDate.of(2021, 6, 19));
+
+        var ctscContactDetails = CtscContactDetails
+                .builder()
+                .centreName("HMCTS Digital Divorce and Dissolution")
+                .serviceCentre("Courts and Tribunals Service Centre")
+                .poBox("PO Box 13226")
+                .town("Harlow")
+                .postcode("CM20 9UG")
+                .phoneNumber("0300 303 0642")
+                .emailAddress("contactdivorce@justice.gov.uk")
+                .build();
+
+        when(docmosisCommonContent.getBasicDocmosisTemplateContent(caseData.getApplicant1().getLanguagePreference()))
+                .thenReturn(getBasicDocmosisTemplateContentWithCtscContactDetails(ENGLISH));
+
+        when(commonContent.getPartner(caseData, caseData.getApplicant2(), ENGLISH)).thenReturn("wife");
+        when(holdingPeriodService.getDueDateFor(LocalDate.of(2021, 6, 18)))
+                .thenReturn(LocalDate.of(2021, 11, 6));
+
+        Map<String, Object> templateContent = noticeOfProceedingJointContent.apply(
+                caseData,
+                TEST_CASE_ID,
+                caseData.getApplicant1(),
+                caseData.getApplicant2());
+
+        assertThat(templateContent)
+                .contains(
+                        entry(CASE_REFERENCE, formatId(1616591401473378L)),
+                        entry(FIRST_NAME, TEST_FIRST_NAME),
+                        entry(LAST_NAME, TEST_LAST_NAME),
+                        entry(ISSUE_DATE, "18 June 2021"),
+                        entry(DUE_DATE, "19 June 2021"),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, DIVORCE_PROCEEDINGS),
+                        entry(DIVORCE_OR_END_CIVIL_PARTNERSHIP, FOR_A_DIVORCE),
+                        entry(DIVORCE_OR_END_CIVIL_PARTNERSHIP_APPLICATION, DIVORCE_APPLICATION),
+                        entry(DIVORCE_OR_END_CIVIL_PARTNERSHIP_PROCESS, DIVORCE_PROCESS),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_APPLICATION, YOUR_DIVORCE),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP, DIVORCE),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_URL, DIVORCE_URL),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_SERVICE, DIVORCE_SERVICE),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_SERVICE_HEADER, THE_DIVORCE_SERVICE),
+                        entry(SUBMISSION_RESPONSE_DATE, "6 November 2021"),
+                        entry(DIVORCE_OR_END_A_CIVIL_PARTNERSHIP, DIVORCE),
+                        entry(DIVORCE_OR_END_YOUR_CIVIL_PARTNERSHIP, DIVORCE),
+                        entry(MARRIAGE_OR_CIVIL_PARTNER, MARRIAGE),
+                        entry("ctscContactDetails", ctscContactDetails),
+                        entry(ADDRESS, "line1\nline2"),
+                        entry(DISPLAY_EMAIL_CONFIRMATION, true)
+            );
+    }
+
+    @Test
+    public void shouldSuccessfullyApplyCivilPartnershipContentForJointNoticeOfProceedings() {
+        CaseData caseData = caseData();
+        caseData.setDivorceOrDissolution(DISSOLUTION);
+        caseData.getApplicant1().setFirstName(TEST_FIRST_NAME);
+        caseData.getApplicant1().setLastName(TEST_LAST_NAME);
+        caseData.getApplicant1().setGender(MALE);
+        caseData.getApplicant1().setOffline(NO);
+        caseData.getApplicant1().setEmail(TEST_USER_EMAIL);
+        caseData.getApplicant1().setAddress(
+                AddressGlobalUK
+                        .builder()
+                        .addressLine1("line1")
+                        .addressLine2("line2")
+                        .country("UK")
+                        .build()
+        );
+        caseData.getApplicant2().setAddress(
+                AddressGlobalUK
+                        .builder()
+                        .addressLine1("10 the street")
+                        .addressLine2("the town")
+                        .country("UK")
+                        .build()
+        );
+
+        caseData.getApplication().setIssueDate(LocalDate.of(2021, 6, 18));
+        caseData.setDueDate(LocalDate.of(2021, 6, 19));
+
+        var ctscContactDetails = CtscContactDetails
+                .builder()
+                .centreName("HMCTS Digital Divorce and Dissolution")
+                .serviceCentre("Courts and Tribunals Service Centre")
+                .poBox("PO Box 13226")
+                .town("Harlow")
+                .postcode("CM20 9UG")
+                .phoneNumber("0300 303 0642")
+                .emailAddress("contactdivorce@justice.gov.uk")
+                .build();
+
+        when(docmosisCommonContent.getBasicDocmosisTemplateContent(caseData.getApplicant1().getLanguagePreference()))
+                .thenReturn(getBasicDocmosisTemplateContentWithCtscContactDetails(ENGLISH));
+
+        when(commonContent.getPartner(caseData, caseData.getApplicant1(), ENGLISH)).thenReturn(CIVIL_PARTNER);
+        when(holdingPeriodService.getDueDateFor(LocalDate.of(2021, 6, 18)))
+                .thenReturn(LocalDate.of(2021, 11, 6));
+
+        Map<String, Object> templateContent = noticeOfProceedingJointContent.apply(
+                caseData,
+                TEST_CASE_ID,
+                caseData.getApplicant1(),
+                caseData.getApplicant2());
+
+        assertThat(templateContent)
+                .contains(
+                        entry(CASE_REFERENCE, formatId(1616591401473378L)),
+                        entry(APPLICANT_1_FIRST_NAME, TEST_FIRST_NAME),
+                        entry(APPLICANT_1_LAST_NAME, TEST_LAST_NAME),
+                        entry(ISSUE_DATE, "18 June 2021"),
+                        entry(DUE_DATE, "19 June 2021"),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS, PROCEEDINGS_TO_END_YOUR_CIVIL_PARTNERSHIP),
+                        entry(DIVORCE_OR_END_CIVIL_PARTNERSHIP, TO_END_YOUR_CIVIL_PARTNERSHIP),
+                        entry(RELATION, CIVIL_PARTNER),
+                        entry(DIVORCE_OR_END_CIVIL_PARTNERSHIP_APPLICATION, APPLICATION_TO_END_YOUR_CIVIL_PARTNERSHIP),
+                        entry(DIVORCE_OR_END_CIVIL_PARTNERSHIP_PROCESS, PROCESS_TO_END_YOUR_CIVIL_PARTNERSHIP),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_APPLICATION, YOUR_APPLICATION_TO_END_YOUR_CIVIL_PARTNERSHIP),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP, ENDING_YOUR_CIVIL_PARTNERSHIP),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_URL, CIVIL_PARTNERSHIP_EMAIL),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_SERVICE, END_A_CIVIL_PARTNERSHIP_SERVICE),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_SERVICE_HEADER, END_A_CIVIL_PARTNERSHIP_SERVICE),
+                        entry(SUBMISSION_RESPONSE_DATE, "6 November 2021"),
+                        entry(DIVORCE_OR_END_A_CIVIL_PARTNERSHIP, ENDING_A_CIVIL_PARTNERSHIP),
+                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_PAPERS, PAPERS_TO_END_YOUR_CIVIL_PARTNERSHIP),
+                        entry(SERVE_PAPERS_BEFORE_DATE, "16 July 2021"),
+                        entry(DIVORCE_OR_END_YOUR_CIVIL_PARTNERSHIP, APPLICATION_TO_END_YOUR_CIVIL_PARTNERSHIP),
+                        entry(BEEN_MARRIED_OR_ENTERED_INTO_CIVIL_PARTNERSHIP, ENTERED_INTO_A_CIVIL_PARTNERSHIP_WITH),
+                        entry(MARRIAGE_OR_CIVIL_PARTNER, CIVIL_PARTNERSHIP),
+                        entry("ctscContactDetails", ctscContactDetails),
+                        entry(APPLICANT_1_ADDRESS, "line1\nline2"),
+                        entry(APPLICANT_2_ADDRESS, "10 the street\nthe town"),
+                        entry(DISPLAY_EMAIL_CONFIRMATION, true)
+            );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingJointContentTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/document/content/NoticeOfProceedingJointContentTest.java
@@ -20,11 +20,8 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
 import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DISSOLUTION;
-import static uk.gov.hmcts.divorce.divorcecase.model.Gender.MALE;
 import static uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference.ENGLISH;
 import static uk.gov.hmcts.divorce.divorcecase.model.ServiceMethod.PERSONAL_SERVICE;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_1_FIRST_NAME;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_1_LAST_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CASE_REFERENCE;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DIVORCE_APPLICATION;
@@ -34,10 +31,7 @@ import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.FO
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.ISSUE_DATE;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.LAST_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.PROCESS_TO_END_YOUR_CIVIL_PARTNERSHIP;
-import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.APPLICANT_1_ADDRESS;
-import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.APPLICANT_2_ADDRESS;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.APPLICATION_TO_END_YOUR_CIVIL_PARTNERSHIP;
-import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.BEEN_MARRIED_OR_ENTERED_INTO_CIVIL_PARTNERSHIP;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.CIVIL_PARTNER;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.CIVIL_PARTNERSHIP;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.CIVIL_PARTNERSHIP_EMAIL;
@@ -46,7 +40,6 @@ import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DI
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_APPLICATION;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL;
-import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_PAPERS;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_PROCEEDINGS;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_SERVICE;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DIVORCE_OR_CIVIL_PARTNERSHIP_SERVICE_HEADER;
@@ -63,13 +56,10 @@ import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.DU
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.ENDING_A_CIVIL_PARTNERSHIP;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.ENDING_YOUR_CIVIL_PARTNERSHIP;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.END_A_CIVIL_PARTNERSHIP_SERVICE;
-import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.ENTERED_INTO_A_CIVIL_PARTNERSHIP_WITH;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.MARRIAGE;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.MARRIAGE_OR_CIVIL_PARTNER;
-import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.PAPERS_TO_END_YOUR_CIVIL_PARTNERSHIP;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.PROCEEDINGS_TO_END_YOUR_CIVIL_PARTNERSHIP;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.RELATION;
-import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.SERVE_PAPERS_BEFORE_DATE;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.SUBMISSION_RESPONSE_DATE;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.THE_DIVORCE_SERVICE;
 import static uk.gov.hmcts.divorce.document.content.NoticeOfProceedingContent.TO_END_YOUR_CIVIL_PARTNERSHIP;
@@ -80,7 +70,7 @@ import static uk.gov.hmcts.divorce.notification.FormatUtil.formatId;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_FIRST_NAME;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_LAST_NAME;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_USER_EMAIL;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_MIDDLE_NAME;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.getBasicDocmosisTemplateContentWithCtscContactDetails;
 
@@ -105,8 +95,8 @@ class NoticeOfProceedingJointContentTest {
     @Test
     public void shouldSuccessfullyApplyDivorceContentForJointNoticeOfProceedings() {
         CaseData caseData = caseData();
-        caseData.getApplicant1().setFirstName(TEST_FIRST_NAME);
-        caseData.getApplicant1().setLastName(TEST_LAST_NAME);
+        caseData.getApplicant2().setFirstName(TEST_FIRST_NAME);
+        caseData.getApplicant2().setLastName(TEST_LAST_NAME);
         caseData.getApplicant1().setAddress(
                 AddressGlobalUK
                         .builder()
@@ -175,11 +165,11 @@ class NoticeOfProceedingJointContentTest {
     public void shouldSuccessfullyApplyCivilPartnershipContentForJointNoticeOfProceedings() {
         CaseData caseData = caseData();
         caseData.setDivorceOrDissolution(DISSOLUTION);
-        caseData.getApplicant1().setFirstName(TEST_FIRST_NAME);
-        caseData.getApplicant1().setLastName(TEST_LAST_NAME);
-        caseData.getApplicant1().setGender(MALE);
+        caseData.getApplicant2().setFirstName(TEST_FIRST_NAME);
+        caseData.getApplicant2().setLastName(TEST_LAST_NAME);
+        caseData.getApplicant2().setMiddleName(TEST_MIDDLE_NAME);
         caseData.getApplicant1().setOffline(NO);
-        caseData.getApplicant1().setEmail(TEST_USER_EMAIL);
+        caseData.getApplicant2().setLanguagePreferenceWelsh(NO);
         caseData.getApplicant1().setAddress(
                 AddressGlobalUK
                         .builder()
@@ -214,7 +204,7 @@ class NoticeOfProceedingJointContentTest {
         when(docmosisCommonContent.getBasicDocmosisTemplateContent(caseData.getApplicant1().getLanguagePreference()))
                 .thenReturn(getBasicDocmosisTemplateContentWithCtscContactDetails(ENGLISH));
 
-        when(commonContent.getPartner(caseData, caseData.getApplicant1(), ENGLISH)).thenReturn(CIVIL_PARTNER);
+        when(commonContent.getPartner(caseData, caseData.getApplicant2(), ENGLISH)).thenReturn(CIVIL_PARTNER);
         when(holdingPeriodService.getDueDateFor(LocalDate.of(2021, 6, 18)))
                 .thenReturn(LocalDate.of(2021, 11, 6));
 
@@ -227,8 +217,8 @@ class NoticeOfProceedingJointContentTest {
         assertThat(templateContent)
                 .contains(
                         entry(CASE_REFERENCE, formatId(1616591401473378L)),
-                        entry(APPLICANT_1_FIRST_NAME, TEST_FIRST_NAME),
-                        entry(APPLICANT_1_LAST_NAME, TEST_LAST_NAME),
+                        entry(FIRST_NAME, TEST_FIRST_NAME),
+                        entry(LAST_NAME, TEST_LAST_NAME),
                         entry(ISSUE_DATE, "18 June 2021"),
                         entry(DUE_DATE, "19 June 2021"),
                         entry(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL),
@@ -244,14 +234,10 @@ class NoticeOfProceedingJointContentTest {
                         entry(DIVORCE_OR_CIVIL_PARTNERSHIP_SERVICE_HEADER, END_A_CIVIL_PARTNERSHIP_SERVICE),
                         entry(SUBMISSION_RESPONSE_DATE, "6 November 2021"),
                         entry(DIVORCE_OR_END_A_CIVIL_PARTNERSHIP, ENDING_A_CIVIL_PARTNERSHIP),
-                        entry(DIVORCE_OR_CIVIL_PARTNERSHIP_PAPERS, PAPERS_TO_END_YOUR_CIVIL_PARTNERSHIP),
-                        entry(SERVE_PAPERS_BEFORE_DATE, "16 July 2021"),
                         entry(DIVORCE_OR_END_YOUR_CIVIL_PARTNERSHIP, APPLICATION_TO_END_YOUR_CIVIL_PARTNERSHIP),
-                        entry(BEEN_MARRIED_OR_ENTERED_INTO_CIVIL_PARTNERSHIP, ENTERED_INTO_A_CIVIL_PARTNERSHIP_WITH),
                         entry(MARRIAGE_OR_CIVIL_PARTNER, CIVIL_PARTNERSHIP),
                         entry("ctscContactDetails", ctscContactDetails),
-                        entry(APPLICANT_1_ADDRESS, "line1\nline2"),
-                        entry(APPLICANT_2_ADDRESS, "10 the street\nthe town"),
+                        entry(ADDRESS, "line1\nline2"),
                         entry(DISPLAY_EMAIL_CONFIRMATION, true)
             );
     }

--- a/src/test/java/uk/gov/hmcts/divorce/legaladvisor/service/task/GenerateCoRefusedCoverLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/legaladvisor/service/task/GenerateCoRefusedCoverLetterTest.java
@@ -33,7 +33,6 @@ import static uk.gov.hmcts.divorce.document.DocumentConstants.REJECTED_REFUSAL_O
 import static uk.gov.hmcts.divorce.document.content.ConditionalOrderRefusedForAmendmentContent.LEGAL_ADVISOR_COMMENTS;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CASE_REFERENCE;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT;
@@ -92,7 +91,7 @@ public class GenerateCoRefusedCoverLetterTest {
         templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CONTACT_DIVORCE_EMAIL);
         templateContent.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
         templateContent.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
-        templateContent.put(CONTACT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        templateContent.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
         templateContent.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
 
         CaseData caseData = CaseData.builder()
@@ -159,7 +158,7 @@ public class GenerateCoRefusedCoverLetterTest {
         templateContent.put(DIVORCE_OR_CIVIL_PARTNERSHIP_EMAIL, CP_CASE_EMAIL);
         templateContent.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
         templateContent.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
-        templateContent.put(CONTACT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        templateContent.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
         templateContent.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
 
         CaseData caseData = CaseData.builder()

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/service/print/CertificateOfEntitlementPrinterTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/service/print/CertificateOfEntitlementPrinterTest.java
@@ -145,7 +145,7 @@ public class CertificateOfEntitlementPrinterTest {
     private CtscContactDetails buildCtscContactDetails() {
         return CtscContactDetails
             .builder()
-            .emailAddress("divorcecase@justice.gov.uk")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .phoneNumber("0300 303 0642")
             .build();
     }

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/service/task/ConditionalOrderPronouncedCoverLetterHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/service/task/ConditionalOrderPronouncedCoverLetterHelperTest.java
@@ -31,7 +31,7 @@ import static uk.gov.hmcts.divorce.document.DocumentConstants.CONDITIONAL_ORDER_
 import static uk.gov.hmcts.divorce.document.DocumentConstants.CO_GRANTED_COVER_LETTER_TEMPLATE_ID;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.CO_PRONOUNCED_COVER_LETTER_OFFLINE_RESPONDENT_TEMPLATE_ID;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CASE_REFERENCE;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
+import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_EMAIL;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT;
@@ -85,7 +85,7 @@ public class ConditionalOrderPronouncedCoverLetterHelperTest {
         Map<String, Object> applicant1TemplateVars = new HashMap<>();
         applicant1TemplateVars.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
         applicant1TemplateVars.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
-        applicant1TemplateVars.put(CONTACT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        applicant1TemplateVars.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
         applicant1TemplateVars.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
         applicant1TemplateVars.put(NAME, "Bob Smith");
         applicant1TemplateVars.put(ADDRESS, "line1\nline2\ncity\npostcode");
@@ -133,7 +133,7 @@ public class ConditionalOrderPronouncedCoverLetterHelperTest {
         Map<String, Object> applicant1TemplateVars = new HashMap<>();
         applicant1TemplateVars.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
         applicant1TemplateVars.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
-        applicant1TemplateVars.put(CONTACT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        applicant1TemplateVars.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
         applicant1TemplateVars.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
         applicant1TemplateVars.put(NAME, "App1 Sol");
         applicant1TemplateVars.put(ADDRESS, "221B Baker Street,\n London,\n NW1 6XE\n");
@@ -174,7 +174,7 @@ public class ConditionalOrderPronouncedCoverLetterHelperTest {
         applicant2TemplateVars.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
         applicant2TemplateVars.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
         applicant2TemplateVars.put("courtName", caseData.getConditionalOrder().getCourt().getLabel());
-        applicant2TemplateVars.put(CONTACT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        applicant2TemplateVars.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
         applicant2TemplateVars.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
         applicant2TemplateVars.put(NAME, "Lily Jones");
         applicant2TemplateVars.put(ADDRESS, "line1\nline2\ncity\npostcode");
@@ -228,7 +228,7 @@ public class ConditionalOrderPronouncedCoverLetterHelperTest {
         applicant2TemplateVars.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
         applicant2TemplateVars.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
         applicant2TemplateVars.put("courtName", caseData.getConditionalOrder().getCourt().getLabel());
-        applicant2TemplateVars.put(CONTACT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+        applicant2TemplateVars.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
         applicant2TemplateVars.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
         applicant2TemplateVars.put(NAME, "App2 Sol");
         applicant2TemplateVars.put(ADDRESS, "221B Baker Street,\n London,\n NW1 6XE\n");

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/service/task/GenerateCertificateOfEntitlementTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/service/task/GenerateCertificateOfEntitlementTest.java
@@ -97,7 +97,7 @@ class GenerateCertificateOfEntitlementTest {
 
     @BeforeEach
     public void setUp() {
-        ReflectionTestUtils.setField(generateCertificateOfEntitlement, "email", "divorcecase@justice.gov.uk");
+        ReflectionTestUtils.setField(generateCertificateOfEntitlement, "email", "contactdivorce@justice.gov.uk");
         ReflectionTestUtils.setField(generateCertificateOfEntitlement, "phoneNumber", "0300 303 0642");
         ReflectionTestUtils.setField(generateCertificateOfEntitlement, "finalOrderOffsetDays", 43);
     }
@@ -464,7 +464,7 @@ class GenerateCertificateOfEntitlementTest {
     private CtscContactDetails buildCtscContactDetails() {
         return CtscContactDetails
             .builder()
-            .emailAddress("divorcecase@justice.gov.uk")
+            .emailAddress("contactdivorce@justice.gov.uk")
             .phoneNumber("0300 303 0642")
             .build();
     }

--- a/src/test/java/uk/gov/hmcts/divorce/testutil/TestDataHelper.java
+++ b/src/test/java/uk/gov/hmcts/divorce/testutil/TestDataHelper.java
@@ -111,9 +111,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.ServiceMethod.SOLICITOR_SER
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_1_FULL_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.APPLICANT_2_FULL_NAME;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_EMAIL;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_DIVORCE_JUSTICE_GOV_UK;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_EMAIL;
-import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CONTACT_JUSTICE_GOV_UK_CY;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY;
@@ -807,12 +805,12 @@ public class TestDataHelper {
         if (ENGLISH.equals(languagePreference)) {
             basicDocmosisTemplateContent.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT);
             basicDocmosisTemplateContent.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT);
-            basicDocmosisTemplateContent.put(CONTACT_EMAIL, CONTACT_DIVORCE_JUSTICE_GOV_UK);
+            basicDocmosisTemplateContent.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
             basicDocmosisTemplateContent.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT);
         } else {
             basicDocmosisTemplateContent.put(DIVORCE_AND_DISSOLUTION_HEADER, DIVORCE_AND_DISSOLUTION_HEADER_TEXT_CY);
             basicDocmosisTemplateContent.put(COURTS_AND_TRIBUNALS_SERVICE_HEADER, COURTS_AND_TRIBUNALS_SERVICE_HEADER_TEXT_CY);
-            basicDocmosisTemplateContent.put(CONTACT_EMAIL, CONTACT_JUSTICE_GOV_UK_CY);
+            basicDocmosisTemplateContent.put(CONTACT_EMAIL, CONTACT_DIVORCE_EMAIL);
             basicDocmosisTemplateContent.put(PHONE_AND_OPENING_TIMES, PHONE_AND_OPENING_TIMES_TEXT_CY);
         }
         return basicDocmosisTemplateContent;


### PR DESCRIPTION
### Change description ###

At the moment, multiple placeholders are defined in multiple classes to have references to the same email address. This PR removes all the others and only refers to the Docmosis commone content class for the email address. 

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3200

**Before merging a pull request make sure that:**

- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**If this ticket will have any visible impact on users and is not behind a feature toggle, make sure that:**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

Note that bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.

### If this user story cannot be immediately merged find a way to put it behind a feature toggle and get it merged.

