### PR TITLE
NFDIV-3899 - No retry on switch to sole events

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SwitchedToSoleCo.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SwitchedToSoleCo.java
@@ -63,7 +63,7 @@ public class SwitchedToSoleCo implements CCDConfig<CaseData, State, UserRole> {
             .description("Application type switched to sole post CO submission")
             .grant(CREATE_READ_UPDATE, CREATOR, APPLICANT_2, SYSTEMUPDATE)
             .grantHistoryOnly(CASE_WORKER, LEGAL_ADVISOR, SUPER_USER, APPLICANT_1_SOLICITOR, APPLICANT_2_SOLICITOR)
-            .retries(0, 0, 0)
+            .retries(0)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }
 
@@ -81,6 +81,7 @@ public class SwitchedToSoleCo implements CCDConfig<CaseData, State, UserRole> {
 
         // triggered by citizen users
         if (ccdAccessService.isApplicant2(httpServletRequest.getHeader(AUTHORIZATION), caseId)) {
+            log.info("Request made by applicant to switch to sole for case id: {}", caseId);
             switchToSoleService.switchUserRoles(data, caseId);
             switchToSoleService.switchApplicantData(data);
         }

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SwitchedToSoleCo.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SwitchedToSoleCo.java
@@ -89,6 +89,7 @@ public class SwitchedToSoleCo implements CCDConfig<CaseData, State, UserRole> {
         // triggered by system update user coming from Offline Document Verified
         if (OfflineWhoApplying.APPLICANT_2.equals(data.getConditionalOrder().getD84WhoApplying())) {
             if (!data.getApplication().isPaperCase()) {
+                log.info("Request made via paper to switch to sole for online case id: {}", caseId);
                 switchToSoleService.switchUserRoles(data, caseId);
             }
             switchToSoleService.switchApplicantData(data);

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SwitchedToSoleCo.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SwitchedToSoleCo.java
@@ -63,7 +63,7 @@ public class SwitchedToSoleCo implements CCDConfig<CaseData, State, UserRole> {
             .description("Application type switched to sole post CO submission")
             .grant(CREATE_READ_UPDATE, CREATOR, APPLICANT_2, SYSTEMUPDATE)
             .grantHistoryOnly(CASE_WORKER, LEGAL_ADVISOR, SUPER_USER, APPLICANT_1_SOLICITOR, APPLICANT_2_SOLICITOR)
-            .retries(120, 120)
+            .retries(0, 0, 0)
             .aboutToSubmitCallback(this::aboutToSubmit);
     }
 

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SwitchedToSoleFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SwitchedToSoleFinalOrder.java
@@ -77,7 +77,7 @@ public class SwitchedToSoleFinalOrder implements CCDConfig<CaseData, State, User
                 .description("Switched to sole final order")
                 .grant(CREATE_READ_UPDATE, CREATOR, APPLICANT_2, SYSTEMUPDATE)
                 .grantHistoryOnly(CASE_WORKER, LEGAL_ADVISOR, SUPER_USER, APPLICANT_1_SOLICITOR, APPLICANT_2_SOLICITOR)
-                .retries(0, 0, 0)
+                .retries(0)
                 .aboutToSubmitCallback(this::aboutToSubmit)
                 .submittedCallback(this::submitted)
         );
@@ -96,6 +96,7 @@ public class SwitchedToSoleFinalOrder implements CCDConfig<CaseData, State, User
 
         // triggered by citizen users
         if (ccdAccessService.isApplicant2(httpServletRequest.getHeader(AUTHORIZATION), caseId)) {
+            log.info("Request made by applicant to switch to sole for case id: {}", caseId);
             switchToSoleService.switchUserRoles(caseData, caseId);
             switchToSoleService.switchApplicantData(caseData);
         }

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SwitchedToSoleFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SwitchedToSoleFinalOrder.java
@@ -77,7 +77,7 @@ public class SwitchedToSoleFinalOrder implements CCDConfig<CaseData, State, User
                 .description("Switched to sole final order")
                 .grant(CREATE_READ_UPDATE, CREATOR, APPLICANT_2, SYSTEMUPDATE)
                 .grantHistoryOnly(CASE_WORKER, LEGAL_ADVISOR, SUPER_USER, APPLICANT_1_SOLICITOR, APPLICANT_2_SOLICITOR)
-                .retries(120, 120)
+                .retries(0, 0, 0)
                 .aboutToSubmitCallback(this::aboutToSubmit)
                 .submittedCallback(this::submitted)
         );

--- a/src/main/java/uk/gov/hmcts/divorce/common/event/SwitchedToSoleFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/event/SwitchedToSoleFinalOrder.java
@@ -107,6 +107,7 @@ public class SwitchedToSoleFinalOrder implements CCDConfig<CaseData, State, User
             && OfflineWhoApplying.APPLICANT_2.equals(caseData.getFinalOrder().getD36WhoApplying())) {
 
             if (!caseData.getApplication().isPaperCase()) {
+                log.info("Request made via paper to switch to sole for online case id: {}", caseId);
                 switchToSoleService.switchUserRoles(caseData, caseId);
             }
             switchToSoleService.switchApplicantData(caseData);


### PR DESCRIPTION
### Change description ###

When a retry is triggered by CCD on a switch to sole event which was originally triggered by applicant2, the isApplicant2 check fails and no roles / data are swapped. We want to disable the retry to avoid this.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-3899