### PR TITLE
Add conditional for sending court orders, if they're not present we will not send them

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/common/notification/RegenerateCourtOrdersNotification.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/notification/RegenerateCourtOrdersNotification.java
@@ -11,6 +11,10 @@ import uk.gov.hmcts.divorce.document.print.documentpack.DocumentPackInfo;
 import uk.gov.hmcts.divorce.document.print.documentpack.FinalOrderGrantedDocumentPack;
 import uk.gov.hmcts.divorce.notification.ApplicantNotification;
 
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.CONDITIONAL_ORDER_GRANTED;
+import static uk.gov.hmcts.divorce.document.model.DocumentType.FINAL_ORDER_GRANTED;
+
 @RequiredArgsConstructor
 @Component
 @Slf4j
@@ -24,30 +28,85 @@ public class RegenerateCourtOrdersNotification implements ApplicantNotification 
     @Override
     public void sendToApplicant1Offline(CaseData caseData, Long caseId) {
         log.info("Sending Regenerated Court Orders to applicant 1 for case : {}", caseId);
-        DocumentPackInfo certOfEntitlementDocPackInfo = certificateOfEntitlementDocPack.getDocumentPack(caseData, caseData.getApplicant1());
-        letterPrinter.sendLetters(
-            caseData, caseId, caseData.getApplicant1(), certOfEntitlementDocPackInfo, certificateOfEntitlementDocPack.getLetterId());
-        DocumentPackInfo finalOrderGrantedDocPackInfo = finalOrderGrantedDocPack.getDocumentPack(caseData, caseData.getApplicant1());
-        letterPrinter.sendLetters(caseData, caseId, caseData.getApplicant1(), finalOrderGrantedDocPackInfo,
-            finalOrderGrantedDocPack.getLetterId());
-        DocumentPackInfo conditionalOrderPronouncedDocPackInfo =
-            conditionalOrderPronouncedDocPack.getDocumentPack(caseData, caseData.getApplicant1());
-        letterPrinter.sendLetters(caseData, caseId, caseData.getApplicant1(), conditionalOrderPronouncedDocPackInfo,
-            conditionalOrderPronouncedDocPack.getLetterId());
+
+        if (caseData.getDocuments().getDocumentGeneratedWithType(CONDITIONAL_ORDER_GRANTED).isPresent()) {
+            DocumentPackInfo certOfEntitlementDocPackInfo
+                = certificateOfEntitlementDocPack.getDocumentPack(caseData, caseData.getApplicant1());
+
+            letterPrinter.sendLetters(
+                caseData,
+                caseId,
+                caseData.getApplicant1(),
+                certOfEntitlementDocPackInfo,
+                certificateOfEntitlementDocPack.getLetterId()
+            );
+        }
+
+        if (caseData.getDocuments().getDocumentGeneratedWithType(FINAL_ORDER_GRANTED).isPresent()) {
+            DocumentPackInfo finalOrderGrantedDocPackInfo = finalOrderGrantedDocPack.getDocumentPack(caseData, caseData.getApplicant1());
+
+            letterPrinter.sendLetters(
+                caseData,
+                caseId,
+                caseData.getApplicant1(),
+                finalOrderGrantedDocPackInfo,
+                finalOrderGrantedDocPack.getLetterId()
+            );
+        }
+
+        if (isNotEmpty(caseData.getConditionalOrder().getCertificateOfEntitlementDocument())) {
+            DocumentPackInfo conditionalOrderPronouncedDocPackInfo =
+                conditionalOrderPronouncedDocPack.getDocumentPack(caseData, caseData.getApplicant1());
+
+            letterPrinter.sendLetters(
+                caseData,
+                caseId,
+                caseData.getApplicant1(),
+                conditionalOrderPronouncedDocPackInfo,
+                conditionalOrderPronouncedDocPack.getLetterId()
+            );
+        }
     }
 
     @Override
     public void sendToApplicant2Offline(CaseData caseData, Long caseId) {
         log.info("Sending Regenerated Court Orders to applicant 2 for case : {}", caseId);
-        DocumentPackInfo documentPackInfo = certificateOfEntitlementDocPack.getDocumentPack(caseData, caseData.getApplicant2());
-        letterPrinter.sendLetters(
-            caseData, caseId, caseData.getApplicant2(), documentPackInfo, certificateOfEntitlementDocPack.getLetterId());
-        DocumentPackInfo finalOrderGrantedDocPackInfo = finalOrderGrantedDocPack.getDocumentPack(caseData, caseData.getApplicant2());
-        letterPrinter.sendLetters(caseData, caseId, caseData.getApplicant2(), finalOrderGrantedDocPackInfo,
-            finalOrderGrantedDocPack.getLetterId());
-        DocumentPackInfo conditionalOrderPronouncedDocPackInfo =
-            conditionalOrderPronouncedDocPack.getDocumentPack(caseData, caseData.getApplicant2());
-        letterPrinter.sendLetters(caseData, caseId, caseData.getApplicant2(), conditionalOrderPronouncedDocPackInfo,
-            conditionalOrderPronouncedDocPack.getLetterId());
+
+        if (caseData.getDocuments().getDocumentGeneratedWithType(CONDITIONAL_ORDER_GRANTED).isPresent()) {
+            DocumentPackInfo documentPackInfo = certificateOfEntitlementDocPack.getDocumentPack(caseData, caseData.getApplicant2());
+
+            letterPrinter.sendLetters(
+                caseData,
+                caseId,
+                caseData.getApplicant2(),
+                documentPackInfo,
+                certificateOfEntitlementDocPack.getLetterId()
+            );
+        }
+
+        if (caseData.getDocuments().getDocumentGeneratedWithType(FINAL_ORDER_GRANTED).isPresent()) {
+            DocumentPackInfo finalOrderGrantedDocPackInfo = finalOrderGrantedDocPack.getDocumentPack(caseData, caseData.getApplicant2());
+
+            letterPrinter.sendLetters(
+                caseData,
+                caseId,
+                caseData.getApplicant2(),
+                finalOrderGrantedDocPackInfo,
+                finalOrderGrantedDocPack.getLetterId()
+            );
+        }
+
+        if (isNotEmpty(caseData.getConditionalOrder().getCertificateOfEntitlementDocument())) {
+            DocumentPackInfo conditionalOrderPronouncedDocPackInfo =
+                conditionalOrderPronouncedDocPack.getDocumentPack(caseData, caseData.getApplicant2());
+
+            letterPrinter.sendLetters(
+                caseData,
+                caseId,
+                caseData.getApplicant2(),
+                conditionalOrderPronouncedDocPackInfo,
+                conditionalOrderPronouncedDocPack.getLetterId()
+            );
+        }
     }
 }


### PR DESCRIPTION
### Change description ###

Exception firing in prod because we conditionally regenerate the document, but we send every time. I've changed the notification class as a quick fix, to check if the document is present before attempting to send.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-N/A