### PR TITLE
Set graceful shutdown with a 2m timeout

### DIFF
--- a/charts/nfdiv-case-api/Chart.yaml
+++ b/charts/nfdiv-case-api/Chart.yaml
@@ -3,12 +3,12 @@ appVersion: "1.0"
 description: A Helm chart for nfdiv-case-api App
 name: nfdiv-case-api
 home: https://github.com/hmcts/nfdiv-case-api
-version: 0.0.76
+version: 0.0.77
 maintainers:
   - name: HMCTS nfdiv team
 dependencies:
   - name: java
-    version: 4.1.5
+    version: 4.1.6-alpha
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: ccd
     version: 8.0.29

--- a/charts/nfdiv-case-api/values.yaml
+++ b/charts/nfdiv-case-api/values.yaml
@@ -29,6 +29,7 @@ java:
   image: 'hmctspublic.azurecr.io/nfdiv/case-api:latest'
   ingressHost: nfdiv-case-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
   aadIdentityName: nfdiv
+  terminationGracePeriodSeconds: 120
   autoscaling:
     enabled: true
     maxReplicas: 9

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,6 @@
 server:
   port: 4013
+  shutdown: graceful
 
 management:
   endpoint:
@@ -20,6 +21,8 @@ spring:
     import: "optional:configtree:/mnt/secrets/nfdiv/"
   main:
     allow-bean-definition-overriding: true
+  lifecycle:
+    timeout-per-shutdown-phase: 2m
 
 springdoc:
   packagesToScan: uk.gov.hmcts.divorce,uk.gov.hmcts.ccd.sdk.runtime


### PR DESCRIPTION
### Change description ###

Set graceful shutdown with a 2m timeout to avoid deployments shutting down the service while it is processing bulk cases.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3608

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
