### PR TITLE
Fix generate-ccd-definition.sh

### DIFF
--- a/bin/generate-ccd-definition.sh
+++ b/bin/generate-ccd-definition.sh
@@ -18,7 +18,7 @@ echo "Definition input directory: ${definition_input_dir}"
 echo "Definition output file: ${definition_output_file}"
 echo "Additional params: ${additionalParameters}"
 
-docker run --pull always --user $UID --rm \
+docker run --pull always --rm \
   -v ${definition_input_dir}:/tmp/ccd-definition \
   -v ${definition_output_file}:/tmp/ccd-definition.xlsx \
   hmctspublic.azurecr.io/ccd/definition-processor:${definition_processor_version} \


### PR DESCRIPTION
Remove user param from docker run call in generate-ccd-definition.sh.

This prevents the inaccessible ./cache folder issue when running the definition processor.