### PR TITLE
NFDIV-3465 - Add applicant2 JS and Separation prayers

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/page/CorrectPaperCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/page/CorrectPaperCase.java
@@ -29,16 +29,21 @@ public class CorrectPaperCase implements CcdPageConfiguration {
 
     private static final String TITLE = "Correct paper case";
     private static final String JOINT_APPLICATION = "applicationType=\"jointApplication\"";
-    private static final String JOINT_DIVORCE_APPLICATION = "applicationType=\"jointApplication\" AND divorceOrDissolution = \"divorce\"";
+    private static final String JOINT_DIVORCE_APPLICATION
+        = "applicationType=\"jointApplication\" AND divorceOrDissolution = \"divorce\" AND supplementaryCaseType = \"notApplicable\"";
     private static final String JOINT_DISSOLUTION_APPLICATION
-        = "applicationType=\"jointApplication\" AND divorceOrDissolution = \"dissolution\" ";
+        = "applicationType=\"jointApplication\" AND divorceOrDissolution = \"dissolution\" AND supplementaryCaseType = \"notApplicable\"";
     private static final String APPLICANT_1_SOLICITOR_REPRESENTED_YES = "applicant1SolicitorRepresented=\"Yes\"";
     private static final String APPLICANT_2_SOLICITOR_REPRESENTED_YES = "applicant2SolicitorRepresented=\"Yes\"";
     private static final String DIVORCE_APPLICATION = "divorceOrDissolution = \"divorce\" AND supplementaryCaseType = \"notApplicable\"";
     private static final String DISSOLUTION_APPLICATION
         = "divorceOrDissolution = \"dissolution\" AND supplementaryCaseType = \"notApplicable\"";
     private static final String JUDICIAL_SEPARATION_APPLICATION = "supplementaryCaseType = \"judicialSeparation\"";
+    private static final String JOINT_JUDICIAL_SEPARATION_APPLICATION
+        = "supplementaryCaseType = \"judicialSeparation\" AND applicationType=\"jointApplication\"";
     private static final String SEPARATION_APPLICATION = "supplementaryCaseType = \"separation\"";
+    private static final String JOINT_SEPARATION_APPLICATION
+        = "supplementaryCaseType = \"separation\" AND applicationType=\"jointApplication\"";
     private static final String JOINT_APPLICATION_APP2_REPRESENTED
         = "applicationType=\"jointApplication\" AND applicant2SolicitorRepresented=\"Yes\"";
 
@@ -282,6 +287,8 @@ public class CorrectPaperCase implements CcdPageConfiguration {
                 .complex(Applicant::getApplicantPrayer)
                 .mandatory(ApplicantPrayer::getPrayerDissolveDivorce, JOINT_DIVORCE_APPLICATION)
                 .mandatory(ApplicantPrayer::getPrayerEndCivilPartnership, JOINT_DISSOLUTION_APPLICATION)
+                .mandatory(ApplicantPrayer::getPrayerJudicialSeparation, JOINT_JUDICIAL_SEPARATION_APPLICATION)
+                .mandatory(ApplicantPrayer::getPrayerSeparation, JOINT_SEPARATION_APPLICATION)
                 .optional(ApplicantPrayer::getPrayerFinancialOrdersThemselves, JOINT_APPLICATION)
                 .optional(ApplicantPrayer::getPrayerFinancialOrdersChild, JOINT_APPLICATION)
                 .done()


### PR DESCRIPTION
### Change description ###

As per story, applicant2's prayer was not showing on the Correct Paper Case event. Adding it in as it is required in a joint application for JS & Separation.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3465
