### PR TITLE
Quick fix for confidentiality

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/AosOverduePrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/AosOverduePrinter.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.springframework.util.CollectionUtils.firstElement;
-import static uk.gov.hmcts.divorce.document.DocumentUtil.lettersWithDocumentType;
+import static uk.gov.hmcts.divorce.document.DocumentUtil.getLettersBasedOnContactPrivacy;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.AOS_OVERDUE_LETTER;
 
 @Component
@@ -28,8 +28,7 @@ public class AosOverduePrinter {
 
     public void sendLetterToApplicant(final CaseData caseData, final Applicant recipient, final Long caseId) {
 
-        final List<Letter> letters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(), AOS_OVERDUE_LETTER);
+        final List<Letter> letters = getLettersBasedOnContactPrivacy(caseData, AOS_OVERDUE_LETTER);
 
         Letter aosOverdueLetter = firstElement(letters);
 

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/AosPackPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/AosPackPrinter.java
@@ -16,7 +16,6 @@ import java.util.UUID;
 import static org.springframework.util.CollectionUtils.firstElement;
 import static org.springframework.util.CollectionUtils.isEmpty;
 import static uk.gov.hmcts.divorce.document.DocumentUtil.getLettersBasedOnContactPrivacy;
-import static uk.gov.hmcts.divorce.document.DocumentUtil.lettersWithDocumentType;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.AOS_RESPONSE_LETTER;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.APPLICATION;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.COVERSHEET;
@@ -124,15 +123,11 @@ public class AosPackPrinter {
 
         final List<Letter> aosResponseLetters = getLettersBasedOnContactPrivacy(caseData, AOS_RESPONSE_LETTER);
 
-        List<Letter> aosLetters;
+        var aosLetters = getLettersBasedOnContactPrivacy(caseData, RESPONDENT_ANSWERS);
         List<Letter> d84FormLetters = null;
+
         if (caseData.getApplicant2().isApplicantOffline()) {
-            // When respondent is offline respondent answers doc is reclassified and added to docs uploaded list
-            aosLetters = lettersWithDocumentType(caseData.getDocuments().getDocumentsUploaded(), RESPONDENT_ANSWERS);
-            d84FormLetters = lettersWithDocumentType(caseData.getDocuments().getDocumentsGenerated(), D84);
-        } else {
-            // When respondent is online respondent answers doc is generated and added to docs generated list
-            aosLetters = lettersWithDocumentType(caseData.getDocuments().getDocumentsGenerated(), RESPONDENT_ANSWERS);
+            d84FormLetters = getLettersBasedOnContactPrivacy(caseData, D84);
         }
 
         final Letter aosResponseLetter = firstElement(aosResponseLetters);
@@ -143,7 +138,7 @@ public class AosPackPrinter {
 
         final List<Letter> aosResponseLetterWithAos = new ArrayList<>();
 
-        final Letter coversheetLetter = firstElement(lettersWithDocumentType(caseData.getDocuments().getDocumentsGenerated(), COVERSHEET));
+        final Letter coversheetLetter = firstElement(getLettersBasedOnContactPrivacy(caseData, COVERSHEET));
 
         if (null != coversheetLetter && caseData.isJudicialSeparationCase()) {
             aosResponseLetterWithAos.add(coversheetLetter);
@@ -184,9 +179,7 @@ public class AosPackPrinter {
     }
 
     private List<Letter> aosLetters(CaseData caseData) {
-        final List<Letter> divorceApplicationLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            APPLICATION);
+        final List<Letter> divorceApplicationLetters = getLettersBasedOnContactPrivacy(caseData, APPLICATION);
 
         //Always get document on top of list as new document is added to top after generation
         final Letter divorceApplicationLetter = firstElement(divorceApplicationLetters);
@@ -206,9 +199,9 @@ public class AosPackPrinter {
     }
 
     private List<Letter> aosLettersForRespondent(CaseData caseData) {
-        final Letter coversheetLetter = firstElement(lettersWithDocumentType(caseData.getDocuments().getDocumentsGenerated(), COVERSHEET));
+        final Letter coversheetLetter = firstElement(getLettersBasedOnContactPrivacy(caseData, COVERSHEET));
         final Letter respondentInvitationLetter = firstElement(getLettersBasedOnContactPrivacy(caseData, NOTICE_OF_PROCEEDINGS_APP_2));
-        final Letter divorceApplicationLetter = firstElement(lettersWithDocumentType(caseData.getDocuments().getDocumentsGenerated(),
+        final Letter divorceApplicationLetter = firstElement(getLettersBasedOnContactPrivacy(caseData,
             APPLICATION));
 
         final List<Letter> currentAosLetters = new ArrayList<>();
@@ -226,17 +219,9 @@ public class AosPackPrinter {
     }
 
     private List<Letter> personalServiceLetters(final CaseData caseData) {
-        final List<Letter> coversheetLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            COVERSHEET);
-
-        final List<Letter> respondentInvitationLetters = getLettersBasedOnContactPrivacy(
-            caseData,
-            NOTICE_OF_PROCEEDINGS_APP_2);
-
-        final List<Letter> divorceApplicationLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            APPLICATION);
+        final List<Letter> coversheetLetters = getLettersBasedOnContactPrivacy(caseData, COVERSHEET);
+        final List<Letter> respondentInvitationLetters = getLettersBasedOnContactPrivacy(caseData, NOTICE_OF_PROCEEDINGS_APP_2);
+        final List<Letter> divorceApplicationLetters = getLettersBasedOnContactPrivacy(caseData, APPLICATION);
 
         final Letter coversheetLetter = firstElement(coversheetLetters);
         final Letter respondentInvitationLetter = firstElement(respondentInvitationLetters);

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/AppliedForCoPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/AppliedForCoPrinter.java
@@ -24,7 +24,7 @@ import static org.springframework.util.CollectionUtils.firstElement;
 import static uk.gov.hmcts.divorce.caseworker.service.task.util.FileNameUtil.formatDocumentName;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.APPLIED_FOR_CONDITIONAL_ORDER_LETTER_DOCUMENT_NAME;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.APPLIED_FOR_CONDITIONAL_ORDER_LETTER_TEMPLATE_ID;
-import static uk.gov.hmcts.divorce.document.DocumentUtil.lettersWithDocumentType;
+import static uk.gov.hmcts.divorce.document.DocumentUtil.getLettersBasedOnContactPrivacy;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.CASE_REFERENCE;
 import static uk.gov.hmcts.divorce.document.content.DocmosisTemplateConstants.DATE;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.APPLIED_FOR_CO_LETTER;
@@ -56,9 +56,7 @@ public class AppliedForCoPrinter {
 
         generateAppliedForCoLetter(caseData, caseId, applicant);
 
-        final List<Letter> appliedForCoLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            APPLIED_FOR_CO_LETTER);
+        final List<Letter> appliedForCoLetters = getLettersBasedOnContactPrivacy(caseData, APPLIED_FOR_CO_LETTER);
 
         final Letter appliedForCoLetter = firstElement(appliedForCoLetters);
 

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/FinalOrderGrantedPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/FinalOrderGrantedPrinter.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.springframework.util.CollectionUtils.firstElement;
 import static uk.gov.hmcts.divorce.document.DocumentUtil.getLettersBasedOnContactPrivacy;
-import static uk.gov.hmcts.divorce.document.DocumentUtil.lettersWithDocumentType;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.FINAL_ORDER_GRANTED;
 
 @Component
@@ -63,9 +62,7 @@ public class FinalOrderGrantedPrinter {
     private List<Letter> finalOrderGrantedLetters(CaseData caseData, final DocumentType coverLetterDocumentType) {
         final List<Letter> finalOrderGrantedCoverLetters = getLettersBasedOnContactPrivacy(caseData, coverLetterDocumentType);
 
-        final List<Letter> finalOrderGrantedCertificates = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            FINAL_ORDER_GRANTED);
+        final List<Letter> finalOrderGrantedCertificates = getLettersBasedOnContactPrivacy(caseData, FINAL_ORDER_GRANTED);
 
         final Letter finalOrderGrantedCoverLetter = firstElement(finalOrderGrantedCoverLetters);
         final Letter finalOrderGrantedCertificate = firstElement(finalOrderGrantedCertificates);

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/RegenerateCourtOrdersPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/RegenerateCourtOrdersPrinter.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.springframework.util.CollectionUtils.firstElement;
-import static uk.gov.hmcts.divorce.document.DocumentUtil.lettersWithDocumentType;
+import static uk.gov.hmcts.divorce.document.DocumentUtil.getLettersBasedOnContactPrivacy;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CERTIFICATE_OF_ENTITLEMENT;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CERTIFICATE_OF_ENTITLEMENT_COVER_LETTER_APP1;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CERTIFICATE_OF_ENTITLEMENT_COVER_LETTER_APP2;
@@ -82,28 +82,28 @@ public class RegenerateCourtOrdersPrinter {
 
     private List<Letter> regeneratedCourtOrderLetters(CaseData caseData, boolean isApplicant1) {
 
-        final List<Letter> conditionalOrderGrantedCoverLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
+        final List<Letter> conditionalOrderGrantedCoverLetters = getLettersBasedOnContactPrivacy(
+            caseData,
             isApplicant1 ? CONDITIONAL_ORDER_GRANTED_COVERSHEET_APP_1 : CONDITIONAL_ORDER_GRANTED_COVERSHEET_APP_2);
 
-        final List<Letter> conditionalOrderGrantedCertificates = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
+        final List<Letter> conditionalOrderGrantedCertificates = getLettersBasedOnContactPrivacy(
+            caseData,
             CONDITIONAL_ORDER_GRANTED);
 
-        final List<Letter> finalOrderGrantedCoverLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
+        final List<Letter> finalOrderGrantedCoverLetters = getLettersBasedOnContactPrivacy(
+            caseData,
             isApplicant1 ? FINAL_ORDER_GRANTED_COVER_LETTER_APP_1 : FINAL_ORDER_GRANTED_COVER_LETTER_APP_2);
 
-        final List<Letter> finalOrderGrantedCertificates = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
+        final List<Letter> finalOrderGrantedCertificates = getLettersBasedOnContactPrivacy(
+            caseData,
             FINAL_ORDER_GRANTED);
 
-        final List<Letter> certificateOfEntitlementCoverLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
+        final List<Letter> certificateOfEntitlementCoverLetters = getLettersBasedOnContactPrivacy(
+            caseData,
             isApplicant1 ? CERTIFICATE_OF_ENTITLEMENT_COVER_LETTER_APP1 : CERTIFICATE_OF_ENTITLEMENT_COVER_LETTER_APP2);
 
-        final List<Letter> certificateOfEntitlementDocuments = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
+        final List<Letter> certificateOfEntitlementDocuments = getLettersBasedOnContactPrivacy(
+            caseData,
             CERTIFICATE_OF_ENTITLEMENT);
 
         final Letter conditionalOrderGrantedCoverLetter = firstElement(conditionalOrderGrantedCoverLetters);

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/SwitchToSoleCoPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/service/print/SwitchToSoleCoPrinter.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.springframework.util.CollectionUtils.firstElement;
-import static uk.gov.hmcts.divorce.document.DocumentUtil.lettersWithDocumentType;
+import static uk.gov.hmcts.divorce.document.DocumentUtil.getLettersBasedOnContactPrivacy;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.SWITCH_TO_SOLE_CO_LETTER;
 
 @Component
@@ -29,9 +29,7 @@ public class SwitchToSoleCoPrinter {
 
     public void print(final CaseData caseData, final Long caseId, final Applicant respondent) {
 
-        final List<Letter> switchToSoleCoLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            SWITCH_TO_SOLE_CO_LETTER);
+        final List<Letter> switchToSoleCoLetters = getLettersBasedOnContactPrivacy(caseData, SWITCH_TO_SOLE_CO_LETTER);
 
         final Letter switchToSoleCoLetter = firstElement(switchToSoleCoLetters);
 

--- a/src/main/java/uk/gov/hmcts/divorce/document/DocumentUtil.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/DocumentUtil.java
@@ -101,11 +101,13 @@ public final class DocumentUtil {
             return lettersWithConfidentialDocumentType(caseData.getDocuments().getConfidentialDocumentsGenerated(),
                 getConfidentialDocumentType(documentType));
         } else {
-            return lettersWithDocumentType(caseData.getDocuments().getDocumentsGenerated(), documentType);
+            var letters = lettersWithDocumentType(caseData.getDocuments().getDocumentsGenerated(), documentType);
+
+            return letters.isEmpty() ? lettersWithDocumentType(caseData.getDocuments().getDocumentsUploaded(), documentType) : letters;
         }
     }
 
-    public static List<Letter> lettersWithDocumentType(final List<ListValue<DivorceDocument>> documents,
+    private static List<Letter> lettersWithDocumentType(final List<ListValue<DivorceDocument>> documents,
                                                        final DocumentType documentType) {
 
         final AtomicInteger letterIndex = new AtomicInteger();

--- a/src/main/java/uk/gov/hmcts/divorce/document/print/BulkPrintService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/print/BulkPrintService.java
@@ -121,19 +121,19 @@ public class BulkPrintService {
         log.info("Bulk print request sent with letterId: " + sendLetterUUID);
 
         for (var letter : print.getLetters()) {
-            log.info("Sent document id {} for case ref {} in letter {}", print.getCaseRef(), getDocumentUrl(letter), sendLetterUUID);
+            log.info("Sent document {} for case {} in letter {}", getDocument(letter).getFilename(), print.getCaseRef(), sendLetterUUID);
         }
 
         return sendLetterUUID;
     }
 
-    private String getDocumentUrl(final Letter letter) {
+    private uk.gov.hmcts.ccd.sdk.type.Document getDocument(final Letter letter) {
         if (letter.getDivorceDocument() != null) {
-            return letter.getDivorceDocument().getDocumentLink().getUrl();
+            return letter.getDivorceDocument().getDocumentLink();
         } else if (letter.getConfidentialDivorceDocument() != null) {
-            return letter.getConfidentialDivorceDocument().getDocumentLink().getUrl();
+            return letter.getConfidentialDivorceDocument().getDocumentLink();
         } else if (letter.getDocument() != null) {
-            return letter.getDocument().getUrl();
+            return letter.getDocument();
         } else {
             throw new InvalidResourceException("Invalid document resource");
         }
@@ -144,7 +144,7 @@ public class BulkPrintService {
                                     final String userAuth,
                                     final String userRoles,
                                     final String userId) {
-        String docUrl = getDocumentUrl(letter);
+        String docUrl = getDocument(letter).getUrl();
 
         final String fileName = FilenameUtils.getName(docUrl);
         ResponseEntity<Resource> resourceResponseEntity = documentManagementClient.downloadBinary(

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/print/ApplyForConditionalOrderPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/print/ApplyForConditionalOrderPrinter.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 import static org.springframework.util.CollectionUtils.firstElement;
 import static org.springframework.util.CollectionUtils.isEmpty;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.COVERSHEET_APPLICANT;
-import static uk.gov.hmcts.divorce.document.DocumentUtil.lettersWithDocumentType;
+import static uk.gov.hmcts.divorce.document.DocumentUtil.getLettersBasedOnContactPrivacy;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CONDITIONAL_ORDER_CAN_APPLY;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.COVERSHEET;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.D84;
@@ -75,18 +75,11 @@ public class ApplyForConditionalOrderPrinter {
 
     private List<Letter> conditionalOrderLetters(final CaseData caseData) {
 
-        final List<Letter> coversheetLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            COVERSHEET);
+        final List<Letter> coversheetLetters = getLettersBasedOnContactPrivacy(caseData, COVERSHEET);
 
-        final List<Letter> canApplyConditionalOrderLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            CONDITIONAL_ORDER_CAN_APPLY);
+        final List<Letter> canApplyConditionalOrderLetters = getLettersBasedOnContactPrivacy(caseData, CONDITIONAL_ORDER_CAN_APPLY);
 
-        final List<Letter> d84Letters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            D84
-        );
+        final List<Letter> d84Letters = getLettersBasedOnContactPrivacy(caseData, D84);
 
         final Letter coversheetLetter = firstElement(coversheetLetters);
         final Letter canApplyConditionalOrderLetter = firstElement(canApplyConditionalOrderLetters);

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/print/ApplyForFinalOrderPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/print/ApplyForFinalOrderPrinter.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 import static org.springframework.util.CollectionUtils.firstElement;
 import static org.springframework.util.CollectionUtils.isEmpty;
 import static uk.gov.hmcts.divorce.document.DocumentConstants.COVERSHEET_APPLICANT;
-import static uk.gov.hmcts.divorce.document.DocumentUtil.lettersWithDocumentType;
+import static uk.gov.hmcts.divorce.document.DocumentUtil.getLettersBasedOnContactPrivacy;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.COVERSHEET;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.D36;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.FINAL_ORDER_CAN_APPLY_APP1;
@@ -90,25 +90,16 @@ public class ApplyForFinalOrderPrinter {
 
     private List<Letter> finalOrderLetters(final CaseData caseData, boolean isApplicant1) {
 
-        final List<Letter> coversheetLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            COVERSHEET);
+        final List<Letter> coversheetLetters = getLettersBasedOnContactPrivacy(caseData, COVERSHEET);
 
         final List<Letter> canApplyFinalOrderLetters;
         if (isApplicant1) {
-            canApplyFinalOrderLetters = lettersWithDocumentType(
-                caseData.getDocuments().getDocumentsGenerated(),
-                FINAL_ORDER_CAN_APPLY_APP1);
+            canApplyFinalOrderLetters = getLettersBasedOnContactPrivacy(caseData, FINAL_ORDER_CAN_APPLY_APP1);
         } else {
-            canApplyFinalOrderLetters = lettersWithDocumentType(
-                caseData.getDocuments().getDocumentsGenerated(),
-                FINAL_ORDER_CAN_APPLY_APP2);
+            canApplyFinalOrderLetters = getLettersBasedOnContactPrivacy(caseData, FINAL_ORDER_CAN_APPLY_APP2);
         }
 
-        final List<Letter> d36Letters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            D36
-        );
+        final List<Letter> d36Letters = getLettersBasedOnContactPrivacy(caseData, D36);
 
         final Letter coversheetLetter = firstElement(coversheetLetters);
         final Letter canApplyFinalOrderLetter = firstElement(canApplyFinalOrderLetters);

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/print/ConditionalOrderPronouncedPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/print/ConditionalOrderPronouncedPrinter.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 import static org.springframework.util.CollectionUtils.firstElement;
 import static org.springframework.util.CollectionUtils.isEmpty;
 import static uk.gov.hmcts.divorce.document.DocumentUtil.getLettersBasedOnContactPrivacy;
-import static uk.gov.hmcts.divorce.document.DocumentUtil.lettersWithDocumentType;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CONDITIONAL_ORDER_GRANTED;
 
 @Component
@@ -62,9 +61,7 @@ public class ConditionalOrderPronouncedPrinter {
     private List<Letter> conditionalOrderPronouncedLetters(CaseData caseData, DocumentType coversheetDocumentType) {
         final List<Letter> coversheetLetters = getLettersBasedOnContactPrivacy(caseData, coversheetDocumentType);
 
-        final List<Letter> conditionalOrderGrantedLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            CONDITIONAL_ORDER_GRANTED);
+        final List<Letter> conditionalOrderGrantedLetters = getLettersBasedOnContactPrivacy(caseData, CONDITIONAL_ORDER_GRANTED);
 
         final Letter coversheetLetter = firstElement(coversheetLetters);
         final Letter conditionalOrderGrantedLetter = firstElement(conditionalOrderGrantedLetters);

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/print/ConditionalOrderReminderPrinter.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/print/ConditionalOrderReminderPrinter.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 
 import static org.springframework.util.CollectionUtils.firstElement;
 import static org.springframework.util.CollectionUtils.isEmpty;
-import static uk.gov.hmcts.divorce.document.DocumentUtil.lettersWithDocumentType;
+import static uk.gov.hmcts.divorce.document.DocumentUtil.getLettersBasedOnContactPrivacy;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CONDITIONAL_ORDER_REMINDER;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.COVERSHEET;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.D84;
@@ -52,18 +52,9 @@ public class ConditionalOrderReminderPrinter {
 
     private List<Letter> conditionalOrderLetters(CaseData caseData) {
 
-        final List<Letter> coversheetLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            COVERSHEET);
-
-        final List<Letter> conditionalOrderReminderLetters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            CONDITIONAL_ORDER_REMINDER);
-
-        final List<Letter> d84Letters = lettersWithDocumentType(
-            caseData.getDocuments().getDocumentsGenerated(),
-            D84
-        );
+        final List<Letter> coversheetLetters = getLettersBasedOnContactPrivacy(caseData, COVERSHEET);
+        final List<Letter> conditionalOrderReminderLetters = getLettersBasedOnContactPrivacy(caseData, CONDITIONAL_ORDER_REMINDER);
+        final List<Letter> d84Letters = getLettersBasedOnContactPrivacy(caseData, D84);
 
         final Letter coversheetLetter = firstElement(coversheetLetters);
         final Letter conditionalOrderReminderLetter = firstElement(conditionalOrderReminderLetters);

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/service/print/AosPackPrinterTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/service/print/AosPackPrinterTest.java
@@ -278,9 +278,9 @@ class AosPackPrinterTest {
                 .build())
             .build();
 
-        final ListValue<DivorceDocument> coversheet = ListValue.<DivorceDocument>builder()
-            .value(DivorceDocument.builder()
-                .documentType(COVERSHEET)
+        final ListValue<ConfidentialDivorceDocument> coversheet = ListValue.<ConfidentialDivorceDocument>builder()
+            .value(ConfidentialDivorceDocument.builder()
+                .confidentialDocumentsReceived(ConfidentialDocumentsReceived.COVERSHEET)
                 .build())
             .build();
 
@@ -295,8 +295,8 @@ class AosPackPrinterTest {
                 .contactDetailsType(ContactDetailsType.PRIVATE)
                 .build())
             .documents(CaseDocuments.builder()
-                .documentsGenerated(asList(application, coversheet, nopAppTwo))
-                .confidentialDocumentsGenerated(List.of(nopAppOne))
+                .documentsGenerated(asList(application, nopAppTwo))
+                .confidentialDocumentsGenerated(List.of(nopAppOne, coversheet))
                 .build())
             .build();
 
@@ -308,12 +308,12 @@ class AosPackPrinterTest {
         assertThat(print.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
         assertThat(print.getCaseRef()).isEqualTo(TEST_CASE_ID.toString());
         assertThat(print.getLetterType()).isEqualTo("applicant-aos-pack");
-        assertThat(print.getLetters().size()).isEqualTo(5);
         assertThat(print.getLetters().get(0).getConfidentialDivorceDocument()).isSameAs(nopAppOne.getValue());
         assertThat(print.getLetters().get(1).getDivorceDocument()).isSameAs(application.getValue());
-        assertThat(print.getLetters().get(2).getDivorceDocument()).isSameAs(coversheet.getValue());
+        assertThat(print.getLetters().get(2).getConfidentialDivorceDocument()).isSameAs(coversheet.getValue());
         assertThat(print.getLetters().get(3).getDivorceDocument()).isSameAs(nopAppTwo.getValue());
         assertThat(print.getLetters().get(4).getDivorceDocument()).isSameAs(application.getValue());
+        assertThat(print.getLetters().size()).isEqualTo(5);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/document/DocumentUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/document/DocumentUtilTest.java
@@ -38,7 +38,6 @@ import static uk.gov.hmcts.divorce.document.DocumentUtil.documentsWithDocumentTy
 import static uk.gov.hmcts.divorce.document.DocumentUtil.getLettersBasedOnContactPrivacy;
 import static uk.gov.hmcts.divorce.document.DocumentUtil.isConfidential;
 import static uk.gov.hmcts.divorce.document.DocumentUtil.isDocumentApplicableForConfidentiality;
-import static uk.gov.hmcts.divorce.document.DocumentUtil.lettersWithDocumentType;
 import static uk.gov.hmcts.divorce.document.DocumentUtil.mapToLetters;
 import static uk.gov.hmcts.divorce.document.DocumentUtil.removeDocumentsBasedOnContactPrivacy;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.APPLICATION;
@@ -46,8 +45,6 @@ import static uk.gov.hmcts.divorce.document.model.DocumentType.D10;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.FINAL_ORDER_GRANTED_COVER_LETTER_APP_1;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.FINAL_ORDER_GRANTED_COVER_LETTER_APP_2;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.GENERAL_LETTER;
-import static uk.gov.hmcts.divorce.document.model.DocumentType.MARRIAGE_CERTIFICATE;
-import static uk.gov.hmcts.divorce.document.model.DocumentType.NAME_CHANGE_EVIDENCE;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.NOTICE_OF_PROCEEDINGS_APP_1;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.NOTICE_OF_PROCEEDINGS_APP_2;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.OTHER;
@@ -90,92 +87,6 @@ class DocumentUtilTest {
                 DOC_URL,
                 PDF_FILENAME,
                 DOC_BINARY_URL);
-    }
-
-    @Test
-    void shouldReturnListOfLetterOfGivenDocumentTypeIfPresent() {
-
-        final ListValue<DivorceDocument> doc1 = ListValue.<DivorceDocument>builder()
-            .value(DivorceDocument.builder()
-                .documentType(APPLICATION)
-                .build())
-            .build();
-
-        final ListValue<DivorceDocument> doc2 = ListValue.<DivorceDocument>builder()
-            .value(DivorceDocument.builder()
-                .documentType(MARRIAGE_CERTIFICATE)
-                .build())
-            .build();
-
-        final List<Letter> letters = lettersWithDocumentType(
-            asList(doc1, doc2),
-            MARRIAGE_CERTIFICATE);
-
-        assertThat(letters.size()).isEqualTo(1);
-        assertThat(letters.get(0).getDivorceDocument()).isSameAs(doc2.getValue());
-    }
-
-    @Test
-    void shouldNotFindDocumentOfGivenDocumentTypeIfNotPresent() {
-
-        final ListValue<DivorceDocument> doc1 = ListValue.<DivorceDocument>builder()
-            .value(DivorceDocument.builder()
-                .documentType(APPLICATION)
-                .build())
-            .build();
-
-        final ListValue<DivorceDocument> doc2 = ListValue.<DivorceDocument>builder()
-            .value(DivorceDocument.builder()
-                .documentType(MARRIAGE_CERTIFICATE)
-                .build())
-            .build();
-
-        final List<Letter> letters = lettersWithDocumentType(
-            asList(doc1, doc2),
-            NAME_CHANGE_EVIDENCE);
-
-        assertThat(letters.size()).isZero();
-    }
-
-    @Test
-    void shouldReturnEmptyListIfNullDocumentList() {
-        final List<Letter> letters = lettersWithDocumentType(null, NAME_CHANGE_EVIDENCE);
-        assertThat(letters.size()).isZero();
-    }
-
-    @Test
-    void shouldReturnEmptyListIfEmptyDocumentList() {
-        final List<Letter> letters = lettersWithDocumentType(emptyList(), NAME_CHANGE_EVIDENCE);
-        assertThat(letters.size()).isZero();
-    }
-
-    @Test
-    void shouldReturnListOfLettersOfGivenDocumentTypesIfPresent() {
-
-        final ListValue<DivorceDocument> doc1 = ListValue.<DivorceDocument>builder()
-            .value(DivorceDocument.builder()
-                .documentType(APPLICATION)
-                .build())
-            .build();
-
-        final ListValue<DivorceDocument> doc2 = ListValue.<DivorceDocument>builder()
-            .value(DivorceDocument.builder()
-                .documentType(MARRIAGE_CERTIFICATE)
-                .build())
-            .build();
-
-        final ListValue<DivorceDocument> doc3 = ListValue.<DivorceDocument>builder()
-            .value(DivorceDocument.builder()
-                .documentType(NAME_CHANGE_EVIDENCE)
-                .build())
-            .build();
-
-        final List<Letter> letters = lettersWithDocumentType(
-            asList(doc1, doc2, doc3),
-            NAME_CHANGE_EVIDENCE);
-
-        assertThat(letters.size()).isEqualTo(1);
-        assertThat(letters.get(0).getDivorceDocument()).isSameAs(doc3.getValue());
     }
 
     @Test


### PR DESCRIPTION
Move all uses of `lettersWithDocumentType` over to `getLettersBasedOnContactPrivacy` to ensure the correct coversheets are selected. 