### PR TITLE
Allow moving out of AwaitingApplicant1Response state for stuck cases

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/State.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/State.java
@@ -460,7 +460,6 @@ public enum State {
 
     public static final EnumSet<State> PRE_RETURN_TO_PREVIOUS_STATES = EnumSet.complementOf(EnumSet.of(
         Draft,
-        AwaitingApplicant1Response,
         AwaitingApplicant2Response,
         Applicant2Approved,
         Withdrawn


### PR DESCRIPTION
### Change description ###

Cases stuck in awaiting app1 response can now be moved out using this event.