### PR TITLE
NFDIV-3824 - Revert to use AwaitingPronouncement

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemLinkWithBulkCase.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemLinkWithBulkCase.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 
 import static uk.gov.hmcts.divorce.common.ccd.CcdPageConfiguration.NEVER_SHOW;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingPronouncement;
-import static uk.gov.hmcts.divorce.divorcecase.model.State.InBulkActionCase;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
@@ -27,7 +26,7 @@ public class SystemLinkWithBulkCase implements CCDConfig<CaseData, State, UserRo
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         new PageBuilder(configBuilder
             .event(SYSTEM_LINK_WITH_BULK_CASE)
-            .forStateTransition(AwaitingPronouncement, InBulkActionCase)
+            .forStates(AwaitingPronouncement)
             .showCondition(NEVER_SHOW)
             .name("Link with bulk case")
             .description("Linked with bulk case")


### PR DESCRIPTION
### Change description ###

Had a meeting with the service team. The new State InBulkActionCase needs further considerations before it can be used correctly.

Keeping state in code but reverting the transition to the new state to go back to old behaviour while we work on it further.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3824