### PR TITLE
[NFDIV-3972] Only show contact details through the confidential tabs (PoC)

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/ApplicationTab.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/ApplicationTab.java
@@ -113,9 +113,6 @@ public class ApplicationTab implements CCDConfig<CaseData, State, UserRole> {
             .label("LabelApplicant1DetailsAreConfidential-Heading",
                 "applicant1ContactDetailsType=\"private\"",
                 "#### ${labelContentTheApplicantOrApplicant1UC}'s contact details are confidential")
-            .field("applicant1PhoneNumber", APPLICANT_1_CONTACT_DETAILS_PUBLIC)
-            .field("applicant1Email", APPLICANT_1_CONTACT_DETAILS_PUBLIC)
-            .field("applicant1Address", APPLICANT_1_CONTACT_DETAILS_PUBLIC)
             .field("applicant1CannotUpload")
             .field("applicant1CannotUploadSupportingDocument")
             .field("applicant1KnowsApplicant2Address",
@@ -170,9 +167,6 @@ public class ApplicationTab implements CCDConfig<CaseData, State, UserRole> {
             .label("LabelApplicant2DetailsAreConfidential-Heading",
                 "applicant2ContactDetailsType=\"private\"",
                 "#### ${labelContentTheApplicant2UC}'s contact details are confidential")
-            .field("applicant2PhoneNumber", APPLICANT_2_CONTACT_DETAILS_PUBLIC)
-            .field("applicant2Email", APPLICANT_2_CONTACT_DETAILS_PUBLIC)
-            .field("applicant2Address", APPLICANT_2_CONTACT_DETAILS_PUBLIC)
             .field("applicant2AgreedToReceiveEmails")
             .field("applicant2CannotUpload")
             .field("applicant2CannotUploadSupportingDocument")

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/ApplicationTab.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/ApplicationTab.java
@@ -14,8 +14,6 @@ import static uk.gov.hmcts.divorce.divorcecase.tab.TabShowCondition.notShowForSt
 @Component
 public class ApplicationTab implements CCDConfig<CaseData, State, UserRole> {
 
-    private static final String APPLICANT_1_CONTACT_DETAILS_PUBLIC = "applicant1ContactDetailsType!=\"private\"";
-    private static final String APPLICANT_2_CONTACT_DETAILS_PUBLIC = "applicant2ContactDetailsType!=\"private\"";
     private static final String NEVER_SHOW = "applicationType=\"NEVER_SHOW\"";
     private static final String JOINT_APPLICATION = "applicationType=\"jointApplication\"";
     private static final String SOLE_APPLICATION = "applicationType=\"soleApplication\"";

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
@@ -221,7 +221,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
 
     private void buildConfidentialApplicantTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("ConfidentialApplicant", "Confidential Applicant")
-            .forRoles(JUDGE)
+            .forRoles(CASE_WORKER, LEGAL_ADVISOR, JUDGE, APPLICANT_1_SOLICITOR, SUPER_USER)
             .field("applicant1PhoneNumber")
             .field("applicant1Email")
             .field("applicant1Address");

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
@@ -221,8 +221,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
 
     private void buildConfidentialApplicantTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("ConfidentialApplicant", "Confidential Applicant")
-            .forRoles(CASE_WORKER, LEGAL_ADVISOR, JUDGE, APPLICANT_1_SOLICITOR, SUPER_USER)
-            .showCondition("applicant1ContactDetailsType=\"private\"")
+            .forRoles(JUDGE)
             .field("applicant1PhoneNumber")
             .field("applicant1Email")
             .field("applicant1Address");
@@ -231,7 +230,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
     private void buildConfidentialRespondentTab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("ConfidentialRespondent", "Confidential Respondent")
             .forRoles(CASE_WORKER, LEGAL_ADVISOR, JUDGE, APPLICANT_2_SOLICITOR, SUPER_USER)
-            .showCondition("applicant2ContactDetailsType=\"private\" AND applicationType=\"soleApplication\"")
+            .showCondition("applicationType=\"soleApplication\"")
             .field("applicant2PhoneNumber")
             .field("applicant2Email")
             .field("applicant2Address");
@@ -240,7 +239,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
     private void buildConfidentialApplicant2Tab(ConfigBuilder<CaseData, State, UserRole> configBuilder) {
         configBuilder.tab("ConfidentialApplicant2", "Confidential Applicant 2")
             .forRoles(CASE_WORKER, LEGAL_ADVISOR, JUDGE, APPLICANT_2_SOLICITOR, SUPER_USER)
-            .showCondition("applicant2ContactDetailsType=\"private\" AND applicationType=\"jointApplication\"")
+            .showCondition("applicationType=\"jointApplication\"")
             .field("applicant2PhoneNumber")
             .field("applicant2Email")
             .field("applicant2Address");


### PR DESCRIPTION
### Change description ###
**NOTE:** I think the service team would like to keep the contact information within the application tab ([see my other PR](https://github.com/hmcts/nfdiv-case-api/pull/3702/files)) rather than merge this.

EXUI show conditions do not stop case fields from being included in the response that users receive, meaning that confidential addresses (controlled by show conditions in the application tab) can be viewed in browser developer tools. To stop this, we've removed information that may be confidential from the application tab and now only show it in the confidential tabs, which have role-based access. 
