### PR TITLE
[NFDIV-4221] Set solicitor firm address during common component NoC

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/noticeofchange/event/SystemApplyNoticeOfChangeIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/noticeofchange/event/SystemApplyNoticeOfChangeIT.java
@@ -216,10 +216,13 @@ public class SystemApplyNoticeOfChangeIT {
 
         OrganisationsResponse organisationResponse = OrganisationsResponse.builder()
                 .organisationIdentifier(USER_IDENTIFIER)
+                .name(TEST_ORGANISATION_NAME)
                 .contactInformation(List.of(
-                    OrganisationContactInformation.builder().addressLine1(TEST_SOLICITOR_ADDRESS).build()
+                    OrganisationContactInformation.builder()
+                        .addressLine1(TEST_SOLICITOR_ADDRESS)
+                        .build()
                 ))
-                .name(TEST_ORGANISATION_NAME).build();
+            .build();
         FindUsersByOrganisationResponse findUsersByOrganisationResponse =
                 FindUsersByOrganisationResponse.builder().users(professionalUsers)
                         .organisationIdentifier(TEST_ORGANISATION_ID).build();

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/noticeofchange/event/SystemApplyNoticeOfChangeIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/noticeofchange/event/SystemApplyNoticeOfChangeIT.java
@@ -217,11 +217,6 @@ public class SystemApplyNoticeOfChangeIT {
         OrganisationsResponse organisationResponse = OrganisationsResponse.builder()
                 .organisationIdentifier(USER_IDENTIFIER)
                 .name(TEST_ORGANISATION_NAME)
-                .contactInformation(List.of(
-                    OrganisationContactInformation.builder()
-                        .addressLine1(TEST_SOLICITOR_ADDRESS)
-                        .build()
-                ))
             .build();
         FindUsersByOrganisationResponse findUsersByOrganisationResponse =
                 FindUsersByOrganisationResponse.builder().users(professionalUsers)

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/noticeofchange/event/SystemApplyNoticeOfChangeIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/noticeofchange/event/SystemApplyNoticeOfChangeIT.java
@@ -33,6 +33,7 @@ import uk.gov.hmcts.divorce.idam.User;
 import uk.gov.hmcts.divorce.noticeofchange.model.AcaRequest;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.FindUsersByOrganisationResponse;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationClient;
+import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationContactInformation;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationsResponse;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.ProfessionalUser;
 import uk.gov.hmcts.divorce.testutil.ManageCaseAssignmentWireMock;
@@ -62,6 +63,7 @@ import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_FIRST_NAME;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_LAST_NAME;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SERVICE_AUTH_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_ADDRESS;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_NAME;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.callbackRequest;
@@ -130,7 +132,14 @@ public class SystemApplyNoticeOfChangeIT {
                 .firstName(TEST_FIRST_NAME).lastName(TEST_LAST_NAME).userIdentifier(USER_IDENTIFIER).build());
 
         OrganisationsResponse organisationResponse = OrganisationsResponse.builder()
-                .organisationIdentifier(USER_IDENTIFIER).name(TEST_ORGANISATION_NAME).build();
+                .organisationIdentifier(USER_IDENTIFIER)
+                .name(TEST_ORGANISATION_NAME)
+                .contactInformation(List.of(
+                    OrganisationContactInformation.builder()
+                        .addressLine1(TEST_SOLICITOR_ADDRESS)
+                        .build()
+                ))
+                .build();
         FindUsersByOrganisationResponse findUsersByOrganisationResponse =
                 FindUsersByOrganisationResponse.builder().users(professionalUsers)
                         .organisationIdentifier(TEST_ORGANISATION_ID).build();
@@ -189,6 +198,8 @@ public class SystemApplyNoticeOfChangeIT {
                         .value(TEST_SOLICITOR_NAME))
                 .andExpect(jsonPath("$.data.applicant1SolicitorEmail")
                         .value(TEST_SOLICITOR_EMAIL))
+                .andExpect(jsonPath("$.data.applicant1SolicitorAddress")
+                        .value(TEST_SOLICITOR_ADDRESS))
                 .andExpect(jsonPath("$.data.applicant1SolicitorOrganisationPolicy.Organisation.OrganisationID")
                         .value(TEST_ORGANISATION_ID))
                 .andExpect(jsonPath("$.data.applicant1SolicitorOrganisationPolicy.Organisation.OrganisationName")
@@ -204,7 +215,11 @@ public class SystemApplyNoticeOfChangeIT {
                 .firstName(TEST_FIRST_NAME).lastName(TEST_LAST_NAME).userIdentifier(USER_IDENTIFIER).build());
 
         OrganisationsResponse organisationResponse = OrganisationsResponse.builder()
-                .organisationIdentifier(USER_IDENTIFIER).name(TEST_ORGANISATION_NAME).build();
+                .organisationIdentifier(USER_IDENTIFIER)
+                .contactInformation(List.of(
+                    OrganisationContactInformation.builder().addressLine1(TEST_SOLICITOR_ADDRESS).build()
+                ))
+                .name(TEST_ORGANISATION_NAME).build();
         FindUsersByOrganisationResponse findUsersByOrganisationResponse =
                 FindUsersByOrganisationResponse.builder().users(professionalUsers)
                         .organisationIdentifier(TEST_ORGANISATION_ID).build();

--- a/src/integrationTest/java/uk/gov/hmcts/divorce/testutil/ManageCaseAssignmentWireMock.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/testutil/ManageCaseAssignmentWireMock.java
@@ -36,6 +36,7 @@ import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.AUTHORIZATION;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.SERVICE_AUTHORIZATION;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_ADDRESS;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_NAME;
 
@@ -153,6 +154,7 @@ public final class ManageCaseAssignmentWireMock {
         Solicitor solicitor = Solicitor.builder()
                 .name(TEST_SOLICITOR_NAME)
                 .email(TEST_SOLICITOR_EMAIL)
+                .address(TEST_SOLICITOR_ADDRESS)
                 .organisationPolicy(OrganisationPolicy.<UserRole>builder().organisation(Organisation.builder()
                                 .organisationId(TEST_ORGANISATION_ID)
                                 .organisationName(TEST_ORGANISATION_NAME)

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Applicant.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Applicant.java
@@ -155,6 +155,7 @@ public class Applicant {
     private YesOrNo solicitorRepresented;
 
     @JsonUnwrapped(prefix = "Solicitor")
+    @CCD(access = {AcaSystemUserAccess.class})
     private Solicitor solicitor;
 
     @CCD(

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Solicitor.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/Solicitor.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.ccd.sdk.api.HasLabel;
 import uk.gov.hmcts.ccd.sdk.type.Organisation;
 import uk.gov.hmcts.ccd.sdk.type.OrganisationPolicy;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
-import uk.gov.hmcts.divorce.divorcecase.model.access.AcaSystemUserAccess;
 import uk.gov.hmcts.divorce.divorcecase.model.access.CaseworkerWithCAAAccess;
 import uk.gov.hmcts.divorce.divorcecase.model.access.OrganisationPolicyAccess;
 
@@ -40,7 +39,7 @@ public class Solicitor {
 
     @CCD(
         label = "Solicitor’s name",
-        access = {CaseworkerWithCAAAccess.class, AcaSystemUserAccess.class}
+        access = {CaseworkerWithCAAAccess.class}
     )
     private String name;
 
@@ -59,14 +58,12 @@ public class Solicitor {
 
     @CCD(
         label = "Solicitor’s Email",
-        typeOverride = Email,
-        access = {AcaSystemUserAccess.class}
+        typeOverride = Email
     )
     private String email;
 
     @CCD(
-        label = "Solicitor’s Firm Name",
-        access = {AcaSystemUserAccess.class}
+        label = "Solicitor’s Firm Name"
     )
     private String firmName;
 

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/util/SolicitorAddressPopulator.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/util/SolicitorAddressPopulator.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.divorce.divorcecase.util;
 
 import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationContactInformation;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
@@ -9,20 +10,22 @@ import static org.springframework.util.ObjectUtils.isEmpty;
 
 public final class SolicitorAddressPopulator {
 
+    private static final int ORGANISATION_ADDRESS_INDEX = 0;
+
     private SolicitorAddressPopulator() {
     }
 
-    public static String populateSolicitorAddress(
-        OrganisationContactInformation organisationContactInformation) {
+    public static String parseOrganisationAddress(List<OrganisationContactInformation> organisationContactInformation) {
+        OrganisationContactInformation orgAddress = organisationContactInformation.get(ORGANISATION_ADDRESS_INDEX);
 
         return Stream.of(
-            organisationContactInformation.getAddressLine1(),
-            organisationContactInformation.getAddressLine2(),
-            organisationContactInformation.getAddressLine3(),
-            organisationContactInformation.getTownCity(),
-            organisationContactInformation.getCounty(),
-            organisationContactInformation.getPostCode(),
-            organisationContactInformation.getCountry())
+            orgAddress.getAddressLine1(),
+                orgAddress.getAddressLine2(),
+                orgAddress.getAddressLine3(),
+                orgAddress.getTownCity(),
+                orgAddress.getCounty(),
+                orgAddress.getPostCode(),
+                orgAddress.getCountry())
             .filter(value -> !isEmpty(value))
             .collect(joining("\n"));
     }

--- a/src/main/java/uk/gov/hmcts/divorce/noticeofchange/service/ChangeOfRepresentativeService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/noticeofchange/service/ChangeOfRepresentativeService.java
@@ -100,15 +100,16 @@ public class ChangeOfRepresentativeService {
         applicant.setOffline(YesOrNo.NO);
     }
 
-    private void updateOrgPolicyAndSolicitorDetails(Solicitor applicantSolicitor, OrganisationsResponse nocRequestUserOrg,
+    private void updateOrgPolicyAndSolicitorDetails(Solicitor applicantSolicitor, OrganisationsResponse nocRequestingUserOrg,
                                                     ProfessionalUser nocRequestingUser, String loggedInUserEmail) {
 
         applicantSolicitor.setName(String.join(" ", nocRequestingUser.getFirstName(), nocRequestingUser.getLastName()));
         applicantSolicitor.setEmail(loggedInUserEmail);
-        applicantSolicitor.setFirmName(nocRequestUserOrg.getName());
+        applicantSolicitor.setFirmName(nocRequestingUserOrg.getName());
         applicantSolicitor.setAddress(
-            parseOrganisationAddress(nocRequestUserOrg.getContactInformation())
+            parseOrganisationAddress(nocRequestingUserOrg.getContactInformation())
         );
+        applicantSolicitor.setAgreeToReceiveEmailsCheckbox(Collections.emptySet());
         applicantSolicitor.setReference(null);
         applicantSolicitor.setAddressOverseas(null);
         applicantSolicitor.setPhone(null);

--- a/src/main/java/uk/gov/hmcts/divorce/noticeofchange/service/ChangeOfRepresentativeService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/noticeofchange/service/ChangeOfRepresentativeService.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.divorce.noticeofchange.model.ChangeOfRepresentative;
 import uk.gov.hmcts.divorce.noticeofchange.model.Representative;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.FindUsersByOrganisationResponse;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationClient;
+import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationContactInformation;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationsResponse;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.ProfessionalUser;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
@@ -24,6 +25,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
@@ -106,9 +108,14 @@ public class ChangeOfRepresentativeService {
         applicantSolicitor.setName(String.join(" ", nocRequestingUser.getFirstName(), nocRequestingUser.getLastName()));
         applicantSolicitor.setEmail(loggedInUserEmail);
         applicantSolicitor.setFirmName(nocRequestingUserOrg.getName());
-        applicantSolicitor.setAddress(
-            parseOrganisationAddress(nocRequestingUserOrg.getContactInformation())
-        );
+
+        List<OrganisationContactInformation> contactInformation = nocRequestingUserOrg.getContactInformation();
+        if (Objects.nonNull(contactInformation) && !contactInformation.isEmpty()) {
+            applicantSolicitor.setAddress(parseOrganisationAddress(contactInformation));
+        } else {
+            applicantSolicitor.setAddress(null);
+        }
+
         applicantSolicitor.setAgreeToReceiveEmailsCheckbox(Collections.emptySet());
         applicantSolicitor.setReference(null);
         applicantSolicitor.setAddressOverseas(null);

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/event/SolicitorSubmitJointApplication.java
@@ -38,7 +38,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.JUDGE;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
-import static uk.gov.hmcts.divorce.divorcecase.util.SolicitorAddressPopulator.populateSolicitorAddress;
+import static uk.gov.hmcts.divorce.divorcecase.util.SolicitorAddressPopulator.parseOrganisationAddress;
 import static uk.gov.hmcts.divorce.document.model.DocumentType.APPLICATION;
 
 @Slf4j
@@ -147,8 +147,7 @@ public class SolicitorSubmitJointApplication implements CCDConfig<CaseData, Stat
             .getContactInformation();
 
         if (!isEmpty(contactInformation)) {
-            final OrganisationContactInformation organisationContactInformation = contactInformation.get(0);
-            final String solicitorAddress = populateSolicitorAddress(organisationContactInformation);
+            final String solicitorAddress = parseOrganisationAddress(contactInformation);
 
             log.info("Setting Applicant 2 solicitor address.  Case ID: {}", caseDetails.getId());
             caseDetails.getData().getApplicant2().getSolicitor().setAddress(solicitorAddress);

--- a/src/main/java/uk/gov/hmcts/divorce/solicitor/service/task/SetApplicant1SolicitorAddress.java
+++ b/src/main/java/uk/gov/hmcts/divorce/solicitor/service/task/SetApplicant1SolicitorAddress.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.util.ObjectUtils.isEmpty;
-import static uk.gov.hmcts.divorce.divorcecase.util.SolicitorAddressPopulator.populateSolicitorAddress;
+import static uk.gov.hmcts.divorce.divorcecase.util.SolicitorAddressPopulator.parseOrganisationAddress;
 
 @Component
 @Slf4j
@@ -40,8 +40,7 @@ public class SetApplicant1SolicitorAddress implements CaseTask {
                 .getContactInformation();
 
             if (!isEmpty(contactInformation)) {
-                final OrganisationContactInformation organisationContactInformation = contactInformation.get(0);
-                final String solicitorAddress = populateSolicitorAddress(organisationContactInformation);
+                final String solicitorAddress = parseOrganisationAddress(contactInformation);
 
                 log.info("Setting Applicant 1 solicitor address.  Case ID: {}", caseDetails.getId());
                 caseDetails.getData().getApplicant1().getSolicitor().setAddress(solicitorAddress);

--- a/src/test/java/uk/gov/hmcts/divorce/noticeofchange/ChangeOfRepresentativeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/noticeofchange/ChangeOfRepresentativeServiceTest.java
@@ -130,6 +130,7 @@ class ChangeOfRepresentativeServiceTest {
         assertEquals(null, applicant2CaseData.getApplicant2().getSolicitor().getAddressOverseas());
         assertEquals(null, applicant2CaseData.getApplicant2().getSolicitor().getPhone());
         assertEquals(null, applicant2CaseData.getApplicant2().getSolicitor().getReference());
+        assertEquals(Collections.emptySet(), applicant2CaseData.getApplicant2().getSolicitor().getAgreeToReceiveEmailsCheckbox());
 
         assertTrue(applicant2CaseData.getApplicant2().isRepresented());
         assertFalse(applicant2CaseData.getApplicant2().isApplicantOffline());

--- a/src/test/java/uk/gov/hmcts/divorce/noticeofchange/ChangeOfRepresentativeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/noticeofchange/ChangeOfRepresentativeServiceTest.java
@@ -100,11 +100,11 @@ class ChangeOfRepresentativeServiceTest {
         when(organisationClient.getOrganisationUsers(TEST_AUTHORIZATION_TOKEN, TEST_SERVICE_AUTH_TOKEN, TEST_ORGANISATION_ID))
                 .thenReturn(findUsersByOrganisationResponse);
 
-        OrganisationContactInformation contactInformation = new OrganisationContactInformation();
-        contactInformation.setAddressLine1(TEST_SOLICITOR_ADDRESS);
         OrganisationsResponse organisationsResponse = OrganisationsResponse.builder()
             .name(TEST_ORGANISATION_NAME)
-            .contactInformation(List.of(contactInformation))
+            .contactInformation(List.of(
+                OrganisationContactInformation.builder().addressLine1(TEST_SOLICITOR_ADDRESS).build()
+            ))
             .build();
 
         when(organisationClient.getOrganisationByUserId(TEST_AUTHORIZATION_TOKEN, TEST_SERVICE_AUTH_TOKEN, TEST_ORGANISATION_USER_ID))

--- a/src/test/java/uk/gov/hmcts/divorce/noticeofchange/ChangeOfRepresentativeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/noticeofchange/ChangeOfRepresentativeServiceTest.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.divorce.idam.User;
 import uk.gov.hmcts.divorce.noticeofchange.service.ChangeOfRepresentativeService;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.FindUsersByOrganisationResponse;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationClient;
+import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationContactInformation;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.OrganisationsResponse;
 import uk.gov.hmcts.divorce.solicitor.client.organisation.ProfessionalUser;
 import uk.gov.hmcts.divorce.testutil.TestDataHelper;
@@ -54,6 +55,7 @@ import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_AUTHORIZATION_TOK
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_ORG_ID;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_ORG_NAME;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SERVICE_AUTH_TOKEN;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_ADDRESS;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_SOLICITOR_NAME;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.organisationPolicy;
@@ -98,7 +100,12 @@ class ChangeOfRepresentativeServiceTest {
         when(organisationClient.getOrganisationUsers(TEST_AUTHORIZATION_TOKEN, TEST_SERVICE_AUTH_TOKEN, TEST_ORGANISATION_ID))
                 .thenReturn(findUsersByOrganisationResponse);
 
-        OrganisationsResponse organisationsResponse = OrganisationsResponse.builder().name(TEST_ORGANISATION_NAME).build();
+        OrganisationContactInformation contactInformation = new OrganisationContactInformation();
+        contactInformation.setAddressLine1(TEST_SOLICITOR_ADDRESS);
+        OrganisationsResponse organisationsResponse = OrganisationsResponse.builder()
+            .name(TEST_ORGANISATION_NAME)
+            .contactInformation(List.of(contactInformation))
+            .build();
 
         when(organisationClient.getOrganisationByUserId(TEST_AUTHORIZATION_TOKEN, TEST_SERVICE_AUTH_TOKEN, TEST_ORGANISATION_USER_ID))
                 .thenReturn(organisationsResponse);
@@ -119,6 +126,11 @@ class ChangeOfRepresentativeServiceTest {
         assertEquals(TEST_ORG_ID, changeOfRepresentative.getRemovedRepresentative().getOrganisation().getOrganisationId());
         assertEquals(TEST_SOLICITOR_EMAIL, applicant2CaseData.getApplicant2().getSolicitor().getEmail());
         assertEquals(TEST_ORGANISATION_NAME, applicant2CaseData.getApplicant2().getSolicitor().getFirmName());
+        assertEquals(TEST_SOLICITOR_ADDRESS, applicant2CaseData.getApplicant2().getSolicitor().getAddress());
+        assertEquals(null, applicant2CaseData.getApplicant2().getSolicitor().getAddressOverseas());
+        assertEquals(null, applicant2CaseData.getApplicant2().getSolicitor().getPhone());
+        assertEquals(null, applicant2CaseData.getApplicant2().getSolicitor().getReference());
+
         assertTrue(applicant2CaseData.getApplicant2().isRepresented());
         assertFalse(applicant2CaseData.getApplicant2().isApplicantOffline());
         assertEquals("Respondent", changeOfRepresentative.getParty());


### PR DESCRIPTION
### Change description ###

Common component NoC update to start automatically populating the sol address and blanking out old sol details when the new sol is assigned to a case.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-4221

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
