### PR TITLE
Limit the total number of cases returned from a CCD search query

### DIFF
--- a/charts/nfdiv-case-api/Chart.yaml
+++ b/charts/nfdiv-case-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for nfdiv-case-api App
 name: nfdiv-case-api
 home: https://github.com/hmcts/nfdiv-case-api
-version: 0.0.82
+version: 0.0.83
 maintainers:
   - name: HMCTS nfdiv team
 dependencies:

--- a/charts/nfdiv-case-api/values.yaml
+++ b/charts/nfdiv-case-api/values.yaml
@@ -51,8 +51,6 @@ java:
     PRD_API_BASEURL : "http://rd-professional-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     SEND_LETTER_SERVICE_BASEURL: "http://rpe-send-letter-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     PAYMENT_API_BASEURL: "http://payment-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
-    BULK_ACTION_BATCH_SIZE_MIN: 30
-    BULK_ACTION_BATCH_SIZE_MAX: 50
     CITIZEN_UPDATE_CASE_STATE_ENABLED: false
     ADMIN_UNLINK_APPLICANT_2_ENABLED: false
     SERVICE_AUTH_MICROSERVICE: nfdiv_case_api

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -58,7 +58,8 @@ core_case_data:
   api:
     url: ${CASE_DATA_STORE_BASEURL:http://ccd-data-store-api-aat.service.core-compute-aat.internal}
   search:
-    page_size: ${CCD_SEARCH_PAGE_SIZE:100}
+    page_size: ${CCD_SEARCH_PAGE_SIZE:50}
+    total_max_results: ${CCD_SEARCH_MAX_RESULTS:250}
 
 doc_assembly:
   url: ${DOC_ASSEMBLY_URL:http://dg-docassembly-aat.service.core-compute-aat.internal}

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -63,7 +63,8 @@ core_case_data:
   api:
     url: http://localhost:4012
   search:
-    page_size: 100
+    page_size: 50
+    total_max_results: 250
 
 doc_assembly:
   url: ${DOC_ASSEMBLY_URL:http://dg-docassembly-aat.service.core-compute-aat.internal}

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/CcdSearchService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/CcdSearchService.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.divorce.systemupdate.service;
 
 import feign.FeignException;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -77,8 +76,10 @@ public class CcdSearchService {
     private int pageSize;
 
     @Value("${bulk-action.page-size}")
-    @Setter
     private int bulkActionPageSize;
+
+    @Value("${core_case_data.search.total_max_results}")
+    private int totalMaxResults;
 
     @Autowired
     private CoreCaseDataApi coreCaseDataApi;
@@ -99,7 +100,7 @@ public class CcdSearchService {
         int totalResults = pageSize;
 
         try {
-            while (totalResults == pageSize) {
+            while (totalResults == pageSize && allCaseDetails.size() <= totalMaxResults) {
                 final SearchResult searchResult = searchForCasesWithQuery(from, pageSize, query, user, serviceAuth);
 
                 final List<CaseDetails> pageResults = searchResult.getCases();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -319,7 +319,8 @@ core_case_data:
   api:
     url: ${CASE_DATA_STORE_BASEURL:http://ccd-data-store-api-aat.service.core-compute-aat.internal}
   search:
-    page_size: ${CCD_SEARCH_PAGE_SIZE:100}
+    page_size: ${CCD_SEARCH_PAGE_SIZE:50}
+    total_max_results: ${CCD_SEARCH_MAX_RESULTS:250}
 
 docmosis:
   templates:

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/service/CcdSearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/service/CcdSearchServiceTest.java
@@ -803,8 +803,8 @@ class CcdSearchServiceTest {
         final User user = new User(SYSTEM_UPDATE_AUTH_TOKEN, UserDetails.builder().build());
         final SearchResult searchResult1 = SearchResult.builder().total(PAGE_SIZE)
             .cases(createCaseDetailsList(PAGE_SIZE, 1)).build();
-        final SearchResult searchResult2 = SearchResult.builder().total(1)
-            .cases(createCaseDetailsList(1, PAGE_SIZE + 1)).build();
+        final SearchResult searchResult2 = SearchResult.builder().total(PAGE_SIZE)
+            .cases(createCaseDetailsList(PAGE_SIZE, PAGE_SIZE + 1)).build();
         final List<CaseDetails> expectedCases = concat(searchResult1.getCases().stream(), searchResult2.getCases().stream())
             .collect(toSet()).stream().toList();
 
@@ -821,12 +821,13 @@ class CcdSearchServiceTest {
             searchSourceBuilderForAwaitingPronouncementCases(PAGE_SIZE).toString()))
             .thenReturn(searchResult2);
         when(caseDetailsListConverter.convertToListOfValidCaseDetails(expectedCases))
-            .thenReturn(createConvertedCaseDetailsList(TOTAL_MAX_RESULTS, TEST_CASE_ID));
+            .thenReturn(createConvertedCaseDetailsList(PAGE_SIZE * 2, TEST_CASE_ID));
 
         final Deque<List<uk.gov.hmcts.ccd.sdk.api.CaseDetails<CaseData, State>>> allPages =
             ccdSearchService.searchAwaitingPronouncementCasesAllPages(user, SERVICE_AUTHORIZATION);
 
-        assertThat(allPages.size()).isEqualTo(3);
+        assertThat(allPages.size()).isEqualTo(4);
+        assertThat(allPages.poll().size()).isEqualTo(BULK_LIST_MAX_PAGE_SIZE);
         assertThat(allPages.poll().size()).isEqualTo(BULK_LIST_MAX_PAGE_SIZE);
         assertThat(allPages.poll().size()).isEqualTo(BULK_LIST_MAX_PAGE_SIZE);
         assertThat(allPages.poll().size()).isEqualTo(BULK_LIST_MAX_PAGE_SIZE);


### PR DESCRIPTION
This change will

- Limit the total number of cases returned from a CCD search query
- Reduce the page size from 100 to 50

In order to prevent the create bulk action task cron jobs from tripping over each other and assigning cases to multiple bulk action cases.