### PR TITLE
Add suppression for CVE-2023-24998

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -62,4 +62,8 @@
     <notes>no updates for hutool or json-java_project which fixes this vulnerability</notes>
     <cve>CVE-2022-45688</cve>
   </suppress>
+  <suppress>
+    <notes>no updates for deps which import Apache Commons FileUpload</notes>
+    <cve>CVE-2023-24998</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Suppress CVE-2023-24998 for the time being, due to lack of updates for deps which import Apache Commons FileUpload.