### PR TITLE
NFDIV-3839: Do not set dueDate if AOS already submitted

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerConfirmServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerConfirmServiceIT.java
@@ -314,7 +314,7 @@ public class CaseworkerConfirmServiceIT {
     }
 
     @Test
-    void shouldSetDueDateTo141DaysFromTodayAndDoNotChangeStateWhenSoleApplicationAndAoSSubmitted() throws Exception {
+    void shouldNotChangeDueDateOrStateWhenSoleApplicationAndAoSSubmitted() throws Exception {
 
         when(serviceTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
 
@@ -356,7 +356,7 @@ public class CaseworkerConfirmServiceIT {
             .andExpect(
                 status().isOk()
             )
-            .andExpect(jsonPath("$.data.dueDate").value(caseData.getApplication().getIssueDate().plusDays(141).toString()))
+            .andExpect(jsonPath("$.data.dueDate").doesNotExist())
             .andExpect(jsonPath("$.state").value("Holding"));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorConfirmServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/solicitor/SolicitorConfirmServiceIT.java
@@ -222,7 +222,7 @@ public class SolicitorConfirmServiceIT {
     }
 
     @Test
-    void shouldSetDueDateTo141DaysFromTodayAndDoNotChangeStateWhenSoleApplicationAndAoSSubmitted() throws Exception {
+    void shouldNotChangeDueDateOrStateWhenSoleApplicationAndAoSSubmitted() throws Exception {
 
         when(serviceTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
 
@@ -265,7 +265,7 @@ public class SolicitorConfirmServiceIT {
             .andExpect(
                 status().isOk()
             )
-            .andExpect(jsonPath("$.data.dueDate").value(caseData.getApplication().getIssueDate().plusDays(141).toString()))
+            .andExpect(jsonPath("$.data.dueDate").doesNotExist())
             .andExpect(jsonPath("$.state").value("Holding"));
     }
 }

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/service/task/SetConfirmServiceDueDate.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/service/task/SetConfirmServiceDueDate.java
@@ -31,17 +31,23 @@ public class SetConfirmServiceDueDate implements CaseTask {
     public CaseDetails<CaseData, State> apply(final CaseDetails<CaseData, State> caseDetails) {
 
         CaseData caseData = caseDetails.getData();
-        SolicitorService solicitorService = caseData.getApplication().getSolicitorService();
 
-        var dueDate = solicitorService.getDateOfService().plusDays(dueDateOffsetDays);
+        if (caseData.getAcknowledgementOfService().getDateAosSubmitted() != null) {
+            log.info("Skip setting dueDate: AoS previously Submitted for CaseId: {}", caseDetails.getId());
+            return caseDetails;
+        } else {
+            SolicitorService solicitorService = caseData.getApplication().getSolicitorService();
 
-        if (!isEmpty(solicitorService.getServiceProcessedByProcessServer())) {
-            dueDate = holdingPeriodService.getDueDateFor(caseData.getApplication().getIssueDate());
+            var dueDate = solicitorService.getDateOfService().plusDays(dueDateOffsetDays);
+
+            if (!isEmpty(solicitorService.getServiceProcessedByProcessServer())) {
+                dueDate = holdingPeriodService.getDueDateFor(caseData.getApplication().getIssueDate());
+            }
+
+            caseData.setDueDate(dueDate);
+
+            log.info("Setting dueDate of {}, for CaseId: {}", caseData.getDueDate(), caseDetails.getId());
         }
-
-        caseData.setDueDate(dueDate);
-
-        log.info("Setting dueDate of {}, for CaseId: {}", caseData.getDueDate(), caseDetails.getId());
 
         return caseDetails;
     }

--- a/src/test/java/uk/gov/hmcts/divorce/solicitor/service/task/SetConfirmServiceDueDateTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/solicitor/service/task/SetConfirmServiceDueDateTest.java
@@ -9,12 +9,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.divorce.common.service.HoldingPeriodService;
+import uk.gov.hmcts.divorce.divorcecase.model.AcknowledgementOfService;
 import uk.gov.hmcts.divorce.divorcecase.model.Application;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.SolicitorService;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -90,5 +92,23 @@ public class SetConfirmServiceDueDateTest {
         final CaseDetails<CaseData, State> result = setConfirmServiceDueDate.apply(caseDetails);
 
         assertThat(result.getData().getDueDate()).isEqualTo(expectedDueDate);
+    }
+
+    @Test
+    void shouldNotSetDueDateIfAosPreviouslySubmitted() {
+        final var caseData = caseData();
+
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseData.setAcknowledgementOfService(
+            AcknowledgementOfService.builder().dateAosSubmitted(LocalDateTime.now()).build()
+        );
+        caseDetails.setData(caseData);
+        caseDetails.setId(TEST_CASE_ID);
+        caseDetails.setCreatedDate(LOCAL_DATE_TIME);
+
+        final CaseDetails<CaseData, State> result = setConfirmServiceDueDate.apply(caseDetails);
+        assertThat(result.getData().getDueDate()).isNull();
+
+        verifyNoInteractions(holdingPeriodService);
     }
 }


### PR DESCRIPTION
### Change description ###

NFDIV-3839: Do not set dueDate if AOS already submitted

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3839

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
