### PR TITLE
NFDIV-3853 Store scanned documents in confidential collections if any applicant is confidential

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerOfflineDocumentVerifiedIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/caseworker/CaseworkerOfflineDocumentVerifiedIT.java
@@ -72,6 +72,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.CaseDocuments.OfflineDocume
 import static uk.gov.hmcts.divorce.divorcecase.model.CaseDocuments.OfflineDocumentReceived.CO_D84;
 import static uk.gov.hmcts.divorce.divorcecase.model.CaseDocuments.OfflineDocumentReceived.FO_D36;
 import static uk.gov.hmcts.divorce.divorcecase.model.CaseDocuments.OfflineDocumentReceived.OTHER;
+import static uk.gov.hmcts.divorce.divorcecase.model.ContactDetailsType.PRIVATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.Gender.FEMALE;
 import static uk.gov.hmcts.divorce.divorcecase.model.HowToRespondApplication.DISPUTE_DIVORCE;
 import static uk.gov.hmcts.divorce.divorcecase.model.HowToRespondApplication.WITHOUT_DISPUTE_DIVORCE;
@@ -115,8 +116,17 @@ public class CaseworkerOfflineDocumentVerifiedIT {
     private static final String CASEWORKER_OFFLINE_DOCUMENT_VERIFIED_D10_RESPONSE =
         "classpath:caseworker-offline-document-verified-d10-response.json";
 
+    private static final String CASEWORKER_OFFLINE_DOCUMENT_VERIFIED_CONFIDENTIAL_D10_RESPONSE =
+        "classpath:caseworker-offline-document-verified-confidential-d10-response.json";
+
     private static final String CASEWORKER_OFFLINE_DOCUMENT_VERIFIED_D84_RESPONSE =
         "classpath:caseworker-offline-document-verified-d84-response.json";
+
+    private static final String CASEWORKER_OFFLINE_DOCUMENT_VERIFIED_CONFIDENTIAL_D84_RESPONSE =
+        "classpath:caseworker-offline-document-verified-confidential-d84-response.json";
+
+    private static final String CASEWORKER_OFFLINE_DOCUMENT_VERIFIED_CONFIDENTIAL_D36_RESPONSE =
+        "classpath:caseworker-offline-document-verified-confidential-d36-response.json";
 
     private static final String CASEWORKER_OFFLINE_DOCUMENT_VERIFIED_OTHER_RESPONSE =
         "classpath:caseworker-offline-document-verified-other-response.json";
@@ -243,6 +253,83 @@ public class CaseworkerOfflineDocumentVerifiedIT {
     }
 
     @Test
+    void shouldTriggerAosSubmissionAndCaseStateToHoldingAndD10ToConfidentialDocsIfApplicantConfidentialAndD10Verified() throws Exception {
+
+        final AcknowledgementOfService acknowledgementOfService = AcknowledgementOfService.builder()
+            .howToRespondApplication(DISPUTE_DIVORCE)
+            .jurisdictionAgree(YES)
+            .build();
+
+        final ListValue<ScannedDocument> doc1 = ListValue.<ScannedDocument>builder()
+            .value(
+                ScannedDocument
+                    .builder()
+                    .url(
+                        Document
+                            .builder()
+                            .filename(FILENAME)
+                            .url("http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d")
+                            .binaryUrl("http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d/binary")
+                            .build()
+                    )
+                    .fileName(FILENAME)
+                    .type(ScannedDocumentType.OTHER)
+                    .subtype("aos")
+                    .build()
+            )
+            .build();
+
+        final CaseData caseData = caseData();
+        caseData.getApplication().setIssueDate(getExpectedLocalDate());
+        caseData.setAcknowledgementOfService(acknowledgementOfService);
+        caseData.setApplicationType(SOLE_APPLICATION);
+        caseData.setSupplementaryCaseType(NA);
+
+        caseData.getApplicant2().setLegalProceedings(YES);
+        caseData.getApplicant2().setLegalProceedingsDetails("some description");
+        caseData.getApplicant2().setContactDetailsType(PRIVATE);
+        caseData.setDocuments(
+            CaseDocuments.builder()
+                .typeOfDocumentAttached(AOS_D10)
+                .scannedDocuments(singletonList(doc1))
+                .scannedDocumentNames(
+                    DynamicList
+                        .builder()
+                        .value(
+                            DynamicListElement
+                                .builder()
+                                .label(FILENAME)
+                                .build()
+                        )
+                        .build()
+                )
+                .build()
+        );
+
+        when(serviceTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
+        stubForIdamDetails(TEST_SYSTEM_AUTHORISATION_TOKEN, SYSTEM_USER_USER_ID, SYSTEM_USER_ROLE);
+        stubForIdamToken(TEST_SYSTEM_AUTHORISATION_TOKEN);
+        stubForDocAssemblyWith("c35b1868-e397-457a-aa67-ac1422bb8100", "NFD_Respondent_Answers_Eng.docx");
+
+        final var jsonStringResponse = mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
+                .contentType(APPLICATION_JSON)
+                .header(SERVICE_AUTHORIZATION, TEST_SERVICE_AUTH_TOKEN)
+                .header(AUTHORIZATION, TEST_SYSTEM_AUTHORISATION_TOKEN)
+                .content(
+                    objectMapper.writeValueAsString(
+                        callbackRequest(caseData, CASEWORKER_OFFLINE_DOCUMENT_VERIFIED, OfflineDocumentReceived.name())))
+                .accept(APPLICATION_JSON))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertThatJson(jsonStringResponse)
+            .when(TREATING_NULL_AS_ABSENT)
+            .when(IGNORING_EXTRA_FIELDS)
+            .isEqualTo(expectedResponse(CASEWORKER_OFFLINE_DOCUMENT_VERIFIED_CONFIDENTIAL_D10_RESPONSE));
+    }
+
+    @Test
     void shouldTriggerCoSubmissionAndMoveCaseStateToJSAwaitingLAIfD84VerifiedAndJudicialSeparation() throws Exception {
 
         final ListValue<ScannedDocument> doc1 = ListValue.<ScannedDocument>builder()
@@ -303,7 +390,67 @@ public class CaseworkerOfflineDocumentVerifiedIT {
     }
 
     @Test
-    void shouldTriggerCoSubmissionAndMoveCaseStateToAwaitingFinalOrderIfSoleCaseAndD36Verified() throws Exception {
+    void shouldTriggerCoSubmissionAndCaseStateToAwaitingLAAndDocToConfidentialDocsIfApplicantConfidentialD84Verified() throws Exception {
+
+        final ListValue<ScannedDocument> doc1 = ListValue.<ScannedDocument>builder()
+            .value(
+                ScannedDocument
+                    .builder()
+                    .url(
+                        Document
+                            .builder()
+                            .filename(FILENAME)
+                            .url("http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d")
+                            .binaryUrl("http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d/binary")
+                            .build()
+                    )
+                    .fileName(FILENAME)
+                    .type(ScannedDocumentType.FORM)
+                    .build()
+            )
+            .build();
+
+        final CaseData caseData = caseData();
+        caseData.setApplicationType(JOINT_APPLICATION);
+        caseData.setApplicant2(getApplicant(FEMALE));
+        caseData.getApplicant2().setContactDetailsType(PRIVATE);
+        caseData.setDocuments(
+            CaseDocuments.builder()
+                .typeOfDocumentAttached(CO_D84)
+                .scannedDocuments(singletonList(doc1))
+                .scannedDocumentNames(
+                    DynamicList
+                        .builder()
+                        .value(
+                            DynamicListElement
+                                .builder()
+                                .label(FILENAME)
+                                .build()
+                        )
+                        .build()
+                )
+                .build()
+        );
+
+        final var jsonStringResponse = mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
+                .contentType(APPLICATION_JSON)
+                .header(SERVICE_AUTHORIZATION, TEST_SERVICE_AUTH_TOKEN)
+                .header(AUTHORIZATION, TEST_SYSTEM_AUTHORISATION_TOKEN)
+                .content(
+                    objectMapper.writeValueAsString(
+                        callbackRequest(caseData, CASEWORKER_OFFLINE_DOCUMENT_VERIFIED, OfflineDocumentReceived.name())))
+                .accept(APPLICATION_JSON))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertThatJson(jsonStringResponse)
+            .when(TREATING_NULL_AS_ABSENT)
+            .isEqualTo(expectedResponse(CASEWORKER_OFFLINE_DOCUMENT_VERIFIED_CONFIDENTIAL_D84_RESPONSE));
+    }
+
+    @Test
+    void shouldTriggerFoSubmissionAndMoveCaseStateToAwaitingFinalOrderIfSoleCaseAndD36Verified() throws Exception {
 
         final ListValue<ScannedDocument> doc1 = ListValue.<ScannedDocument>builder()
             .value(
@@ -360,7 +507,67 @@ public class CaseworkerOfflineDocumentVerifiedIT {
     }
 
     @Test
-    void shouldTriggerCoSubmissionAndMoveCaseStateToFinalOrderRequestedIfJointCaseAndD36Verified() throws Exception {
+    void shouldTriggerFoSubmissionAndCaseStateToAwaitingFinalOrderAndDocToConfidentialIfSoleConfidentialAndD36Verified() throws Exception {
+
+        final ListValue<ScannedDocument> doc1 = ListValue.<ScannedDocument>builder()
+            .value(
+                ScannedDocument
+                    .builder()
+                    .url(
+                        Document
+                            .builder()
+                            .filename(FILENAME)
+                            .url("http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d")
+                            .binaryUrl("http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d/binary")
+                            .build()
+                    )
+                    .fileName(FILENAME)
+                    .type(ScannedDocumentType.FORM)
+                    .build()
+            )
+            .build();
+
+        final CaseData caseData = caseData();
+        caseData.setApplicationType(SOLE_APPLICATION);
+        caseData.setApplicant2(getApplicant(FEMALE));
+        caseData.getApplicant2().setContactDetailsType(PRIVATE);
+        caseData.setDocuments(
+            CaseDocuments.builder()
+                .typeOfDocumentAttached(FO_D36)
+                .scannedDocuments(singletonList(doc1))
+                .scannedDocumentNames(
+                    DynamicList
+                        .builder()
+                        .value(
+                            DynamicListElement
+                                .builder()
+                                .label(FILENAME)
+                                .build()
+                        )
+                        .build()
+                )
+                .build()
+        );
+
+        final var jsonStringResponse = mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
+                .contentType(APPLICATION_JSON)
+                .header(SERVICE_AUTHORIZATION, TEST_SERVICE_AUTH_TOKEN)
+                .header(AUTHORIZATION, TEST_SYSTEM_AUTHORISATION_TOKEN)
+                .content(
+                    objectMapper.writeValueAsString(
+                        callbackRequest(caseData, CASEWORKER_OFFLINE_DOCUMENT_VERIFIED, OfflineDocumentReceived.name())))
+                .accept(APPLICATION_JSON))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertThatJson(jsonStringResponse)
+            .when(TREATING_NULL_AS_ABSENT)
+            .isEqualTo(expectedResponse(CASEWORKER_OFFLINE_DOCUMENT_VERIFIED_CONFIDENTIAL_D36_RESPONSE));
+    }
+
+    @Test
+    void shouldTriggerFoSubmissionAndMoveCaseStateToFinalOrderRequestedIfJointCaseAndD36Verified() throws Exception {
 
         final ListValue<ScannedDocument> doc1 = ListValue.<ScannedDocument>builder()
             .value(

--- a/src/integrationTest/resources/caseworker-offline-document-verified-confidential-d10-response.json
+++ b/src/integrationTest/resources/caseworker-offline-document-verified-confidential-d10-response.json
@@ -1,0 +1,66 @@
+{
+  "data": {
+    "divorceOrDissolution": "divorce",
+    "applicationType": "soleApplication",
+    "supplementaryCaseType": "notApplicable",
+    "applicant1FirstName": "test_first_name",
+    "applicant1MiddleName": "test_middle_name",
+    "sentNotifications": {},
+    "coCronRetriesRemindApplicantApplyCo": 0,
+    "applicant1LastName": "test_last_name",
+    "applicant1Email": "test@test.com",
+    "applicant1LanguagePreferenceWelsh": "No",
+    "applicant1Gender": "female",
+    "applicant1ContactDetailsType": "public",
+    "applicant1FinancialOrder": "No",
+    "applicant2LegalProceedings": "Yes",
+    "applicant2LegalProceedingsDetails": "some description",
+    "applicant2Offline": "Yes",
+    "solServiceTruthStatement": "I believe that the facts stated in the application are true.",
+    "issueDate": "${json-unit.any-string}",
+    "dateAosSubmitted": "${json-unit.any-string}",
+    "howToRespondApplication": "disputeDivorce",
+    "typeOfDocumentAttached": "D10",
+    "dueDate": "${json-unit.any-string}",
+    "statementOfTruth": "Yes",
+    "confidentialDocumentsUploaded": [
+      {
+        "id": "${json-unit.any-string}",
+        "value": {
+          "confidentialDocumentsReceived": "respondentAnswers",
+          "documentComment": "Reclassified scanned document",
+          "documentDateAdded": "${json-unit.any-string}",
+          "documentFileName": "doc1.pdf",
+          "documentLink": {
+            "document_binary_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d/binary",
+            "document_filename": "doc1.pdf",
+            "document_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d"
+          }
+        }
+      }
+    ],
+    "scannedDocuments": [
+      {
+        "value": {
+          "type": "other",
+          "subtype": "aos",
+          "url": {
+            "document_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d",
+            "document_filename": "doc1.pdf",
+            "document_binary_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d/binary"
+          },
+          "fileName": "doc1.pdf"
+        }
+      }
+    ],
+    "scannedDocumentNames": {
+      "value": {
+        "label": "doc1.pdf"
+      },
+      "valueLabel": "doc1.pdf"
+    },
+    "dataVersion": 5,
+    "warnings": []
+  },
+  "state": "Holding"
+}

--- a/src/integrationTest/resources/caseworker-offline-document-verified-confidential-d36-response.json
+++ b/src/integrationTest/resources/caseworker-offline-document-verified-confidential-d36-response.json
@@ -1,0 +1,72 @@
+{
+  "data": {
+    "divorceOrDissolution": "divorce",
+    "sentNotifications": {},
+    "solServiceTruthStatement": "I believe that the facts stated in the application are true.",
+    "supplementaryCaseType": "notApplicable",
+    "applicant1ContactDetailsType": "public",
+    "applicant1Email": "test@test.com",
+    "applicant1FinancialOrder": "No",
+    "applicant1FirstName": "test_first_name",
+    "applicant1Gender": "female",
+    "applicant1LanguagePreferenceWelsh": "No",
+    "applicant1LastName": "test_last_name",
+    "applicant1MiddleName": "test_middle_name",
+    "applicant1Offline": "Yes",
+    "applicant2ContactDetailsType": "private",
+    "applicant2Email": "test@test.com",
+    "applicant2FinancialOrder": "No",
+    "applicant2FirstName": "test_first_name",
+    "applicant2Gender": "female",
+    "applicant2LanguagePreferenceWelsh": "No",
+    "applicant2LastName": "test_last_name",
+    "applicant2MiddleName": "test_middle_name",
+    "applicationType": "soleApplication",
+    "coCronRetriesRemindApplicantApplyCo": 0,
+    "scannedD36Form": {
+      "document_binary_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d/binary",
+      "document_filename": "doc1.pdf",
+      "document_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d"
+    },
+    "confidentialDocumentsUploaded": [
+      {
+        "id": "${json-unit.any-string}",
+        "value": {
+          "confidentialDocumentsReceived": "finalOrderApplication",
+          "documentComment": "Reclassified scanned document",
+          "documentDateAdded": "${json-unit.any-string}",
+          "documentFileName": "doc1.pdf",
+          "documentLink": {
+            "document_binary_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d/binary",
+            "document_filename": "doc1.pdf",
+            "document_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d"
+          }
+        }
+      }
+    ],
+    "scannedDocumentNames": {
+      "value": {
+        "label": "doc1.pdf"
+      },
+      "valueLabel": "doc1.pdf"
+    },
+    "scannedDocuments": [
+      {
+        "value": {
+          "fileName": "doc1.pdf",
+          "type": "form",
+          "url": {
+            "document_binary_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d/binary",
+            "document_filename": "doc1.pdf",
+            "document_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d"
+          }
+        }
+      }
+    ],
+    "dataVersion": 5,
+    "typeOfDocumentAttached": "D36",
+    "warnings": []
+  },
+  "state": "FinalOrderRequested"
+}
+

--- a/src/integrationTest/resources/caseworker-offline-document-verified-confidential-d84-response.json
+++ b/src/integrationTest/resources/caseworker-offline-document-verified-confidential-d84-response.json
@@ -1,0 +1,88 @@
+{
+  "data": {
+    "applicant1ContactDetailsType": "public",
+    "applicant1Email": "test@test.com",
+    "applicant1FinancialOrder": "No",
+    "applicant1FirstName": "test_first_name",
+    "applicant1Gender": "female",
+    "applicant1LanguagePreferenceWelsh": "No",
+    "applicant1LastName": "test_last_name",
+    "applicant1MiddleName": "test_middle_name",
+    "applicant1Offline": "Yes",
+    "applicant2ContactDetailsType": "private",
+    "applicant2Email": "test@test.com",
+    "applicant2FinancialOrder": "No",
+    "applicant2FirstName": "test_first_name",
+    "applicant2Gender": "female",
+    "applicant2LanguagePreferenceWelsh": "No",
+    "applicant2LastName": "test_last_name",
+    "applicant2MiddleName": "test_middle_name",
+    "applicant2Offline": "Yes",
+    "applicationType": "jointApplication",
+    "coCronRetriesRemindApplicantApplyCo": 0,
+    "coScannedD84Form": {
+      "document_binary_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d/binary",
+      "document_filename": "doc1.pdf",
+      "document_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d"
+    },
+    "confidentialDocumentsGenerated": [
+      {
+        "id": "${json-unit.any-string}",
+        "value": {
+          "confidentialDocumentsReceived": "conditionalOrderApplication",
+          "documentComment": "Reclassified scanned document",
+          "documentDateAdded": "${json-unit.any-string}",
+          "documentFileName": "doc1.pdf",
+          "documentLink": {
+            "document_binary_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d/binary",
+            "document_filename": "doc1.pdf",
+            "document_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d"
+          }
+        }
+      }
+    ],
+    "confidentialDocumentsUploaded": [
+      {
+        "id": "${json-unit.any-string}",
+        "value": {
+          "confidentialDocumentsReceived": "conditionalOrderApplication",
+          "documentComment": "Reclassified scanned document",
+          "documentDateAdded": "${json-unit.any-string}",
+          "documentFileName": "doc1.pdf",
+          "documentLink": {
+            "document_binary_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d/binary",
+            "document_filename": "doc1.pdf",
+            "document_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d"
+          }
+        }
+      }
+    ],
+    "dataVersion": 5,
+    "divorceOrDissolution": "divorce",
+    "scannedDocumentNames": {
+      "value": {
+        "label": "doc1.pdf"
+      },
+      "valueLabel": "doc1.pdf"
+    },
+    "scannedDocuments": [
+      {
+        "value": {
+          "fileName": "doc1.pdf",
+          "type": "form",
+          "url": {
+            "document_binary_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d/binary",
+            "document_filename": "doc1.pdf",
+            "document_url": "http://localhost:8080/f62d42fd-a5f0-43ff-874b-d1666c1bf00d"
+          }
+        }
+      }
+    ],
+    "sentNotifications": {},
+    "solServiceTruthStatement": "I believe that the facts stated in the application are true.",
+    "supplementaryCaseType": "notApplicable",
+    "typeOfDocumentAttached": "D84",
+    "warnings": []
+  },
+  "state": "AwaitingLegalAdvisorReferral"
+}

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerOfflineDocumentVerified.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerOfflineDocumentVerified.java
@@ -319,7 +319,7 @@ public class CaseworkerOfflineDocumentVerified implements CCDConfig<CaseData, St
 
             log.info("Reclassifying scanned doc {} to {} doc type", filename, documentType);
 
-            caseData.reclassifyScannedDocumentToChosenDocumentType(documentType, clock, filename);
+            caseData.reclassifyScannedDocumentToChosenDocumentType(caseData, documentType, clock, filename);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDocuments.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDocuments.java
@@ -327,6 +327,19 @@ public class CaseDocuments {
             .build();
     }
 
+    @JsonIgnore
+    public ConfidentialDivorceDocument mapScannedDocumentToConfidentialDocument(final ScannedDocument scannedDocument,
+                                                                                final DocumentType documentType,
+                                                                                final Clock clock) {
+        return ConfidentialDivorceDocument.builder()
+            .documentLink(scannedDocument.getUrl())
+            .documentFileName(scannedDocument.getFileName())
+            .documentDateAdded(LocalDate.now(clock))
+            .confidentialDocumentsReceived(getConfidentialDocumentType(documentType))
+            .documentComment("Reclassified scanned document")
+            .build();
+    }
+
     public Optional<ListValue<DivorceDocument>> getDocumentGeneratedWithType(final DocumentType documentType) {
         return !isEmpty(this.getDocumentsGenerated())
             ? this.getDocumentsGenerated().stream()

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
@@ -48,10 +48,13 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
 
     private static final String IS_SOLE = "applicationType=\"soleApplication\"";
     private static final String IS_JOINT = "applicationType=\"jointApplication\"";
-    private static final String IS_JOINT_AND_HWF_ENTERED = "applicationType=\"jointApplication\" AND applicant2HWFReferenceNumber=\"*\"";
+    private static final String IS_JOINT_AND_HWF_ENTERED =
+        "applicationType=\"jointApplication\" AND applicant2HWFReferenceNumber=\"*\"";
     private static final String IS_NEW_PAPER_CASE = "newPaperCase=\"Yes\"";
-    private static final String APPLICANTS_CONTACT_DETAILS_PUBLIC = "applicant1ContactDetailsType!=\"private\" AND applicant2ContactDetailsType!=\"private\"";
-    private static final String APPLICANTS_CONTACT_DETAILS_PRIVATE = "applicant1ContactDetailsType=\"private\" OR applicant2ContactDetailsType=\"private\"";
+    private static final String APPLICANTS_CONTACT_DETAILS_PUBLIC =
+        "applicant1ContactDetailsType!=\"private\" AND applicant2ContactDetailsType!=\"private\"";
+    private static final String APPLICANTS_CONTACT_DETAILS_PRIVATE =
+        "applicant1ContactDetailsType=\"private\" OR applicant2ContactDetailsType=\"private\"";
     private static final String PAPER_FORM_APPLICANT_1_PAYMENT_OTHER_DETAILS =
         "paperFormApplicant1NoPaymentIncluded=\"Yes\" AND paperFormSoleOrApplicant1PaymentOther=\"Yes\"";
     private static final String PAPER_FORM_APPLICANT_2_PAYMENT_OTHER_DETAILS =

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
@@ -50,8 +50,8 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
     private static final String IS_JOINT = "applicationType=\"jointApplication\"";
     private static final String IS_JOINT_AND_HWF_ENTERED = "applicationType=\"jointApplication\" AND applicant2HWFReferenceNumber=\"*\"";
     private static final String IS_NEW_PAPER_CASE = "newPaperCase=\"Yes\"";
-    private static final String APPLICANT_1_CONTACT_DETAILS_PUBLIC = "applicant1ContactDetailsType!=\"private\"";
-    private static final String APPLICANT_1_CONTACT_DETAILS_PRIVATE = "applicant1ContactDetailsType=\"private\"";
+    private static final String APPLICANTS_CONTACT_DETAILS_PUBLIC = "applicant1ContactDetailsType!=\"private\" AND applicant2ContactDetailsType!=\"private\"";
+    private static final String APPLICANTS_CONTACT_DETAILS_PRIVATE = "applicant1ContactDetailsType=\"private\" OR applicant2ContactDetailsType=\"private\"";
     private static final String PAPER_FORM_APPLICANT_1_PAYMENT_OTHER_DETAILS =
         "paperFormApplicant1NoPaymentIncluded=\"Yes\" AND paperFormSoleOrApplicant1PaymentOther=\"Yes\"";
     private static final String PAPER_FORM_APPLICANT_2_PAYMENT_OTHER_DETAILS =
@@ -187,7 +187,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
             .field("documentsGenerated")
             .field("applicant1DocumentsUploaded")
             .field("applicant2DocumentsUploaded")
-            .field("scannedDocuments", APPLICANT_1_CONTACT_DETAILS_PUBLIC)
+            .field("scannedDocuments", APPLICANTS_CONTACT_DETAILS_PUBLIC)
             .field(CaseData::getGeneralOrders)
             .field("documentsUploaded")
             .field(CaseData::getGeneralEmails)
@@ -293,7 +293,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
             .forRoles(CASE_WORKER, LEGAL_ADVISOR, JUDGE, SUPER_USER)
             .field("confidentialDocumentsGenerated")
             .field("confidentialDocumentsUploaded")
-            .field("scannedDocuments", APPLICANT_1_CONTACT_DETAILS_PRIVATE);
+            .field("scannedDocuments", APPLICANTS_CONTACT_DETAILS_PRIVATE);
     }
 
     private void buildServiceApplicationTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
@@ -332,7 +332,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
         configBuilder.tab("conditionalOrder", "Conditional Order")
             .forRoles(CASE_WORKER, LEGAL_ADVISOR, JUDGE, APPLICANT_1_SOLICITOR, APPLICANT_2_SOLICITOR, SUPER_USER)
             .showCondition("coApplicant1SubmittedDate=\"*\" OR coApplicant2SubmittedDate=\"*\" OR "
-                + showForState(
+                    + showForState(
                     ConditionalOrderDrafted,
                     ConditionalOrderPending,
                     AwaitingLegalAdvisorReferral,
@@ -385,7 +385,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
         configBuilder.tab("outcomeOfConditionalOrder", "Outcome of Conditional Order")
             .forRoles(CASE_WORKER, LEGAL_ADVISOR, JUDGE, APPLICANT_1_SOLICITOR, APPLICANT_2_SOLICITOR, SUPER_USER)
             .showCondition("coGranted=\"*\" OR "
-                + showForState(
+                    + showForState(
                     AwaitingAdminClarification,
                     AwaitingClarification,
                     AwaitingAmendedApplication,

--- a/src/main/java/uk/gov/hmcts/divorce/document/DocumentUtil.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/DocumentUtil.java
@@ -27,9 +27,11 @@ import static uk.gov.hmcts.divorce.document.model.DocumentType.AOS_OVERDUE_LETTE
 import static uk.gov.hmcts.divorce.document.model.DocumentType.AOS_RESPONSE_LETTER;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CERTIFICATE_OF_ENTITLEMENT_COVER_LETTER_APP1;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CERTIFICATE_OF_ENTITLEMENT_COVER_LETTER_APP2;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.CONDITIONAL_ORDER_APPLICATION;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CONDITIONAL_ORDER_GRANTED_COVERSHEET_APP_1;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CONDITIONAL_ORDER_GRANTED_COVERSHEET_APP_2;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CONDITIONAL_ORDER_REFUSAL_COVER_LETTER;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.FINAL_ORDER_APPLICATION;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.FINAL_ORDER_CAN_APPLY_APP1;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.FINAL_ORDER_CAN_APPLY_APP2;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.FINAL_ORDER_GRANTED_COVER_LETTER_APP_1;
@@ -38,6 +40,7 @@ import static uk.gov.hmcts.divorce.document.model.DocumentType.GENERAL_LETTER;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.JUDICIAL_SEPARATION_ORDER_CLARIFICATION_REFUSAL_COVER_LETTER;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.NOTICE_OF_PROCEEDINGS_APP_1;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.NOTICE_OF_PROCEEDINGS_APP_2;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.RESPONDENT_ANSWERS;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.SEPARATION_ORDER_CLARIFICATION_REFUSAL_COVER_LETTER;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.SEPARATION_ORDER_REFUSAL_COVER_LETTER;
 
@@ -180,6 +183,9 @@ public final class DocumentUtil {
             Map.of(
                 FINAL_ORDER_CAN_APPLY_APP1, ConfidentialDocumentsReceived.FINAL_ORDER_CAN_APPLY_APP1,
                 FINAL_ORDER_CAN_APPLY_APP2, ConfidentialDocumentsReceived.FINAL_ORDER_CAN_APPLY_APP2,
+                FINAL_ORDER_APPLICATION, ConfidentialDocumentsReceived.FINAL_ORDER_APPLICATION,
+                RESPONDENT_ANSWERS, ConfidentialDocumentsReceived.RESPONDENT_ANSWERS,
+                CONDITIONAL_ORDER_APPLICATION, ConfidentialDocumentsReceived.CONDITIONAL_ORDER_APPLICATION,
                 AOS_OVERDUE_LETTER, ConfidentialDocumentsReceived.AOS_OVERDUE_LETTER)
         );
 

--- a/src/main/java/uk/gov/hmcts/divorce/document/model/DocumentType.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/model/DocumentType.java
@@ -56,7 +56,7 @@ public enum DocumentType implements HasLabel {
     CONDITIONAL_ORDER_ANSWERS("Conditional order answers", false),
 
     @JsonProperty("conditionalOrderApplication")
-    CONDITIONAL_ORDER_APPLICATION("Conditional order application (D84)", false),
+    CONDITIONAL_ORDER_APPLICATION("Conditional order application (D84)", true),
 
     @JsonProperty("conditionalOrderCanApply")
     CONDITIONAL_ORDER_CAN_APPLY("Conditional order can apply", true),
@@ -177,7 +177,7 @@ public enum DocumentType implements HasLabel {
     FINAL_ORDER_CAN_APPLY_APP2("Final order can apply - Applicant 2", true),
 
     @JsonProperty("finalOrderApplication")
-    FINAL_ORDER_APPLICATION("Final Order application (D36)", false),
+    FINAL_ORDER_APPLICATION("Final Order application (D36)", true),
 
     @JsonProperty("finalOrderGranted")
     FINAL_ORDER_GRANTED("Final order granted", false),
@@ -221,7 +221,7 @@ public enum DocumentType implements HasLabel {
 
     @JsonProperty("respondentAnswers")
     @JsonAlias("applicant2Answers")
-    RESPONDENT_ANSWERS("Respondent answers", false),
+    RESPONDENT_ANSWERS("Respondent answers", true),
 
     @JsonProperty("aos")
     @Deprecated

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemAttachScannedDocuments.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemAttachScannedDocuments.java
@@ -123,7 +123,7 @@ public class SystemAttachScannedDocuments implements CCDConfig<CaseData, State, 
             final DocumentType documentType = getDocumentType(scannedDocumentSubtype);
 
             if (isNotEmpty(documentType)) {
-                caseData.reclassifyScannedDocumentToChosenDocumentType(documentType, clock, scannedDocument);
+                caseData.reclassifyScannedDocumentToChosenDocumentType(caseData, documentType, clock, scannedDocument);
                 caseData.getDocuments().setScannedSubtypeReceived(scannedDocumentSubtype);
             }
         }

--- a/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDataTest.java
@@ -344,8 +344,88 @@ class CaseDataTest {
         final Document document = Document.builder().build();
         ScannedDocument scannedDocument = ScannedDocument.builder().url(document).build();
 
-        caseData.reclassifyScannedDocumentToChosenDocumentType(DocumentType.FINAL_ORDER_APPLICATION, clock, scannedDocument);
+        caseData.reclassifyScannedDocumentToChosenDocumentType(caseData, DocumentType.FINAL_ORDER_APPLICATION, clock, scannedDocument);
 
         assertThat(caseData.getFinalOrder().getScannedD36Form()).isEqualTo(document);
+    }
+
+    @Test
+    void shouldSetConfidentialDocumentsUploadedConfidentialCaseD10() {
+        final CaseData caseData = new CaseData();
+        caseData.getApplicant1().setContactDetailsType(ContactDetailsType.PRIVATE);
+
+        final Clock clock = mock(Clock.class);
+        setMockClock(clock);
+
+        final Document document = Document.builder().build();
+        ScannedDocument scannedDocument = ScannedDocument.builder().url(document).build();
+
+        caseData.reclassifyScannedDocumentToChosenDocumentType(caseData, DocumentType.RESPONDENT_ANSWERS, clock, scannedDocument);
+
+        assertThat(caseData.getDocuments().getConfidentialDocumentsUploaded().size()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldSetScannedD84FormOnFinalOrderAndSetConfidentialDocumentsUploadedConfidentialCase() {
+        final CaseData caseData = new CaseData();
+        caseData.getApplicant1().setContactDetailsType(ContactDetailsType.PRIVATE);
+
+        final Clock clock = mock(Clock.class);
+        setMockClock(clock);
+
+        final Document document = Document.builder().build();
+        ScannedDocument scannedDocument = ScannedDocument.builder().url(document).build();
+
+        caseData.reclassifyScannedDocumentToChosenDocumentType(caseData, DocumentType.CONDITIONAL_ORDER_APPLICATION, clock, scannedDocument);
+
+        assertThat(caseData.getConditionalOrder().getScannedD84Form()).isEqualTo(document);
+        assertThat(caseData.getDocuments().getConfidentialDocumentsUploaded().size()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldSetScannedD36FormOnFinalOrderAndSetConfidentialDocumentsUploadedConfidentialCase() {
+        final CaseData caseData = new CaseData();
+        caseData.getApplicant1().setContactDetailsType(ContactDetailsType.PRIVATE);
+
+        final Clock clock = mock(Clock.class);
+        setMockClock(clock);
+
+        final Document document = Document.builder().build();
+        ScannedDocument scannedDocument = ScannedDocument.builder().url(document).build();
+
+        caseData.reclassifyScannedDocumentToChosenDocumentType(caseData, DocumentType.FINAL_ORDER_APPLICATION, clock, scannedDocument);
+
+        assertThat(caseData.getFinalOrder().getScannedD36Form()).isEqualTo(document);
+        assertThat(caseData.getDocuments().getConfidentialDocumentsUploaded().size()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldSetScannedD84FormOnFinalOrder() {
+        final CaseData caseData = new CaseData();
+        final Clock clock = mock(Clock.class);
+        setMockClock(clock);
+        final Document document = Document.builder().build();
+        ScannedDocument scannedDocument = ScannedDocument.builder().url(document).build();
+
+        caseData.reclassifyScannedDocumentToChosenDocumentType(caseData, DocumentType.CONDITIONAL_ORDER_APPLICATION, clock, scannedDocument);
+
+        assertThat(caseData.getConditionalOrder().getScannedD84Form()).isEqualTo(document);
+        assertThat(caseData.getDocuments().getDocumentsGenerated().size()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldSetDocumentsUploadedForNonConfidentialD10Case() {
+        final CaseData caseData = new CaseData();
+        caseData.getApplicant1().setContactDetailsType(ContactDetailsType.PUBLIC);
+
+        final Clock clock = mock(Clock.class);
+        setMockClock(clock);
+
+        final Document document = Document.builder().build();
+        ScannedDocument scannedDocument = ScannedDocument.builder().url(document).build();
+
+        caseData.reclassifyScannedDocumentToChosenDocumentType(caseData, DocumentType.RESPONDENT_ANSWERS, clock, scannedDocument);
+
+        assertThat(caseData.getDocuments().getDocumentsUploaded().size()).isEqualTo(1);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDataTest.java
@@ -376,7 +376,12 @@ class CaseDataTest {
         final Document document = Document.builder().build();
         ScannedDocument scannedDocument = ScannedDocument.builder().url(document).build();
 
-        caseData.reclassifyScannedDocumentToChosenDocumentType(caseData, DocumentType.CONDITIONAL_ORDER_APPLICATION, clock, scannedDocument);
+        caseData.reclassifyScannedDocumentToChosenDocumentType(
+            caseData,
+            DocumentType.CONDITIONAL_ORDER_APPLICATION,
+            clock,
+            scannedDocument
+        );
 
         assertThat(caseData.getConditionalOrder().getScannedD84Form()).isEqualTo(document);
         assertThat(caseData.getDocuments().getConfidentialDocumentsUploaded().size()).isEqualTo(1);
@@ -407,7 +412,12 @@ class CaseDataTest {
         final Document document = Document.builder().build();
         ScannedDocument scannedDocument = ScannedDocument.builder().url(document).build();
 
-        caseData.reclassifyScannedDocumentToChosenDocumentType(caseData, DocumentType.CONDITIONAL_ORDER_APPLICATION, clock, scannedDocument);
+        caseData.reclassifyScannedDocumentToChosenDocumentType(
+            caseData,
+            DocumentType.CONDITIONAL_ORDER_APPLICATION,
+            clock,
+            scannedDocument
+        );
 
         assertThat(caseData.getConditionalOrder().getScannedD84Form()).isEqualTo(document);
         assertThat(caseData.getDocuments().getDocumentsGenerated().size()).isEqualTo(1);

--- a/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDocumentsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/divorcecase/model/CaseDocumentsTest.java
@@ -331,6 +331,30 @@ class CaseDocumentsTest {
     }
 
     @Test
+    void shouldMapScannedDocumentToConfidentialDocument() {
+
+        final CaseDocuments caseDocuments = CaseDocuments.builder().build();
+        final Clock clock = mock(Clock.class);
+        setMockClock(clock);
+
+        final ScannedDocument scannedDocument = ScannedDocument.builder()
+            .url(Document.builder().build())
+            .fileName("D36.pdf")
+            .build();
+
+        final ConfidentialDivorceDocument expectedResponse = ConfidentialDivorceDocument.builder()
+            .documentLink(scannedDocument.getUrl())
+            .documentFileName(scannedDocument.getFileName())
+            .documentDateAdded(LocalDate.now(clock))
+            .confidentialDocumentsReceived(ConfidentialDocumentsReceived.FINAL_ORDER_APPLICATION)
+            .documentComment("Reclassified scanned document")
+            .build();
+
+        assertThat(caseDocuments.mapScannedDocumentToConfidentialDocument(scannedDocument, FINAL_ORDER_APPLICATION, clock))
+            .isEqualTo(expectedResponse);
+    }
+
+    @Test
     public void shouldRemoveGivenConfidentialDocumentType() {
         final CaseDocuments caseDocuments = CaseDocuments.builder()
             .confidentialDocumentsGenerated(Lists.newArrayList(

--- a/src/test/java/uk/gov/hmcts/divorce/document/DocumentUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/document/DocumentUtilTest.java
@@ -45,13 +45,16 @@ import static uk.gov.hmcts.divorce.document.model.DocumentType.APPLICATION;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CERTIFICATE_OF_ENTITLEMENT;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CERTIFICATE_OF_ENTITLEMENT_COVER_LETTER_APP1;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.CERTIFICATE_OF_ENTITLEMENT_COVER_LETTER_APP2;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.CONDITIONAL_ORDER_APPLICATION;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.D10;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.FINAL_ORDER_APPLICATION;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.FINAL_ORDER_GRANTED_COVER_LETTER_APP_1;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.FINAL_ORDER_GRANTED_COVER_LETTER_APP_2;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.GENERAL_LETTER;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.NOTICE_OF_PROCEEDINGS_APP_1;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.NOTICE_OF_PROCEEDINGS_APP_2;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.OTHER;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.RESPONDENT_ANSWERS;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
 
 @ExtendWith(MockitoExtension.class)
@@ -257,7 +260,10 @@ class DocumentUtilTest {
             NOTICE_OF_PROCEEDINGS_APP_2,
             GENERAL_LETTER,
             FINAL_ORDER_GRANTED_COVER_LETTER_APP_1,
-            FINAL_ORDER_GRANTED_COVER_LETTER_APP_2
+            FINAL_ORDER_GRANTED_COVER_LETTER_APP_2,
+            FINAL_ORDER_APPLICATION,
+            RESPONDENT_ANSWERS,
+            CONDITIONAL_ORDER_APPLICATION
         );
 
         assertThat(documentTypes.stream().map(DocumentUtil::getConfidentialDocumentType)
@@ -267,7 +273,10 @@ class DocumentUtilTest {
                 ConfidentialDocumentsReceived.NOTICE_OF_PROCEEDINGS_APP_2,
                 ConfidentialDocumentsReceived.GENERAL_LETTER,
                 ConfidentialDocumentsReceived.FINAL_ORDER_GRANTED_COVER_LETTER_APP_1,
-                ConfidentialDocumentsReceived.FINAL_ORDER_GRANTED_COVER_LETTER_APP_2
+                ConfidentialDocumentsReceived.FINAL_ORDER_GRANTED_COVER_LETTER_APP_2,
+                ConfidentialDocumentsReceived.FINAL_ORDER_APPLICATION,
+                ConfidentialDocumentsReceived.RESPONDENT_ANSWERS,
+                ConfidentialDocumentsReceived.CONDITIONAL_ORDER_APPLICATION
             );
     }
 


### PR DESCRIPTION
### Change description ###

When either applicant is confidential, store scanned docs in confidentialDocumentsUploaded

To avoid data breaches and handling sensitive documents incorrectly, we're moving scanned and reclassified
documents into confidential document arrays if any applicant is confidential on the case.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3853