### PR TITLE
Fix Dynamic List serialisation issue

### DIFF
--- a/src/functionalTest/resources/responses/response-solicitor-payment-mid-event.json
+++ b/src/functionalTest/resources/responses/response-solicitor-payment-mid-event.json
@@ -13,10 +13,6 @@
     "solServiceTruthStatement": "I believe that the facts stated in the application are true.",
     "solPaymentHowToPay": "feePayByAccount",
     "pbaNumbers": {
-      "value": {
-        "code": "${json-unit.any-string}",
-        "label": "pbaNumber"
-      },
       "list_items": [
         {
           "code": "${json-unit.any-string}",

--- a/src/functionalTest/resources/responses/response-solicitor-payment-mid-event.json
+++ b/src/functionalTest/resources/responses/response-solicitor-payment-mid-event.json
@@ -34,9 +34,7 @@
           "code": "${json-unit.any-string}",
           "label": "PBA0023444"
         }
-      ],
-      "valueLabel": "pbaNumber",
-      "valueCode": "${json-unit.any-string}"
+      ]
     },
     "dataVersion": "${json-unit.any-number}",
     "warnings": []

--- a/src/integrationTest/resources/caseworker-offline-document-about-to-start-response.json
+++ b/src/integrationTest/resources/caseworker-offline-document-about-to-start-response.json
@@ -14,18 +14,12 @@
       }
     ],
     "scannedDocumentNames": {
-      "value": {
-        "code": "${json-unit.ignore}",
-        "label": "scannedDocumentName"
-      },
       "list_items": [
         {
           "code": "${json-unit.ignore}",
           "label": "doc1.pdf"
         }
-      ],
-      "valueLabel": "scannedDocumentName",
-      "valueCode": "${json-unit.ignore}"
+      ]
     },
     "dataVersion": 5,
     "warnings": []

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerOfflineDocumentVerified.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerOfflineDocumentVerified.java
@@ -166,7 +166,6 @@ public class CaseworkerOfflineDocumentVerified implements CCDConfig<CaseData, St
 
             DynamicList scannedDocNamesDynamicList = DynamicList
                 .builder()
-                .value(DynamicListElement.builder().label("scannedDocumentName").code(UUID.randomUUID()).build())
                 .listItems(scannedDocumentNames)
                 .build();
 

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/PbaService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/client/pba/PbaService.java
@@ -42,7 +42,6 @@ public class PbaService {
 
         return DynamicList
             .builder()
-            .value(DynamicListElement.builder().label("pbaNumber").code(UUID.randomUUID()).build())
             .listItems(pbaAccountNumbers)
             .build();
     }


### PR DESCRIPTION
### Change description ###

Fix Dynamic List serialisation issue - occurring for both pbaNumbers and scanned Document Names
Caused by setting a default value for the selected element which allowed users to progress to event submission without selecting an item from the dropdown. When clicking submit in these conditions, the exception is thrown.
Fixed by removing the default selected value for the dynamic list

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3568

### Pull request checklist ###

**Before raising**
- [x] tests have been updated / new tests has been added (if needed)
- [x] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
