### PR TITLE
Option 2: Fix/unset fo sot when overdue 

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyFinalOrderOverdue.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyFinalOrderOverdue.java
@@ -41,6 +41,8 @@ public class SystemNotifyFinalOrderOverdue implements CCDConfig<CaseData, State,
                                                                        CaseDetails<CaseData, State> beforeDetails) {
         CaseData data = details.getData();
         data.getFinalOrder().setIsFinalOrderOverdue(YesOrNo.YES);
+        data.getFinalOrder().setApplicant1FinalOrderStatementOfTruth(null);
+        data.getFinalOrder().setApplicant2FinalOrderStatementOfTruth(null);
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()
             .data(data)
             .build();

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyFinalOrderOverdueTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyFinalOrderOverdueTest.java
@@ -47,5 +47,7 @@ class SystemNotifyFinalOrderOverdueTest {
             systemNotifyFinalOrderOverdue.aboutToSubmit(details, details);
 
         assertThat(response.getData().getFinalOrder().getIsFinalOrderOverdue()).isEqualTo(YES);
+        assertThat(response.getData().getFinalOrder().getApplicant1FinalOrderStatementOfTruth()).isEqualTo(null);
+        assertThat(response.getData().getFinalOrder().getApplicant2FinalOrderStatementOfTruth()).isEqualTo(null);
     }
 }


### PR DESCRIPTION
### Change description ###
Nightly test fail because the the fo sot of field is set to true before the case goes overdue. This makes sure the fields are set to null when overdue.

Option 1: https://github.com/hmcts/nfdiv-frontend/pull/3368

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
