### PR TITLE
Add event to remove errored cases from list

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/SuperuserRemoveErroredCases.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/SuperuserRemoveErroredCases.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.divorce.bulkaction.ccd.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionPageBuilder;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkActionCaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState.Created;
+import static uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState.Listed;
+import static uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState.Pronounced;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+
+@Component
+@Slf4j
+public class SuperuserRemoveErroredCases implements CCDConfig<BulkActionCaseData, BulkActionState, UserRole> {
+
+    public static final String SUPERUSER_REMOVE_ERRORED_CASES = "caseworker-remove-errored-cases";
+
+    @Override
+    public void configure(final ConfigBuilder<BulkActionCaseData, BulkActionState, UserRole> configBuilder) {
+        new BulkActionPageBuilder(configBuilder
+            .event(SUPERUSER_REMOVE_ERRORED_CASES)
+            .forStates(Created, Listed, Pronounced)
+            .name("Remove cases from bulk list")
+            .description("Remove cases from bulk list")
+            .showEventNotes()
+            .explicitGrants()
+            .grant(CREATE_READ_UPDATE, CASE_WORKER, SYSTEMUPDATE))
+            .page("removeCasesFromErroredList")
+            .pageLabel("Remove cases from bulk list")
+            .mandatoryNoSummary(BulkActionCaseData::getErroredCaseDetails);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/SuperuserRemoveErroredCases.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/SuperuserRemoveErroredCases.java
@@ -27,8 +27,8 @@ public class SuperuserRemoveErroredCases implements CCDConfig<BulkActionCaseData
         new BulkActionPageBuilder(configBuilder
             .event(SUPERUSER_REMOVE_ERRORED_CASES)
             .forStates(Created, Listed, Pronounced)
-            .name("Remove errored cases from bulk list")
-            .description("Remove errored cases from bulk list")
+            .name("Remove errored cases")
+            .description("Remove errored cases")
             .showEventNotes()
             .explicitGrants()
             .grant(CREATE_READ_UPDATE, CASE_WORKER, SYSTEMUPDATE))

--- a/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/SuperuserRemoveErroredCases.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/SuperuserRemoveErroredCases.java
@@ -20,7 +20,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_R
 @Slf4j
 public class SuperuserRemoveErroredCases implements CCDConfig<BulkActionCaseData, BulkActionState, UserRole> {
 
-    public static final String SUPERUSER_REMOVE_ERRORED_CASES = "caseworker-remove-errored-cases";
+    public static final String SUPERUSER_REMOVE_ERRORED_CASES = "superuser-remove-errored-cases";
 
     @Override
     public void configure(final ConfigBuilder<BulkActionCaseData, BulkActionState, UserRole> configBuilder) {

--- a/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/SuperuserRemoveErroredCases.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/SuperuserRemoveErroredCases.java
@@ -27,8 +27,8 @@ public class SuperuserRemoveErroredCases implements CCDConfig<BulkActionCaseData
         new BulkActionPageBuilder(configBuilder
             .event(SUPERUSER_REMOVE_ERRORED_CASES)
             .forStates(Created, Listed, Pronounced)
-            .name("Remove cases from bulk list")
-            .description("Remove cases from bulk list")
+            .name("Remove errored cases from bulk list")
+            .description("Remove errored cases from bulk list")
             .showEventNotes()
             .explicitGrants()
             .grant(CREATE_READ_UPDATE, CASE_WORKER, SYSTEMUPDATE))

--- a/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/SuperuserRemoveErroredCases.java
+++ b/src/main/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/SuperuserRemoveErroredCases.java
@@ -34,7 +34,7 @@ public class SuperuserRemoveErroredCases implements CCDConfig<BulkActionCaseData
             .grant(CREATE_READ_UPDATE, CASE_WORKER, SYSTEMUPDATE))
             .page("removeCasesFromErroredList")
             .pageLabel("Remove cases from bulk list")
-            .mandatoryNoSummary(BulkActionCaseData::getErroredCaseDetails);
+            .optionalNoSummary(BulkActionCaseData::getErroredCaseDetails);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/SuperuserRemoveErroredCasesTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/bulkaction/ccd/event/SuperuserRemoveErroredCasesTest.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.divorce.bulkaction.ccd.event;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.bulkaction.ccd.BulkActionState;
+import uk.gov.hmcts.divorce.bulkaction.data.BulkActionCaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.divorce.bulkaction.ccd.event.SuperuserRemoveErroredCases.SUPERUSER_REMOVE_ERRORED_CASES;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createBulkActionConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+
+@ExtendWith(MockitoExtension.class)
+class SuperuserRemoveErroredCasesTest {
+
+    @InjectMocks
+    private SuperuserRemoveErroredCases superuserRemoveErroredCases;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() {
+        final ConfigBuilderImpl<BulkActionCaseData, BulkActionState, UserRole> configBuilder = createBulkActionConfigBuilder();
+
+        superuserRemoveErroredCases.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(SUPERUSER_REMOVE_ERRORED_CASES);
+    }
+
+}


### PR DESCRIPTION
### Change description ###

There are numerous bulk cases that have cases in the errored list that have been completed. This means the bulk case crons have been continually retrying to progress the cases for months.

This event will allow super users to manually remove cases from the errored list when cases have been progressed manually.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3767

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
