### PR TITLE
NFDIV-3041 - New state for sol respondent submits a final order

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/common/Applicant2ApplyForFinalOrderIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/common/Applicant2ApplyForFinalOrderIT.java
@@ -11,7 +11,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.divorce.common.config.WebMvcConfig;
-import uk.gov.hmcts.divorce.common.service.task.ProgressFinalOrderState;
+import uk.gov.hmcts.divorce.common.service.task.ProgressApplicant1FinalOrderState;
+import uk.gov.hmcts.divorce.common.service.task.ProgressApplicant2FinalOrderState;
 import uk.gov.hmcts.divorce.divorcecase.model.ApplicationType;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
@@ -76,7 +77,10 @@ public class Applicant2ApplyForFinalOrderIT {
     private ObjectMapper objectMapper;
 
     @Autowired
-    private ProgressFinalOrderState progressFinalOrderState;
+    private ProgressApplicant1FinalOrderState progressApplicant1FinalOrderState;
+
+    @Autowired
+    private ProgressApplicant2FinalOrderState progressApplicant2FinalOrderState;
 
     @MockBean
     private AuthTokenGenerator serviceTokenGenerator;

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/common/ApplyForFinalOrderIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/common/ApplyForFinalOrderIT.java
@@ -12,7 +12,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.config.WebMvcConfig;
-import uk.gov.hmcts.divorce.common.service.task.ProgressFinalOrderState;
+import uk.gov.hmcts.divorce.common.service.task.ProgressApplicant1FinalOrderState;
+import uk.gov.hmcts.divorce.common.service.task.ProgressApplicant2FinalOrderState;
 import uk.gov.hmcts.divorce.divorcecase.model.ApplicationType;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
@@ -80,7 +81,11 @@ public class ApplyForFinalOrderIT {
     private ObjectMapper objectMapper;
 
     @Autowired
-    private ProgressFinalOrderState progressFinalOrderState;
+    private ProgressApplicant1FinalOrderState progressApplicant1FinalOrderState;
+
+
+    @Autowired
+    private ProgressApplicant2FinalOrderState progressApplicant2FinalOrderState;
 
     @MockBean
     private AuthTokenGenerator serviceTokenGenerator;

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/ApplyForFinalOrderService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/ApplyForFinalOrderService.java
@@ -3,7 +3,8 @@ package uk.gov.hmcts.divorce.common.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
-import uk.gov.hmcts.divorce.common.service.task.ProgressFinalOrderState;
+import uk.gov.hmcts.divorce.common.service.task.ProgressApplicant1FinalOrderState;
+import uk.gov.hmcts.divorce.common.service.task.ProgressApplicant2FinalOrderState;
 import uk.gov.hmcts.divorce.common.service.task.SetFinalOrderFieldsAsApplicant1;
 import uk.gov.hmcts.divorce.common.service.task.SetFinalOrderFieldsAsApplicant2;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
@@ -28,13 +29,17 @@ public class ApplyForFinalOrderService {
     private SetFinalOrderFieldsAsApplicant2 setFinalOrderFieldsAsApplicant2;
 
     @Autowired
-    private ProgressFinalOrderState progressFinalOrderState;
+    private ProgressApplicant1FinalOrderState progressApplicant1FinalOrderState;
+
+
+    @Autowired
+    private ProgressApplicant2FinalOrderState progressApplicant2FinalOrderState;
 
     public CaseDetails<CaseData, State> applyForFinalOrderAsApplicant1(final CaseDetails<CaseData, State> caseDetails) {
 
         return CaseTaskRunner.caseTasks(
             setFinalOrderFieldsAsApplicant1,
-            progressFinalOrderState
+            progressApplicant1FinalOrderState
         ).run(caseDetails);
     }
 
@@ -42,7 +47,7 @@ public class ApplyForFinalOrderService {
 
         return CaseTaskRunner.caseTasks(
             setFinalOrderFieldsAsApplicant2,
-            progressFinalOrderState
+            progressApplicant2FinalOrderState
         ).run(caseDetails);
     }
 

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/ProgressApplicant1FinalOrderState.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/ProgressApplicant1FinalOrderState.java
@@ -13,11 +13,11 @@ import static uk.gov.hmcts.divorce.divorcecase.model.State.FinalOrderRequested;
 
 @Slf4j
 @Component
-public class ProgressFinalOrderState implements CaseTask {
+public class ProgressApplicant1FinalOrderState implements CaseTask {
 
     @Override
     public CaseDetails<CaseData, State> apply(CaseDetails<CaseData, State> details) {
-        log.info("Running ProgressFinalOrderState task for CaseID {}", details.getId());
+        log.info("Running ProgressApplicant1FinalOrderState task for CaseID {}", details.getId());
 
         CaseData data = details.getData();
         State state = details.getState();

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/ProgressApplicant2FinalOrderState.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/ProgressApplicant2FinalOrderState.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.divorce.common.service.task;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingFinalOrder;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingJointFinalOrder;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.FinalOrderRequested;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.RespondentFinalOrderRequested;
+
+@Slf4j
+@Component
+public class ProgressApplicant2FinalOrderState implements CaseTask {
+
+    @Override
+    public CaseDetails<CaseData, State> apply(CaseDetails<CaseData, State> details) {
+        log.info("Running ProgressApplicant2FinalOrderState task for CaseID {}", details.getId());
+
+        CaseData data = details.getData();
+        State state = details.getState();
+
+        var isSole = data.getApplicationType().isSole();
+        state = isSole
+            ? RespondentFinalOrderRequested
+            : AwaitingFinalOrder.equals(state)
+                ? AwaitingJointFinalOrder
+                : FinalOrderRequested;
+
+        details.setData(data);
+        details.setState(state);
+        return details;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/State.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/State.java
@@ -323,6 +323,13 @@ public enum State {
     FinalOrderRequested,
 
     @CCD(
+        label = "Respondent Final order requested",
+        hint = "### Case number: ${hyphenatedCaseRef}\n ### ${applicant1LastName} and ${applicant2LastName}\n",
+        access = {DefaultStateAccess.class}
+    )
+    RespondentFinalOrderRequested,
+
+    @CCD(
         label = "General application received",
         hint = "### Case number: ${hyphenatedCaseRef}\n ### ${applicant1LastName} and ${applicant2LastName}\n",
         access = {DefaultStateAccess.class}

--- a/src/test/java/uk/gov/hmcts/divorce/common/service/ApplyForFinalOrderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/service/ApplyForFinalOrderServiceTest.java
@@ -7,7 +7,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
-import uk.gov.hmcts.divorce.common.service.task.ProgressFinalOrderState;
+import uk.gov.hmcts.divorce.common.service.task.ProgressApplicant1FinalOrderState;
+import uk.gov.hmcts.divorce.common.service.task.ProgressApplicant2FinalOrderState;
 import uk.gov.hmcts.divorce.common.service.task.SetFinalOrderFieldsAsApplicant1;
 import uk.gov.hmcts.divorce.common.service.task.SetFinalOrderFieldsAsApplicant2;
 import uk.gov.hmcts.divorce.divorcecase.model.ApplicationType;
@@ -34,7 +35,10 @@ class ApplyForFinalOrderServiceTest {
     private SetFinalOrderFieldsAsApplicant2 setFinalOrderFieldsAsApplicant2;
 
     @Mock
-    private ProgressFinalOrderState progressFinalOrderState;
+    private ProgressApplicant1FinalOrderState progressApplicant1FinalOrderState;
+
+    @Mock
+    private ProgressApplicant2FinalOrderState progressApplicant2FinalOrderState;
 
     @Test
     void shouldRunCorrectTasksForApplyForFinalOrderAsApplicant1() {
@@ -42,12 +46,12 @@ class ApplyForFinalOrderServiceTest {
         final CaseDetails<CaseData, State> expectedCaseDetails = new CaseDetails<>();
 
         when(setFinalOrderFieldsAsApplicant1.apply(caseDetails)).thenReturn(expectedCaseDetails);
-        when(progressFinalOrderState.apply(caseDetails)).thenReturn(expectedCaseDetails);
+        when(progressApplicant1FinalOrderState.apply(caseDetails)).thenReturn(expectedCaseDetails);
 
         applyForFinalOrderService.applyForFinalOrderAsApplicant1(caseDetails);
 
         verify(setFinalOrderFieldsAsApplicant1).apply(caseDetails);
-        verify(progressFinalOrderState).apply(caseDetails);
+        verify(progressApplicant1FinalOrderState).apply(caseDetails);
     }
 
     @Test
@@ -56,12 +60,12 @@ class ApplyForFinalOrderServiceTest {
         final CaseDetails<CaseData, State> expectedCaseDetails = new CaseDetails<>();
 
         when(setFinalOrderFieldsAsApplicant2.apply(caseDetails)).thenReturn(expectedCaseDetails);
-        when(progressFinalOrderState.apply(caseDetails)).thenReturn(expectedCaseDetails);
+        when(progressApplicant2FinalOrderState.apply(caseDetails)).thenReturn(expectedCaseDetails);
 
         applyForFinalOrderService.applyForFinalOrderAsApplicant2(caseDetails);
 
         verify(setFinalOrderFieldsAsApplicant2).apply(caseDetails);
-        verify(progressFinalOrderState).apply(caseDetails);
+        verify(progressApplicant2FinalOrderState).apply(caseDetails);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/service/task/ProgressApplicant1FinalOrderStateTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/service/task/ProgressApplicant1FinalOrderStateTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
-import uk.gov.hmcts.divorce.common.service.task.ProgressFinalOrderState;
+import uk.gov.hmcts.divorce.common.service.task.ProgressApplicant1FinalOrderState;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 
@@ -18,8 +18,8 @@ import static uk.gov.hmcts.divorce.divorcecase.model.State.FinalOrderRequested;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
 
 @ExtendWith(MockitoExtension.class)
-class ProgressFinalOrderStateTest {
-    private final ProgressFinalOrderState task = new ProgressFinalOrderState();
+class ProgressApplicant1FinalOrderStateTest {
+    private final ProgressApplicant1FinalOrderState task = new ProgressApplicant1FinalOrderState();
 
     @Test
     void shouldSetStateToFinalOrderRequestedIfEnglishSoleApplication() {

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/service/task/ProgressApplicant2FinalOrderStateTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/service/task/ProgressApplicant2FinalOrderStateTest.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.divorce.solicitor.service.task;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.common.service.task.ProgressApplicant2FinalOrderState;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+import static uk.gov.hmcts.divorce.divorcecase.model.ApplicationType.JOINT_APPLICATION;
+import static uk.gov.hmcts.divorce.divorcecase.model.ApplicationType.SOLE_APPLICATION;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingFinalOrder;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingJointFinalOrder;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.FinalOrderRequested;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.RespondentFinalOrderRequested;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
+
+@ExtendWith(MockitoExtension.class)
+class ProgressApplicant2FinalOrderStateTest {
+    private final ProgressApplicant2FinalOrderState task = new ProgressApplicant2FinalOrderState();
+
+    @Test
+    void shouldSetStateToFinalOrderRequestedIfEnglishSoleApplication() {
+
+        CaseData caseData = caseData();
+        caseData.setApplicationType(SOLE_APPLICATION);
+        caseData.getApplicant1().setLanguagePreferenceWelsh(NO);
+
+        var details = CaseDetails.<CaseData, State>builder().data(caseData).state(AwaitingFinalOrder).build();
+        var result = task.apply(details);
+
+        assertEquals(result.getState(), RespondentFinalOrderRequested);
+    }
+
+    @Test
+    void shouldSetStateToAwaitingJointFinalOrderIfEnglishJointApplicationFirstInTime() {
+
+        CaseData caseData = caseData();
+        caseData.setApplicationType(JOINT_APPLICATION);
+        caseData.getApplicant1().setLanguagePreferenceWelsh(NO);
+
+        var details = CaseDetails.<CaseData, State>builder().data(caseData).state(AwaitingFinalOrder).build();
+        var result = task.apply(details);
+
+        assertEquals(result.getState(), AwaitingJointFinalOrder);
+    }
+
+    @Test
+    void shouldSetStateToFinalOrderRequestedIfEnglishJointApplicationSecondInTime() {
+
+        CaseData caseData = caseData();
+        caseData.setApplicationType(JOINT_APPLICATION);
+        caseData.getApplicant1().setLanguagePreferenceWelsh(NO);
+
+        var details = CaseDetails.<CaseData, State>builder().data(caseData).state(AwaitingJointFinalOrder).build();
+        var result = task.apply(details);
+
+        assertEquals(result.getState(), FinalOrderRequested);
+    }
+}


### PR DESCRIPTION
- Add new RespondentFinalOrderRequested state

- Add unit tests

### Change description ###

When a respondent applies for a final order in a sole case the state should move to a new state of RespondentFinalOrderRequested.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3041
