### PR TITLE
[NFDIV-4139] Stop confidential address check when getting address for CO pronounced template variables

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/document/content/ConditionalOrderPronouncedTemplateContent.java
+++ b/src/main/java/uk/gov/hmcts/divorce/document/content/ConditionalOrderPronouncedTemplateContent.java
@@ -104,7 +104,7 @@ public class ConditionalOrderPronouncedTemplateContent implements TemplateConten
         } else {
             templateContent.put(CommonContent.NAME, join(" ", applicant.getFirstName(), applicant.getLastName()));
         }
-        templateContent.put(CommonContent.ADDRESS, applicant.getCorrespondenceAddress());
+        templateContent.put(CommonContent.ADDRESS, applicant.getCorrespondenceAddressWithoutConfidentialCheck());
 
         templateContent.put(DATE, LocalDate.now().format(DATE_TIME_FORMATTER));
         templateContent.put(PRONOUNCEMENT_DATE_PLUS_43,


### PR DESCRIPTION
### Change description ###

INC5627697 - it looks like we started doing a confidential check here by mistake in NFDIV-3878, which causes the address to be set as null in letters when a litigant is confidential.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-4139

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
