### PR TITLE
Clean up state condition for event

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemPronounceCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemPronounceCase.java
@@ -24,6 +24,7 @@ import java.util.EnumSet;
 
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingPronouncement;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.ConditionalOrderPronounced;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.OfflineDocumentReceived;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.SeparationOrderGranted;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.JUDGE;
@@ -62,7 +63,7 @@ public class SystemPronounceCase implements CCDConfig<CaseData, State, UserRole>
         new PageBuilder(
             configBuilder
                 .event(SYSTEM_PRONOUNCE_CASE)
-                .forStates(EnumSet.of(AwaitingPronouncement, ConditionalOrderPronounced))
+                .forStates(EnumSet.of(AwaitingPronouncement, OfflineDocumentReceived, ConditionalOrderPronounced))
                 .name("System pronounce case")
                 .description("System pronounce case")
                 .grant(CREATE_READ_UPDATE, SYSTEMUPDATE, SUPER_USER)

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemPronounceCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemPronounceCase.java
@@ -24,7 +24,6 @@ import java.util.EnumSet;
 
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingPronouncement;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.ConditionalOrderPronounced;
-import static uk.gov.hmcts.divorce.divorcecase.model.State.OfflineDocumentReceived;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.SeparationOrderGranted;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.JUDGE;
@@ -63,9 +62,7 @@ public class SystemPronounceCase implements CCDConfig<CaseData, State, UserRole>
         new PageBuilder(
             configBuilder
                 .event(SYSTEM_PRONOUNCE_CASE)
-                .forStateTransition(
-                    EnumSet.of(AwaitingPronouncement, OfflineDocumentReceived, ConditionalOrderPronounced),
-                    EnumSet.of(ConditionalOrderPronounced, SeparationOrderGranted))
+                .forStates(EnumSet.of(AwaitingPronouncement, ConditionalOrderPronounced))
                 .name("System pronounce case")
                 .description("System pronounce case")
                 .grant(CREATE_READ_UPDATE, SYSTEMUPDATE, SUPER_USER)


### PR DESCRIPTION
Clean up as it doesnt make sense to use the forStateTransition call with the end state being a set.

### Change description ###

Enter a description.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3767

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
