### PR TITLE
Change use of toBoolean to equals method to handle null values

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/document/content/ConditionalOrderRefusedForAmendmentContent.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/content/ConditionalOrderRefusedForAmendmentContent.java
@@ -72,7 +72,7 @@ public class ConditionalOrderRefusedForAmendmentContent {
                 WELSH.equals(languagePreference) ? CIVIL_PARTNERSHIP_CY : CIVIL_PARTNERSHIP);
         }
 
-        templateContent.put(IS_JUDICIAL_SEPARATION, YesOrNo.YES.equals(caseData.getIsJudicialSeparation()));
+        templateContent.put(IS_JUDICIAL_SEPARATION, caseData.isJudicialSeparationCase());
 
         templateContent.put(
             LEGAL_ADVISOR_COMMENTS, conditionalOrderCommonContent.generateLegalAdvisorComments(caseData.getConditionalOrder()));

--- a/src/main/java/uk/gov/hmcts/divorce/document/content/ConditionalOrderRefusedForAmendmentContent.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/content/ConditionalOrderRefusedForAmendmentContent.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.divorce.document.content;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference;
 
@@ -25,7 +24,6 @@ import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.MA
 import static uk.gov.hmcts.divorce.notification.CommonContent.DIVORCE;
 import static uk.gov.hmcts.divorce.notification.CommonContent.DIVORCE_WELSH;
 import static uk.gov.hmcts.divorce.notification.CommonContent.PARTNER;
-import static uk.gov.hmcts.divorce.notification.CommonContent.YES;
 import static uk.gov.hmcts.divorce.notification.FormatUtil.DATE_TIME_FORMATTER;
 import static uk.gov.hmcts.divorce.notification.FormatUtil.formatId;
 

--- a/src/main/java/uk/gov/hmcts/divorce/document/content/ConditionalOrderRefusedForAmendmentContent.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/content/ConditionalOrderRefusedForAmendmentContent.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.divorce.document.content;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.LanguagePreference;
 
@@ -24,6 +25,7 @@ import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.MA
 import static uk.gov.hmcts.divorce.notification.CommonContent.DIVORCE;
 import static uk.gov.hmcts.divorce.notification.CommonContent.DIVORCE_WELSH;
 import static uk.gov.hmcts.divorce.notification.CommonContent.PARTNER;
+import static uk.gov.hmcts.divorce.notification.CommonContent.YES;
 import static uk.gov.hmcts.divorce.notification.FormatUtil.DATE_TIME_FORMATTER;
 import static uk.gov.hmcts.divorce.notification.FormatUtil.formatId;
 
@@ -70,7 +72,7 @@ public class ConditionalOrderRefusedForAmendmentContent {
                 WELSH.equals(languagePreference) ? CIVIL_PARTNERSHIP_CY : CIVIL_PARTNERSHIP);
         }
 
-        templateContent.put(IS_JUDICIAL_SEPARATION, caseData.getIsJudicialSeparation().toBoolean());
+        templateContent.put(IS_JUDICIAL_SEPARATION, YesOrNo.YES.equals(caseData.getIsJudicialSeparation()));
 
         templateContent.put(
             LEGAL_ADVISOR_COMMENTS, conditionalOrderCommonContent.generateLegalAdvisorComments(caseData.getConditionalOrder()));

--- a/src/main/java/uk/gov/hmcts/divorce/legaladvisor/service/printer/AwaitingAmendedApplicationPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/legaladvisor/service/printer/AwaitingAmendedApplicationPrinter.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.divorce.legaladvisor.service.printer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.caseworker.service.task.GenerateCoversheet;
 import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
@@ -20,6 +21,7 @@ import java.util.UUID;
 
 import static org.springframework.util.CollectionUtils.firstElement;
 import static org.springframework.util.CollectionUtils.isEmpty;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.COVERSHEET_APPLICANT;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.JUDICIAL_SEPARATION_CONDITIONAL_ORDER_REFUSAL_COVER_LETTER_TEMPLATE_ID;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.REJECTED_REFUSAL_ORDER_COVER_LETTER_TEMPLATE_ID;
@@ -85,7 +87,7 @@ public class AwaitingAmendedApplicationPrinter {
             caseData.getDocuments().getDocumentsGenerated(),
             COVERSHEET);
 
-        DocumentType refusalCoverLetterType = caseData.getIsJudicialSeparation().toBoolean()
+        DocumentType refusalCoverLetterType = YES.equals(caseData.getIsJudicialSeparation())
             ? JUDICIAL_SEPARATION_CONDITIONAL_ORDER_REFUSAL_COVER_LETTER
             : CONDITIONAL_ORDER_REFUSAL_COVER_LETTER;
 
@@ -135,7 +137,7 @@ public class AwaitingAmendedApplicationPrinter {
             coversheetApplicantTemplateContent.apply(caseData, caseId, applicant),
             applicant.getLanguagePreference()
         );
-        if (caseData.getIsJudicialSeparation().toBoolean()) {
+        if (YES.equals(caseData.getIsJudicialSeparation())) {
             generateJudicialSeparationCORefusedForAmendmentCoverLetter.generateAndUpdateCaseData(
                 caseData,
                 caseId,

--- a/src/main/java/uk/gov/hmcts/divorce/legaladvisor/service/printer/AwaitingAmendedApplicationPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/legaladvisor/service/printer/AwaitingAmendedApplicationPrinter.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.divorce.legaladvisor.service.printer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.caseworker.service.task.GenerateCoversheet;
 import uk.gov.hmcts.divorce.divorcecase.model.Applicant;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
@@ -21,7 +20,6 @@ import java.util.UUID;
 
 import static org.springframework.util.CollectionUtils.firstElement;
 import static org.springframework.util.CollectionUtils.isEmpty;
-import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.COVERSHEET_APPLICANT;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.JUDICIAL_SEPARATION_CONDITIONAL_ORDER_REFUSAL_COVER_LETTER_TEMPLATE_ID;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.REJECTED_REFUSAL_ORDER_COVER_LETTER_TEMPLATE_ID;

--- a/src/main/java/uk/gov/hmcts/divorce/legaladvisor/service/printer/AwaitingAmendedApplicationPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/legaladvisor/service/printer/AwaitingAmendedApplicationPrinter.java
@@ -87,7 +87,7 @@ public class AwaitingAmendedApplicationPrinter {
             caseData.getDocuments().getDocumentsGenerated(),
             COVERSHEET);
 
-        DocumentType refusalCoverLetterType = YES.equals(caseData.getIsJudicialSeparation())
+        DocumentType refusalCoverLetterType = caseData.isJudicialSeparationCase()
             ? JUDICIAL_SEPARATION_CONDITIONAL_ORDER_REFUSAL_COVER_LETTER
             : CONDITIONAL_ORDER_REFUSAL_COVER_LETTER;
 
@@ -137,7 +137,7 @@ public class AwaitingAmendedApplicationPrinter {
             coversheetApplicantTemplateContent.apply(caseData, caseId, applicant),
             applicant.getLanguagePreference()
         );
-        if (YES.equals(caseData.getIsJudicialSeparation())) {
+        if (caseData.isJudicialSeparationCase()) {
             generateJudicialSeparationCORefusedForAmendmentCoverLetter.generateAndUpdateCaseData(
                 caseData,
                 caseId,


### PR DESCRIPTION
### Change description ###

Saw in prod logs we had some NPE around using judicial separation toBoolean method, but JS can be null so changed it to be null safe.

### JIRA link (if applicable) ###

N/A - Azure prod logs.

**Before merging a pull request make sure that:**

- [X] tests have been updated / new tests has been added (if needed)
- [X] README and other documentation has been updated / added (if needed)