### PR TITLE
NFD - Move from ZERO expiry token to 5minutes to avoid expiring issues mid processing

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/common/config/AuthConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/config/AuthConfiguration.java
@@ -9,6 +9,8 @@ import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGeneratorFactory;
 import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
 import uk.gov.hmcts.reform.authorisation.validators.ServiceAuthTokenValidator;
 
+import java.time.Duration;
+
 @Configuration
 public class AuthConfiguration {
     @Bean
@@ -22,6 +24,6 @@ public class AuthConfiguration {
         @Value("${idam.s2s-auth.microservice}") final String microService,
         final ServiceAuthorisationApi serviceAuthorisationApi
     ) {
-        return AuthTokenGeneratorFactory.createDefaultGenerator(secret, microService, serviceAuthorisationApi);
+        return AuthTokenGeneratorFactory.createDefaultGenerator(secret, microService, serviceAuthorisationApi, Duration.ofMinutes(5));
     }
 }


### PR DESCRIPTION
NFD are getting token expiry 401 unauthorised issues during bulk case processing and we've traced it to the fact that the auto refresh doesn't work as intended as the value for the offset time is ZERO. So the token is valid all the up until it fails, which means we never get a refreshed token. 

This causes us to have an expired token occasionally during processing of bulk cases. The failed cases also don't make it onto the failed case list because we use the same expired token to make that call.

This should fix it.