### PR TITLE
NFDIV-3756: Allow citizen-applicant2-update-application when in Offli…

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant2UpdateApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenApplicant2UpdateApplication.java
@@ -22,6 +22,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingJointFinalOrd
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingService;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.ConditionalOrderDrafted;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.ConditionalOrderPending;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.OfflineDocumentReceived;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.APPLICANT_2;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
 
@@ -38,7 +39,7 @@ public class CitizenApplicant2UpdateApplication implements CCDConfig<CaseData, S
             .event(CITIZEN_APPLICANT2_UPDATE)
             .forStates(ArrayUtils.addAll(AOS_STATES, AwaitingApplicant2Response, AosDrafted, AosOverdue,
                 ConditionalOrderDrafted, ConditionalOrderPending, AwaitingClarification, AwaitingService,
-                AwaitingFinalOrder, AwaitingJointFinalOrder))
+                AwaitingFinalOrder, AwaitingJointFinalOrder, OfflineDocumentReceived))
             .name("Patch a joint case")
             .description("Patch a joint divorce or dissolution as applicant 2")
             .aboutToSubmitCallback(this::aboutToSubmit)


### PR DESCRIPTION


### Change description ###

Allow citizen-applicant2-update-application when in OfflineDocumentReceived state

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3756

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
