### PR TITLE
Fix enum jsonProperty which was duplicated

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/document/model/ConfidentialDocumentsReceived.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/model/ConfidentialDocumentsReceived.java
@@ -152,12 +152,12 @@ public enum ConfidentialDocumentsReceived implements HasLabel {
     @JsonProperty("aosOverdueLetter")
     AOS_OVERDUE_LETTER("Aos overdue letter"),
 
-    @JsonProperty("judicialSeparationOrderRefusalCoverLetter")
+    @JsonProperty("judicialSeparationOrderClarificationRefusalCoverLetter")
     JUDICIAL_SEPARATION_ORDER_CLARIFICATION_REFUSAL_COVER_LETTER(
         "Judicial Separation order clarification refusal cover letter"
     ),
 
-    @JsonProperty("separationOrderRefusalCoverLetter")
+    @JsonProperty("separationOrderClarificationRefusalCoverLetter")
     SEPARATION_ORDER_CLARIFICATION_REFUSAL_COVER_LETTER(
         "Separation order clarification refusal cover letter"
     ),

--- a/src/main/java/uk/gov/hmcts/divorce/document/model/DocumentType.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/model/DocumentType.java
@@ -81,7 +81,7 @@ public enum DocumentType implements HasLabel {
         "Judicial Separation order refusal solicitor cover letter"
     ),
 
-    @JsonProperty("judicialSeparationOrderRefusalCoverLetter")
+    @JsonProperty("judicialSeparationOrderClarificationRefusalCoverLetter")
     JUDICIAL_SEPARATION_ORDER_CLARIFICATION_REFUSAL_COVER_LETTER(
         "Judicial Separation order clarification refusal cover letter"
     ),
@@ -99,7 +99,7 @@ public enum DocumentType implements HasLabel {
         "Separation order refusal solicitor cover letter"
     ),
 
-    @JsonProperty("separationOrderRefusalCoverLetter")
+    @JsonProperty("separationOrderClarificationRefusalCoverLetter")
     SEPARATION_ORDER_CLARIFICATION_REFUSAL_COVER_LETTER(
         "Separation order clarification refusal cover letter"
     ),


### PR DESCRIPTION
### Change description ###

We found that 2 enums shared the same JsonProperties. I've looked at the 2 cases which have used this cover letter, both have:

"Judicial Separation order refusal cover letter".

I believe we can safely edit the clarification jsonProperty as it appears to be unused.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-TBC