### PR TITLE
NFDIV-3405 updated NoC to keep the solicitor roles when applicants are represented and solicitor is online

### DIFF
--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChangeTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerNoticeOfChangeTest.java
@@ -128,8 +128,7 @@ class CaseworkerNoticeOfChangeTest {
 
         verify(caseAccessService).removeUsersWithRole(anyLong(), eq(
             List.of(
-                CREATOR.getRole(),
-                APPLICANT_1_SOLICITOR.getRole()
+                CREATOR.getRole()
             )
         ));
     }
@@ -157,8 +156,7 @@ class CaseworkerNoticeOfChangeTest {
 
         verify(caseAccessService).removeUsersWithRole(anyLong(), eq(
             List.of(
-                CREATOR.getRole(),
-                APPLICANT_1_SOLICITOR.getRole()
+                CREATOR.getRole()
             )
         ));
     }
@@ -236,8 +234,7 @@ class CaseworkerNoticeOfChangeTest {
 
         verify(caseAccessService).removeUsersWithRole(anyLong(), eq(
             List.of(
-                UserRole.APPLICANT_2.getRole(),
-                APPLICANT_2_SOLICITOR.getRole()
+                UserRole.APPLICANT_2.getRole()
             )
         ));
     }
@@ -266,8 +263,7 @@ class CaseworkerNoticeOfChangeTest {
 
         verify(caseAccessService).removeUsersWithRole(anyLong(), eq(
             List.of(
-                UserRole.APPLICANT_2.getRole(),
-                APPLICANT_2_SOLICITOR.getRole()
+                UserRole.APPLICANT_2.getRole()
             )
         ));
     }


### PR DESCRIPTION
Updated NoC event to keep the solicitor roles

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3405

### Pull request checklist ###

**Before raising**
- [x] tests have been updated / new tests has been added (if needed)
- [x] README and other documentation has been updated / added (if needed)

**Before merging**
- [x] this ticket been reviewed by QA
- [x] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
