### PR TITLE
Fix:  Error creating bean with name 'uk.gov.hmcts.divorce.payment.Pay…

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/payment/PaymentClient.java
+++ b/src/main/java/uk/gov/hmcts/divorce/payment/PaymentClient.java
@@ -20,5 +20,5 @@ public interface PaymentClient {
     Payment getPaymentByReference(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
-        @PathVariable String paymentReference);
+        @PathVariable("paymentReference") String paymentReference);
 }


### PR DESCRIPTION
### Change description ###

Fix:  Error creating bean with name 'uk.gov.hmcts.divorce.payment.PaymentClient': FactoryBean threw exception on object creation / PathVariable annotation was empty on param 2.

### JIRA link (if applicable) ###
N/A

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
