### PR TITLE
Bump java chart to 4.0.9 as 4.0.6 is now depreciated

### DIFF
--- a/charts/nfdiv-case-api/Chart.yaml
+++ b/charts/nfdiv-case-api/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
   - name: HMCTS nfdiv team
 dependencies:
   - name: java
-    version: 4.0.6
+    version: 4.0.8
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: ccd
     version: 8.0.20

--- a/charts/nfdiv-case-api/Chart.yaml
+++ b/charts/nfdiv-case-api/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
   - name: HMCTS nfdiv team
 dependencies:
   - name: java
-    version: 4.0.8
+    version: 4.0.9
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: ccd
     version: 8.0.20


### PR DESCRIPTION
### Change description ###

NFD pipeline builds are failing on deployment tasks as java chart is deprecated. Upgrading to suggested version of 4.0.8 as per the logs on the jenkins pipeline.

### JIRA link (if applicable) ###

N/A

**Before merging a pull request make sure that:**

- [X] tests have been updated / new tests has been added (if needed)
- [X] README and other documentation has been updated / added (if needed)