### PR TITLE
NFDIV-3318 - Fix migrations ccd issue

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/BaseMigration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/BaseMigration.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.divorce.systemupdate.schedule.migration;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.RetiredFields;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.task.MigrateRetiredFields;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.task.SetFailedMigrationVersionToZero;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
@@ -14,7 +14,6 @@ import uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.idam.client.models.User;
 
-import java.util.Map;
 
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCase.SYSTEM_MIGRATE_CASE;
@@ -23,7 +22,6 @@ import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCase.SYSTEM_M
 @Slf4j
 public class BaseMigration implements Migration {
 
-    public static final int HIGHEST_PRIORITY = 0;
     @Autowired
     private CcdSearchService ccdSearchService;
 
@@ -31,12 +29,10 @@ public class BaseMigration implements Migration {
     private CcdUpdateService ccdUpdateService;
 
     @Autowired
-    private ObjectMapper objectMapper;
+    private MigrateRetiredFields migrateRetiredFields;
 
-    @Override
-    public Integer getPriority() {
-        return HIGHEST_PRIORITY;
-    }
+    @Autowired
+    private SetFailedMigrationVersionToZero setFailedMigrationVersionToZero;
 
     @Override
     public void apply(final User user, final String serviceAuthorization) {
@@ -52,49 +48,21 @@ public class BaseMigration implements Migration {
     }
 
     private void migrateCase(final CaseDetails caseDetails, final User user, final String serviceAuthorization) {
-        final Long caseId = caseDetails.getId();
+        final String caseId = caseDetails.getId().toString();
 
         try {
-            final var data = RetiredFields.migrate(caseDetails.getData());
-            verifyData(data, caseId);
-
-            caseDetails.setData(data);
-            ccdUpdateService.submitEvent(caseDetails, SYSTEM_MIGRATE_CASE, user, serviceAuthorization);
+            ccdUpdateService.submitEventWithRetry(caseId, SYSTEM_MIGRATE_CASE, migrateRetiredFields, user, serviceAuthorization);
             log.info("Migration complete for case id: {}", caseId);
         } catch (final CcdConflictException e) {
             log.error("Could not get lock for case id: {}, continuing to next case", caseId);
-        } catch (final CcdManagementException e) {
-            log.error("Submit event failed for case id: {}, continuing to next case", caseId);
-            failedMigrationSetVersionToZero(caseDetails, user, serviceAuthorization, caseId, e);
-        }
-    }
-
-    private void failedMigrationSetVersionToZero(final CaseDetails caseDetails,
-                                                 final User user,
-                                                 final String serviceAuthorization,
-                                                 final Long caseId,
-                                                 final CcdManagementException ccdManagementException) {
-
-        if (ccdManagementException.getStatus() != NOT_FOUND.value()) {
-            log.info("Setting dataVersion to 0 for case id: {} after failed migration", caseDetails.getId());
-
-            caseDetails.setData(Map.of("dataVersion", HIGHEST_PRIORITY));
-            ccdUpdateService.submitEvent(caseDetails, SYSTEM_MIGRATE_CASE, user, serviceAuthorization);
-
-            log.info("dataVersion set for case id: {}", caseDetails.getId());
-        } else {
-            log.info("Version not set to 0 case not found for case id: {}", caseId);
-        }
-    }
-
-    private void verifyData(final Map<String, Object> data, final Long id) {
-        try {
-            objectMapper.convertValue(data, CaseData.class);
+        } catch (final CcdManagementException e ) {
+            if(e.getStatus() != NOT_FOUND.value()) {
+                log.error("Submit event failed for case id: {}, setting dataVersion to highest priority. Caused by: {}", caseId, e.getMessage());
+                ccdUpdateService.submitEventWithRetry(caseId, SYSTEM_MIGRATE_CASE, setFailedMigrationVersionToZero, user, serviceAuthorization);
+            }
         } catch (final IllegalArgumentException e) {
-            log.info("Migration failed for case id {} due to deserialization error", id);
-            log.info("Deserialization error caused by {}", e.getMessage());
-
-            data.put("dataVersion", HIGHEST_PRIORITY);
+            log.error("Submit event failed for case id: {}, setting dataVersion to highest priority. Caused by: {}", caseId, e.getMessage());
+            ccdUpdateService.submitEventWithRetry(caseId, SYSTEM_MIGRATE_CASE, setFailedMigrationVersionToZero, user, serviceAuthorization);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/BaseMigration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/BaseMigration.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.idam.client.models.User;
 
-
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCase.SYSTEM_MIGRATE_CASE;
 
@@ -56,13 +55,25 @@ public class BaseMigration implements Migration {
         } catch (final CcdConflictException e) {
             log.error("Could not get lock for case id: {}, continuing to next case", caseId);
         } catch (final CcdManagementException e ) {
-            if(e.getStatus() != NOT_FOUND.value()) {
-                log.error("Submit event failed for case id: {}, setting dataVersion to highest priority. Caused by: {}", caseId, e.getMessage());
-                ccdUpdateService.submitEventWithRetry(caseId, SYSTEM_MIGRATE_CASE, setFailedMigrationVersionToZero, user, serviceAuthorization);
+            if (e.getStatus() != NOT_FOUND.value()) {
+                log.error("Submit event failed for case id: {}, setting dataVersion to highest priority. Caused by: {}",
+                    caseId, e.getMessage());
+                ccdUpdateService.submitEventWithRetry(
+                    caseId,
+                    SYSTEM_MIGRATE_CASE,
+                    setFailedMigrationVersionToZero,
+                    user,
+                    serviceAuthorization);
             }
         } catch (final IllegalArgumentException e) {
-            log.error("Submit event failed for case id: {}, setting dataVersion to highest priority. Caused by: {}", caseId, e.getMessage());
-            ccdUpdateService.submitEventWithRetry(caseId, SYSTEM_MIGRATE_CASE, setFailedMigrationVersionToZero, user, serviceAuthorization);
+            log.error("Submit event failed for case id: {}, setting dataVersion to highest priority. Caused by: {}",
+                caseId, e.getMessage());
+            ccdUpdateService.submitEventWithRetry(
+                caseId,
+                SYSTEM_MIGRATE_CASE,
+                setFailedMigrationVersionToZero,
+                user,
+                serviceAuthorization);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/BaseMigration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/BaseMigration.java
@@ -54,7 +54,7 @@ public class BaseMigration implements Migration {
             log.info("Migration complete for case id: {}", caseId);
         } catch (final CcdConflictException e) {
             log.error("Could not get lock for case id: {}, continuing to next case", caseId);
-        } catch (final CcdManagementException e ) {
+        } catch (final CcdManagementException e) {
             if (e.getStatus() != NOT_FOUND.value()) {
                 log.error("Submit event failed for case id: {}, setting dataVersion to highest priority. Caused by: {}",
                     caseId, e.getMessage());

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/ConfirmReadPetitionMigration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/ConfirmReadPetitionMigration.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.divorce.systemupdate.schedule.migration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.task.UpdateConfirmReadPetitionFields;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
@@ -23,6 +23,9 @@ public class ConfirmReadPetitionMigration implements Migration {
 
     @Autowired
     private CcdUpdateService ccdUpdateService;
+
+    @Autowired
+    private UpdateConfirmReadPetitionFields updateConfirmReadPetitionFields;
 
     @Override
     public void apply(final User user, final String serviceAuthorization) {
@@ -44,12 +47,16 @@ public class ConfirmReadPetitionMigration implements Migration {
     }
 
     private void resetAosFields(final CaseDetails caseDetails, final User user, final String serviceAuthorization) {
-        final Long caseId = caseDetails.getId();
-
+        String caseId = caseDetails.getId().toString();
         try {
-            caseDetails.getData().put("confirmReadPetition", YesOrNo.NO);
-            caseDetails.getData().put("aosIsDrafted", YesOrNo.NO);
-            ccdUpdateService.submitEvent(caseDetails, SYSTEM_MIGRATE_CASE, user, serviceAuthorization);
+            ccdUpdateService.submitEventWithRetry(
+                caseId,
+                SYSTEM_MIGRATE_CASE,
+                updateConfirmReadPetitionFields,
+                user,
+                serviceAuthorization
+            );
+
             log.info("Reset AOS fields successfully for case id: {}", caseId);
         } catch (final CcdConflictException e) {
             log.error("Could not get lock for case id: {}, continuing to next case", caseId);

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/JointApplicationMigration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/JointApplicationMigration.java
@@ -25,7 +25,7 @@ public class JointApplicationMigration implements Migration {
     private CcdUpdateService ccdUpdateService;
 
     @Autowired
-    private RemoveAccessCode removeAccessCode;
+    private RemoveAccessCode removeAccessCodeTask;
 
     @Override
     public void apply(final User user, final String serviceAuthorization) {
@@ -48,7 +48,7 @@ public class JointApplicationMigration implements Migration {
             ccdUpdateService.submitEventWithRetry(
                 caseId,
                 SYSTEM_MIGRATE_CASE,
-                removeAccessCode,
+                removeAccessCodeTask,
                 user,
                 serviceAuthorization
             );

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/JointApplicationMigration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/JointApplicationMigration.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.divorce.systemupdate.schedule.migration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.task.RemoveAccessCode;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
@@ -23,6 +24,9 @@ public class JointApplicationMigration implements Migration {
     @Autowired
     private CcdUpdateService ccdUpdateService;
 
+    @Autowired
+    private RemoveAccessCode removeAccessCode;
+
     @Override
     public void apply(final User user, final String serviceAuthorization) {
         log.info("Started migrating cases joint application");
@@ -38,11 +42,17 @@ public class JointApplicationMigration implements Migration {
     }
 
     private void removeAccessCode(final CaseDetails caseDetails, final User user, final String serviceAuthorization) {
-        final Long caseId = caseDetails.getId();
+        final String caseId = caseDetails.getId().toString();
 
         try {
-            caseDetails.getData().put("accessCode", "");
-            ccdUpdateService.submitEvent(caseDetails, SYSTEM_MIGRATE_CASE, user, serviceAuthorization);
+            ccdUpdateService.submitEventWithRetry(
+                caseId,
+                SYSTEM_MIGRATE_CASE,
+                removeAccessCode,
+                user,
+                serviceAuthorization
+            );
+
             log.info("Removed access code successfully for case id: {}", caseId);
         } catch (final CcdConflictException e) {
             log.error("Could not get lock for case id: {}, continuing to next case", caseId);

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/PaperApplicationMigration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/PaperApplicationMigration.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.divorce.systemupdate.schedule.migration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.systemupdate.schedule.migration.task.UpdateApplicant2Offline;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/MigrateRetiredFields.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/MigrateRetiredFields.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.RetiredFields;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import java.util.Map;
+
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+
+@Component
+@Slf4j
+public class MigrateRetiredFields implements CaseTask {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public CaseDetails<CaseData, State> apply(final CaseDetails<CaseData, State> caseDetails) throws IllegalArgumentException  {
+
+        Map<String, Object> mappedData = objectMapper.convertValue(caseDetails.getData(), new TypeReference<>() {});
+        final var migratedMappedData = RetiredFields.migrate(mappedData);
+
+        final var convertedData = objectMapper.convertValue(migratedMappedData, CaseData.class);
+        caseDetails.setData(convertedData);
+
+        return caseDetails;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/MigrateRetiredFields.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/MigrateRetiredFields.java
@@ -13,8 +13,6 @@ import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
 
 import java.util.Map;
 
-import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
-
 @Component
 @Slf4j
 public class MigrateRetiredFields implements CaseTask {

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/RemoveAccessCode.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/RemoveAccessCode.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+@Component
+public class RemoveAccessCode implements CaseTask {
+
+    @Override
+    public CaseDetails<CaseData, State> apply(final CaseDetails<CaseData, State> caseDetails) {
+        final CaseData caseData = caseDetails.getData();
+
+        caseData.setCaseInvite(caseData.getCaseInvite().useAccessCode());
+
+        return caseDetails;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/SetFailedMigrationVersionToZero.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/SetFailedMigrationVersionToZero.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.RetiredFields;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import java.util.Map;
+
+@Component
+@Slf4j
+public class SetFailedMigrationVersionToZero implements CaseTask {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    public static final int HIGHEST_PRIORITY = 0;
+
+    @Override
+    public CaseDetails<CaseData, State> apply(final CaseDetails<CaseData, State> caseDetails) {
+
+        Map<String, Object> mappedData = objectMapper.convertValue(caseDetails.getData(), new TypeReference<>() {});
+        mappedData.put("dataVersion", HIGHEST_PRIORITY);
+
+        final var convertedData = objectMapper.convertValue(mappedData, CaseData.class);
+        caseDetails.setData(convertedData);
+
+        return caseDetails;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/SetFailedMigrationVersionToZero.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/SetFailedMigrationVersionToZero.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
-import uk.gov.hmcts.divorce.divorcecase.model.RetiredFields;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
 

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateAosIsDrafted.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateAosIsDrafted.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
+
+@Component
+public class UpdateAosIsDrafted implements CaseTask {
+
+    @Override
+    public CaseDetails<CaseData, State> apply(final CaseDetails<CaseData, State> caseDetails) {
+        final CaseData caseData = caseDetails.getData();
+
+        caseData.getAcknowledgementOfService().setAosIsDrafted(YES);
+
+        return caseDetails;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateApplicant2Offline.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateApplicant2Offline.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
+
+@Component
+public class UpdateApplicant2Offline implements CaseTask {
+
+    @Override
+    public CaseDetails<CaseData, State> apply(final CaseDetails<CaseData, State> caseDetails) {
+        final CaseData caseData = caseDetails.getData();
+
+        caseData.getApplicant2().setOffline(YES);
+
+        return caseDetails;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateConfirmReadPetitionFields.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateConfirmReadPetitionFields.java
@@ -2,18 +2,11 @@ package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
-import uk.gov.hmcts.ccd.sdk.type.ListValue;
-import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
-import uk.gov.hmcts.divorce.document.model.DivorceDocument;
-
-import java.util.Collection;
-import java.util.stream.Stream;
 
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
-import static uk.gov.hmcts.divorce.document.model.DocumentType.APPLICATION;
 
 @Component
 public class UpdateConfirmReadPetitionFields implements CaseTask {

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateConfirmReadPetitionFields.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateConfirmReadPetitionFields.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+import uk.gov.hmcts.divorce.document.model.DivorceDocument;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.APPLICATION;
+
+@Component
+public class UpdateConfirmReadPetitionFields implements CaseTask {
+
+    @Override
+    public CaseDetails<CaseData, State> apply(final CaseDetails<CaseData, State> caseDetails) {
+        final CaseData caseData = caseDetails.getData();
+
+        caseData.getAcknowledgementOfService().setConfirmReadPetition(NO);
+        caseData.getAcknowledgementOfService().setAosIsDrafted(NO);
+
+        return caseDetails;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/BaseMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/BaseMigrationTest.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.task.MigrateRetiredFields;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.task.SetFailedMigrationVersionToZero;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
@@ -20,16 +21,13 @@ import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.cloud.contract.spec.internal.HttpStatus.NOT_FOUND;
 import static org.springframework.cloud.contract.spec.internal.HttpStatus.REQUEST_TIMEOUT;
@@ -37,6 +35,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.RetiredFields.getVersion;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCase.SYSTEM_MIGRATE_CASE;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
 
 @ExtendWith(MockitoExtension.class)
 class BaseMigrationTest {
@@ -46,6 +45,12 @@ class BaseMigrationTest {
 
     @Mock
     private CcdSearchService ccdSearchService;
+
+    @Mock
+    private MigrateRetiredFields migrateRetiredFields;
+
+    @Mock
+    private SetFailedMigrationVersionToZero setFailedMigrationVersionToZero;
 
     @Mock
     private ObjectMapper objectMapper;
@@ -72,43 +77,62 @@ class BaseMigrationTest {
 
     @Test
     void shouldContinueProcessingIfThereIsConflictDuringSubmissionForBaseMigration() {
-        final CaseDetails caseDetails1 = mock(CaseDetails.class);
-        final CaseDetails caseDetails2 = mock(CaseDetails.class);
+        final CaseDetails caseDetails1 =
+            CaseDetails.builder()
+                .data(new HashMap<>())
+                .id(TEST_CASE_ID)
+                .build();
+        final CaseDetails caseDetails2 =
+            CaseDetails.builder()
+                .data(new HashMap<>())
+                .id(1616591401473379L)
+                .build();
+
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
         when(ccdSearchService.searchForCasesWithVersionLessThan(getVersion(), user, SERVICE_AUTHORIZATION))
             .thenReturn(caseDetailsList);
 
         doThrow(new CcdConflictException("Case is modified by another transaction", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(caseDetails1.getId().toString(), SYSTEM_MIGRATE_CASE, migrateRetiredFields, user, SERVICE_AUTHORIZATION);
+
         doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(caseDetails2.getId().toString(), SYSTEM_MIGRATE_CASE, migrateRetiredFields, user, SERVICE_AUTHORIZATION);
 
         baseMigration.apply(user, SERVICE_AUTHORIZATION);
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(caseDetails1.getId().toString(), SYSTEM_MIGRATE_CASE, migrateRetiredFields, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(caseDetails2.getId().toString(), SYSTEM_MIGRATE_CASE, migrateRetiredFields, user, SERVICE_AUTHORIZATION);
     }
+
 
     @Test
     void shouldContinueToNextCaseIfExceptionIsThrownWhileProcessingPreviousCaseForBaseMigration() {
-        final CaseDetails caseDetails1 = mock(CaseDetails.class);
-        final CaseDetails caseDetails2 = mock(CaseDetails.class);
-        final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
+        final CaseDetails caseDetails1 =
+            CaseDetails.builder()
+                .data(new HashMap<>())
+                .id(TEST_CASE_ID)
+                .build();
+        final CaseDetails caseDetails2 =
+            CaseDetails.builder()
+                .data(new HashMap<>())
+                .id(1616591401473379L)
+                .build();
 
+        final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
         when(ccdSearchService.searchForCasesWithVersionLessThan(getVersion(), user, SERVICE_AUTHORIZATION))
             .thenReturn(caseDetailsList);
 
         doThrow(new CcdManagementException(REQUEST_TIMEOUT, "Failed processing of case", mock(FeignException.class)))
             .doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(caseDetails1.getId().toString(), SYSTEM_MIGRATE_CASE, migrateRetiredFields, user, SERVICE_AUTHORIZATION);
         doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(caseDetails2.getId().toString(), SYSTEM_MIGRATE_CASE, migrateRetiredFields, user, SERVICE_AUTHORIZATION);
 
         baseMigration.apply(user, SERVICE_AUTHORIZATION);
 
-        verify(ccdUpdateService, times(2)).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(caseDetails1.getId().toString(), SYSTEM_MIGRATE_CASE, migrateRetiredFields, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(caseDetails2.getId().toString(), SYSTEM_MIGRATE_CASE, migrateRetiredFields, user, SERVICE_AUTHORIZATION);
     }
 
     @Test
@@ -116,6 +140,7 @@ class BaseMigrationTest {
         final CaseDetails caseDetails1 =
             CaseDetails.builder()
                 .data(new HashMap<>())
+                .id(TEST_CASE_ID)
                 .build();
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1);
@@ -123,22 +148,31 @@ class BaseMigrationTest {
         when(ccdSearchService.searchForCasesWithVersionLessThan(getVersion(), user, SERVICE_AUTHORIZATION))
             .thenReturn(caseDetailsList);
 
-        doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
-
-        when(objectMapper.convertValue(eq(caseDetails1.getData()), eq(CaseData.class)))
-            .thenThrow(new IllegalArgumentException("Failed to deserialize"));
+        doThrow(new IllegalArgumentException("Failed to deserialize"), mock(FeignException.class))
+            .doNothing()
+            .when(ccdUpdateService).submitEventWithRetry(caseDetails1.getId().toString(), SYSTEM_MIGRATE_CASE, migrateRetiredFields, user, SERVICE_AUTHORIZATION);
 
         baseMigration.apply(user, SERVICE_AUTHORIZATION);
 
-        assertThat(caseDetails1.getData()).isEqualTo(Map.of("dataVersion", 0));
-    }
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails1.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            migrateRetiredFields,
+            user,
+            SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails1.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            setFailedMigrationVersionToZero,
+            user,
+            SERVICE_AUTHORIZATION);    }
 
     @Test
     void shouldSetDataVersionToZeroIfExceptionIsThrownWhilstSubmittingCcdUpdateEventForBaseMigration() {
         final CaseDetails caseDetails1 =
             CaseDetails.builder()
                 .data(new HashMap<>())
+                .id(TEST_CASE_ID)
                 .build();
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1);
@@ -148,11 +182,22 @@ class BaseMigrationTest {
 
         doThrow(new CcdManagementException(REQUEST_TIMEOUT, "Failed processing of case", mock(FeignException.class)))
             .doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(caseDetails1.getId().toString(), SYSTEM_MIGRATE_CASE, migrateRetiredFields, user, SERVICE_AUTHORIZATION);
 
         baseMigration.apply(user, SERVICE_AUTHORIZATION);
 
-        assertThat(caseDetails1.getData()).isEqualTo(Map.of("dataVersion", 0));
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails1.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            migrateRetiredFields,
+            user,
+            SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails1.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            setFailedMigrationVersionToZero,
+            user,
+            SERVICE_AUTHORIZATION);
     }
 
     @Test
@@ -160,6 +205,7 @@ class BaseMigrationTest {
         final CaseDetails caseDetails1 =
             CaseDetails.builder()
                 .data(new HashMap<>())
+                .id(TEST_CASE_ID)
                 .build();
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1);
@@ -170,10 +216,16 @@ class BaseMigrationTest {
 
         doThrow(new CcdManagementException(NOT_FOUND, "Failed processing of case", mock(FeignException.class)))
             .doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(caseDetails1.getId().toString(), SYSTEM_MIGRATE_CASE, migrateRetiredFields, user, SERVICE_AUTHORIZATION);
 
         baseMigration.apply(user, SERVICE_AUTHORIZATION);
 
-        assertThat(caseDetails1.getData()).isEqualTo(Map.of("dataVersion", latestVersion));
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails1.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            migrateRetiredFields,
+            user,
+            SERVICE_AUTHORIZATION);
+        verifyNoMoreInteractions(ccdUpdateService);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/ConfirmReadPetitionMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/ConfirmReadPetitionMigrationTest.java
@@ -154,7 +154,8 @@ class ConfirmReadPetitionMigrationTest {
             updateConfirmReadPetitionFields,
             user,
             SERVICE_AUTHORIZATION
-        );    }
+        );
+    }
 
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/ConfirmReadPetitionMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/ConfirmReadPetitionMigrationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.task.UpdateConfirmReadPetitionFields;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
@@ -16,6 +17,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.idam.client.models.User;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
+import java.util.HashMap;
 import java.util.List;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
@@ -29,6 +31,7 @@ import static org.springframework.cloud.contract.spec.internal.HttpStatus.REQUES
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCase.SYSTEM_MIGRATE_CASE;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
 
 @ExtendWith(MockitoExtension.class)
 class ConfirmReadPetitionMigrationTest {
@@ -38,6 +41,9 @@ class ConfirmReadPetitionMigrationTest {
 
     @Mock
     private CcdSearchService ccdSearchService;
+
+    @Mock
+    private UpdateConfirmReadPetitionFields updateConfirmReadPetitionFields;
 
     @InjectMocks
     private ConfirmReadPetitionMigration confirmReadPetitionMigration;
@@ -64,8 +70,8 @@ class ConfirmReadPetitionMigrationTest {
     @Test
     void shouldContinueProcessingIfThereIsConflictDuringSubmissionForConfirmReadPetitionMigration() throws Exception {
 
-        final CaseDetails caseDetails1 = mock(CaseDetails.class);
-        final CaseDetails caseDetails2 = mock(CaseDetails.class);
+        final CaseDetails caseDetails1 = CaseDetails.builder().data(new HashMap<>()).id(TEST_CASE_ID).build();
+        final CaseDetails caseDetails2 = CaseDetails.builder().data(new HashMap<>()).id(1616591401473379L).build();
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
@@ -73,22 +79,48 @@ class ConfirmReadPetitionMigrationTest {
             .thenReturn(caseDetailsList);
 
         doThrow(new CcdConflictException("Case is modified by another transaction", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails1.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                updateConfirmReadPetitionFields,
+                user,
+                SERVICE_AUTHORIZATION
+            );
+
         doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails2.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                updateConfirmReadPetitionFields,
+                user,
+                SERVICE_AUTHORIZATION
+            );
 
         withEnvironmentVariable("ENABLE_CONFIRM_READ_PETITION_MIGRATION", "true")
             .execute(() -> confirmReadPetitionMigration.apply(user, SERVICE_AUTHORIZATION));
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails1.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            updateConfirmReadPetitionFields,
+            user,
+            SERVICE_AUTHORIZATION
+        );
+
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails2.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            updateConfirmReadPetitionFields,
+            user,
+            SERVICE_AUTHORIZATION
+        );
     }
 
     @Test
     void shouldContinueToNextCaseIfExceptionIsThrownWhileProcessingPreviousCaseForConfirmReadPetitionMigration() throws Exception {
 
-        final CaseDetails caseDetails1 = mock(CaseDetails.class);
-        final CaseDetails caseDetails2 = mock(CaseDetails.class);
+        final CaseDetails caseDetails1 = CaseDetails.builder().data(new HashMap<>()).id(TEST_CASE_ID).build();
+        final CaseDetails caseDetails2 = CaseDetails.builder().data(new HashMap<>()).id(1616591401473379L).build();
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
@@ -96,15 +128,33 @@ class ConfirmReadPetitionMigrationTest {
             .thenReturn(caseDetailsList);
 
         doThrow(new CcdManagementException(REQUEST_TIMEOUT, "Failed processing of case", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails1.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                updateConfirmReadPetitionFields,
+                user,
+                SERVICE_AUTHORIZATION
+            );
+
         doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails2.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                updateConfirmReadPetitionFields,
+                user,
+                SERVICE_AUTHORIZATION
+            );
 
         withEnvironmentVariable("ENABLE_CONFIRM_READ_PETITION_MIGRATION", "true")
             .execute(() -> confirmReadPetitionMigration.apply(user, SERVICE_AUTHORIZATION));
 
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
-    }
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails2.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            updateConfirmReadPetitionFields,
+            user,
+            SERVICE_AUTHORIZATION
+        );    }
 
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/JointApplicationMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/JointApplicationMigrationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.task.RemoveAccessCode;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
@@ -16,6 +17,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.idam.client.models.User;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
+import java.util.HashMap;
 import java.util.List;
 
 import static org.mockito.Mockito.doNothing;
@@ -28,6 +30,7 @@ import static org.springframework.cloud.contract.spec.internal.HttpStatus.REQUES
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCase.SYSTEM_MIGRATE_CASE;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
 
 @ExtendWith(MockitoExtension.class)
 class JointApplicationMigrationTest {
@@ -37,6 +40,9 @@ class JointApplicationMigrationTest {
 
     @Mock
     private CcdSearchService ccdSearchService;
+
+    @Mock
+    private RemoveAccessCode removeAccessCode;
 
     @InjectMocks
     private JointApplicationMigration jointApplicationMigration;
@@ -62,8 +68,8 @@ class JointApplicationMigrationTest {
     @Test
     void shouldContinueProcessingIfThereIsConflictDuringSubmissionForJointAppMigration() {
 
-        final CaseDetails caseDetails1 = mock(CaseDetails.class);
-        final CaseDetails caseDetails2 = mock(CaseDetails.class);
+        final CaseDetails caseDetails1 = CaseDetails.builder().data(new HashMap<>()).id(TEST_CASE_ID).build();
+        final CaseDetails caseDetails2 = CaseDetails.builder().data(new HashMap<>()).id(1616591401473379L).build();
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
@@ -71,21 +77,47 @@ class JointApplicationMigrationTest {
             .thenReturn(caseDetailsList);
 
         doThrow(new CcdConflictException("Case is modified by another transaction", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails1.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                removeAccessCode,
+                user,
+                SERVICE_AUTHORIZATION
+            );
+
         doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails2.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                removeAccessCode,
+                user,
+                SERVICE_AUTHORIZATION
+            );
 
         jointApplicationMigration.apply(user, SERVICE_AUTHORIZATION);
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails1.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            removeAccessCode,
+            user,
+            SERVICE_AUTHORIZATION
+        );
+
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails2.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            removeAccessCode,
+            user,
+            SERVICE_AUTHORIZATION
+        );
     }
 
     @Test
     void shouldContinueToNextCaseIfExceptionIsThrownWhileProcessingPreviousCaseForJointAppMigration() {
 
-        final CaseDetails caseDetails1 = mock(CaseDetails.class);
-        final CaseDetails caseDetails2 = mock(CaseDetails.class);
+        final CaseDetails caseDetails1 = CaseDetails.builder().data(new HashMap<>()).id(TEST_CASE_ID).build();
+        final CaseDetails caseDetails2 = CaseDetails.builder().data(new HashMap<>()).id(1616591401473379L).build();
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
@@ -93,12 +125,32 @@ class JointApplicationMigrationTest {
             .thenReturn(caseDetailsList);
 
         doThrow(new CcdManagementException(REQUEST_TIMEOUT, "Failed processing of case", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails1.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                removeAccessCode,
+                user,
+                SERVICE_AUTHORIZATION
+            );
+
         doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails2.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                removeAccessCode,
+                user,
+                SERVICE_AUTHORIZATION
+            );
+
 
         jointApplicationMigration.apply(user, SERVICE_AUTHORIZATION);
 
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails2.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            removeAccessCode,
+            user,
+            SERVICE_AUTHORIZATION
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/PaperApplicationMigrationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/PaperApplicationMigrationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.divorce.systemupdate.schedule.migration.task.UpdateApplicant2Offline;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdConflictException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdManagementException;
 import uk.gov.hmcts.divorce.systemupdate.service.CcdSearchCaseException;
@@ -16,6 +17,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.idam.client.models.User;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
+import java.util.HashMap;
 import java.util.List;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
@@ -29,6 +31,7 @@ import static org.springframework.cloud.contract.spec.internal.HttpStatus.REQUES
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemMigrateCase.SYSTEM_MIGRATE_CASE;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SYSTEM_UPDATE_AUTH_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
 
 @ExtendWith(MockitoExtension.class)
 class PaperApplicationMigrationTest {
@@ -38,6 +41,9 @@ class PaperApplicationMigrationTest {
 
     @Mock
     private CcdSearchService ccdSearchService;
+
+    @Mock
+    private UpdateApplicant2Offline updateApplicant2Offline;
 
     @InjectMocks
     private PaperApplicationMigration paperApplicationMigration;
@@ -75,8 +81,8 @@ class PaperApplicationMigrationTest {
     @Test
     void shouldContinueProcessingIfThereIsConflictDuringSubmissionForJointPaperAppMigration() throws Exception {
 
-        final CaseDetails caseDetails1 = mock(CaseDetails.class);
-        final CaseDetails caseDetails2 = mock(CaseDetails.class);
+        final CaseDetails caseDetails1 = CaseDetails.builder().data(new HashMap<>()).id(TEST_CASE_ID).build();
+        final CaseDetails caseDetails2 = CaseDetails.builder().data(new HashMap<>()).id(1616591401473379L).build();
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
@@ -84,22 +90,49 @@ class PaperApplicationMigrationTest {
             .thenReturn(caseDetailsList);
 
         doThrow(new CcdConflictException("Case is modified by another transaction", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails1.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                updateApplicant2Offline,
+                user,
+                SERVICE_AUTHORIZATION
+            );
+
         doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails2.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                updateApplicant2Offline,
+                user,
+                SERVICE_AUTHORIZATION
+            );
+
 
         withEnvironmentVariable("ENABLE_PAPER_APPLICATION_MIGRATION", "true")
             .execute(() -> paperApplicationMigration.apply(user, SERVICE_AUTHORIZATION));
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails1.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            updateApplicant2Offline,
+            user,
+            SERVICE_AUTHORIZATION
+        );
+
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails2.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            updateApplicant2Offline,
+            user,
+            SERVICE_AUTHORIZATION
+        );
     }
 
     @Test
     void shouldContinueProcessingIfThereIsConflictDuringSubmissionForSolePaperAppMigration() throws Exception {
 
-        final CaseDetails caseDetails1 = mock(CaseDetails.class);
-        final CaseDetails caseDetails2 = mock(CaseDetails.class);
+        final CaseDetails caseDetails1 = CaseDetails.builder().data(new HashMap<>()).id(TEST_CASE_ID).build();
+        final CaseDetails caseDetails2 = CaseDetails.builder().data(new HashMap<>()).id(1616591401473379L).build();
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
@@ -107,22 +140,49 @@ class PaperApplicationMigrationTest {
             .thenReturn(caseDetailsList);
 
         doThrow(new CcdConflictException("Case is modified by another transaction", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails1.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                updateApplicant2Offline,
+                user,
+                SERVICE_AUTHORIZATION
+            );
+
         doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails2.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                updateApplicant2Offline,
+                user,
+                SERVICE_AUTHORIZATION
+            );
+
 
         withEnvironmentVariable("ENABLE_PAPER_APPLICATION_MIGRATION", "true")
             .execute(() -> paperApplicationMigration.apply(user, SERVICE_AUTHORIZATION));
 
-        verify(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails1.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            updateApplicant2Offline,
+            user,
+            SERVICE_AUTHORIZATION
+        );
+
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails2.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            updateApplicant2Offline,
+            user,
+            SERVICE_AUTHORIZATION
+        );
     }
 
     @Test
     void shouldContinueToNextCaseIfExceptionIsThrownWhileProcessingPreviousCaseForJointPaperAppMigration() throws Exception {
 
-        final CaseDetails caseDetails1 = mock(CaseDetails.class);
-        final CaseDetails caseDetails2 = mock(CaseDetails.class);
+        final CaseDetails caseDetails1 = CaseDetails.builder().data(new HashMap<>()).id(TEST_CASE_ID).build();
+        final CaseDetails caseDetails2 = CaseDetails.builder().data(new HashMap<>()).id(1616591401473379L).build();
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
@@ -130,21 +190,40 @@ class PaperApplicationMigrationTest {
             .thenReturn(caseDetailsList);
 
         doThrow(new CcdManagementException(REQUEST_TIMEOUT, "Failed processing of case", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails1.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                updateApplicant2Offline,
+                user,
+                SERVICE_AUTHORIZATION
+            );
+
         doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails2.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                updateApplicant2Offline,
+                user,
+                SERVICE_AUTHORIZATION
+            );
 
         withEnvironmentVariable("ENABLE_PAPER_APPLICATION_MIGRATION", "true")
             .execute(() -> paperApplicationMigration.apply(user, SERVICE_AUTHORIZATION));
 
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails2.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            updateApplicant2Offline,
+            user,
+            SERVICE_AUTHORIZATION
+        );
     }
 
     @Test
     void shouldContinueToNextCaseIfExceptionIsThrownWhileProcessingPreviousCaseForSolePaperAppMigration() throws Exception {
 
-        final CaseDetails caseDetails1 = mock(CaseDetails.class);
-        final CaseDetails caseDetails2 = mock(CaseDetails.class);
+        final CaseDetails caseDetails1 = CaseDetails.builder().data(new HashMap<>()).id(TEST_CASE_ID).build();
+        final CaseDetails caseDetails2 = CaseDetails.builder().data(new HashMap<>()).id(1616591401473379L).build();
 
         final List<CaseDetails> caseDetailsList = List.of(caseDetails1, caseDetails2);
 
@@ -152,14 +231,33 @@ class PaperApplicationMigrationTest {
             .thenReturn(caseDetailsList);
 
         doThrow(new CcdManagementException(REQUEST_TIMEOUT, "Failed processing of case", mock(FeignException.class)))
-            .when(ccdUpdateService).submitEvent(caseDetails1, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails1.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                updateApplicant2Offline,
+                user,
+                SERVICE_AUTHORIZATION
+            );
+
         doNothing()
-            .when(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+            .when(ccdUpdateService).submitEventWithRetry(
+                caseDetails2.getId().toString(),
+                SYSTEM_MIGRATE_CASE,
+                updateApplicant2Offline,
+                user,
+                SERVICE_AUTHORIZATION
+            );
 
         withEnvironmentVariable("ENABLE_PAPER_APPLICATION_MIGRATION", "true")
             .execute(() -> paperApplicationMigration.apply(user, SERVICE_AUTHORIZATION));
 
-        verify(ccdUpdateService).submitEvent(caseDetails2, SYSTEM_MIGRATE_CASE, user, SERVICE_AUTHORIZATION);
+        verify(ccdUpdateService).submitEventWithRetry(
+            caseDetails2.getId().toString(),
+            SYSTEM_MIGRATE_CASE,
+            updateApplicant2Offline,
+            user,
+            SERVICE_AUTHORIZATION
+        );
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/MigrateRetiredFieldsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/MigrateRetiredFieldsTest.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.testutil.TestDataHelper;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.DivorceOrDissolution.DIVORCE;
+
+
+@ExtendWith(MockitoExtension.class)
+class MigrateRetiredFieldsTest {
+
+    @Spy
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private MigrateRetiredFields migrateRetiredFields;
+
+    @Test
+    void shouldMigrateFields() {
+        final CaseData caseData = TestDataHelper.caseData();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> result = migrateRetiredFields.apply(caseDetails);
+
+        Assertions.assertThat(result.getData().getDivorceOrDissolution()).isEqualTo(DIVORCE);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/RemoveAccessCodeTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/RemoveAccessCodeTest.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
+
+@ExtendWith(MockitoExtension.class)
+class RemoveAccessCodeTest {
+
+    @InjectMocks
+    private RemoveAccessCode removeAccessCode;
+
+    @Test
+    void shouldSetConfirmReadPetitionFields() {
+
+        final CaseData caseData = caseData();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> result = removeAccessCode.apply(caseDetails);
+
+        assertThat(result.getData().getCaseInvite().accessCode()).isEqualTo(null);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/SetFailedMigrationVersionToZeroTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/SetFailedMigrationVersionToZeroTest.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.RetiredFields;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.testutil.TestDataHelper;
+
+import java.util.Map;
+
+
+@ExtendWith(MockitoExtension.class)
+class SetFailedMigrationVersionToZeroTest {
+
+    @Spy
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private SetFailedMigrationVersionToZero setFailedMigrationVersionToZero;
+
+    @Test
+    void shouldSetVersionToZero() {
+        final CaseData caseData = TestDataHelper.caseData();
+        caseData.setRetiredFields(new RetiredFields());
+        caseData.getRetiredFields().setDataVersion(1);
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> result = setFailedMigrationVersionToZero.apply(caseDetails);
+        Assertions.assertThat(result.getData().getRetiredFields().getDataVersion()).isEqualTo(0);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateAosIsDraftedTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateAosIsDraftedTest.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateAosIsDraftedTest {
+
+    @InjectMocks
+    private UpdateAosIsDrafted updateAosIsDrafted;
+
+    @Test
+    void shouldSetAosIsDraftedToYes() {
+
+        final CaseData caseData = caseData();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> result = updateAosIsDrafted.apply(caseDetails);
+
+        assertThat(result.getData().getAcknowledgementOfService().getAosIsDrafted()).isEqualTo(YES);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateApplicant2OfflineTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateApplicant2OfflineTest.java
@@ -19,7 +19,7 @@ class UpdateApplicant2OfflineTest {
     private UpdateApplicant2Offline updateApplicant2Offline;
 
     @Test
-    void shouldSetConfirmReadPetitionFields() {
+    void shouldSetApplicant2OfflineToYes() {
 
         final CaseData caseData = caseData();
 

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateApplicant2OfflineTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateApplicant2OfflineTest.java
@@ -9,24 +9,25 @@ import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
 
 @ExtendWith(MockitoExtension.class)
-class RemoveAccessCodeTest {
+class UpdateApplicant2OfflineTest {
 
     @InjectMocks
-    private RemoveAccessCode removeAccessCode;
+    private UpdateApplicant2Offline updateApplicant2Offline;
 
     @Test
-    void shouldSetAccessCodeToNull() {
+    void shouldSetConfirmReadPetitionFields() {
 
         final CaseData caseData = caseData();
 
         final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
         caseDetails.setData(caseData);
 
-        final CaseDetails<CaseData, State> result = removeAccessCode.apply(caseDetails);
+        final CaseDetails<CaseData, State> result = updateApplicant2Offline.apply(caseDetails);
 
-        assertThat(result.getData().getCaseInvite().accessCode()).isEqualTo(null);
+        assertThat(result.getData().getApplicant2().getOffline()).isEqualTo(YES);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateConfirmReadPetitionFieldsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/schedule/migration/task/UpdateConfirmReadPetitionFieldsTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.divorce.systemupdate.schedule.migration.task;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateConfirmReadPetitionFieldsTest {
+
+    @InjectMocks
+    private UpdateConfirmReadPetitionFields updateConfirmReadPetitionFields;
+
+    @Test
+    void shouldSetConfirmReadPetitionFields() {
+
+        final CaseData caseData = caseData();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setData(caseData);
+
+        final CaseDetails<CaseData, State> result = updateConfirmReadPetitionFields.apply(caseDetails);
+
+        assertThat(result.getData().getAcknowledgementOfService().getConfirmReadPetition()).isEqualTo(NO);
+        assertThat(result.getData().getAcknowledgementOfService().getAosIsDrafted()).isEqualTo(NO);
+    }
+}


### PR DESCRIPTION
### Change description ###

NFD team has been made aware that the way we call the CCD API may not be concurrent safe. Updating all migrations to be concurrent safe by using the startEventResponse caseDetails instead of passing our own caseDetails in from the Ccd Search Service.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3318
https://tools.hmcts.net/jira/browse/NFDIV-3309