### PR TITLE
Ignore 404 returned from CDAM as document already deleted

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/document/CaseDocumentAccessManagement.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/CaseDocumentAccessManagement.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.divorce.document;
 
+import feign.FeignException;
 import lombok.AllArgsConstructor;
 import org.apache.commons.io.IOUtils;
 import org.springframework.core.io.Resource;
@@ -49,7 +50,14 @@ public class CaseDocumentAccessManagement {
     }
 
     public void deleteDocument(String userToken, String serviceToken, Document document, boolean hard) {
-        client.deleteDocument(userToken, serviceToken, getUuid(document), hard);
+        try {
+            client.deleteDocument(userToken, serviceToken, getUuid(document), hard);
+        } catch (FeignException e) {
+            // Ignore 404 as document is already deleted if returned.
+            if (e.status() != 404) {
+                throw e;
+            }
+        }
     }
 
     public ResponseEntity<Resource> downloadBinary(String userAuth, String serviceAuth, Document document) {

--- a/src/test/java/uk/gov/hmcts/divorce/document/CaseDocumentAccessManagementTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/document/CaseDocumentAccessManagementTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.divorce.document;
 
+import feign.FeignException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -11,8 +12,11 @@ import uk.gov.hmcts.reform.ccd.document.am.model.UploadResponse;
 import java.io.IOException;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,6 +24,7 @@ import static uk.gov.hmcts.divorce.divorcecase.NoFaultDivorce.JURISDICTION;
 import static uk.gov.hmcts.divorce.divorcecase.NoFaultDivorce.getCaseType;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.APPLICATION;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.documentWithType;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.feignException;
 
 @ExtendWith(MockitoExtension.class)
 class CaseDocumentAccessManagementTest {
@@ -58,5 +63,36 @@ class CaseDocumentAccessManagementTest {
 
         cdam.downloadBinary("dummy", "dummy", doc.getValue().getDocumentLink());
         verify(client).getDocumentBinary("dummy", "dummy", uuid);
+    }
+
+    @Test
+    void Ignore404ErrorFromCdam() {
+
+        var doc = documentWithType(APPLICATION);
+        var url = doc.getValue().getDocumentLink().getUrl();
+        var uuid = UUID.fromString(url.substring(url.lastIndexOf('/') + 1));
+
+        doThrow(feignException(404, "NOT FOUND"))
+            .when(client).deleteDocument("dummy", "dummy", uuid, true);
+
+        cdam.deleteDocument("dummy", "dummy", doc.getValue().getDocumentLink(), true);
+        verify(client).deleteDocument("dummy", "dummy", uuid, true);
+    }
+
+    @Test
+    void RethrowExceptionIfNot404WhenCallingToDeleteDocumentFromCdam() {
+
+        var doc = documentWithType(APPLICATION);
+        var url = doc.getValue().getDocumentLink().getUrl();
+        var uuid = UUID.fromString(url.substring(url.lastIndexOf('/') + 1));
+
+        doThrow(feignException(401, "some error"))
+            .when(client).deleteDocument("dummy", "dummy", uuid, true);
+
+        final FeignException exception = assertThrows(
+            FeignException.class,
+            () -> cdam.deleteDocument("dummy", "dummy", doc.getValue().getDocumentLink(), true));
+
+        assertThat(exception.getMessage()).contains("some error");
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/document/CaseDocumentAccessManagementTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/document/CaseDocumentAccessManagementTest.java
@@ -66,7 +66,7 @@ class CaseDocumentAccessManagementTest {
     }
 
     @Test
-    void Ignore404ErrorFromCdam() {
+    void ignore404ErrorFromCdam() {
 
         var doc = documentWithType(APPLICATION);
         var url = doc.getValue().getDocumentLink().getUrl();
@@ -80,7 +80,7 @@ class CaseDocumentAccessManagementTest {
     }
 
     @Test
-    void RethrowExceptionIfNot404WhenCallingToDeleteDocumentFromCdam() {
+    void rethrowExceptionIfNot404WhenCallingToDeleteDocumentFromCdam() {
 
         var doc = documentWithType(APPLICATION);
         var url = doc.getValue().getDocumentLink().getUrl();


### PR DESCRIPTION
### Change description ###

CDAM returning 404 but this can be ignored as document has already been deleted.

