### PR TITLE
NFDIV - Hide letter pack tab

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
@@ -88,7 +88,9 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
         buildConfidentialDocumentsTab(configBuilder);
         buildCorrespondenceTab(configBuilder);
         buildAmendedApplicationTab(configBuilder);
-        buildLetterPackTab(configBuilder);
+
+        // Commented out as requested by service team. This can't be available for super users. Maybe we need a "Developer" role?
+        //buildLetterPackTab(configBuilder);
     }
 
     private void buildWarningsTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {


### PR DESCRIPTION
### Change description ###

Service team have raised concerns about the tab in production. We can't show it to super users. Commenting so we can spend time to maybe get a "developer" role for our team to use the tab.