### PR TITLE
[NFDIV-4255] New event to reset conditional order drafted and submitted flags

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerResetConditionalOrderFlags.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerResetConditionalOrderFlags.java
@@ -28,15 +28,16 @@ import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_R
 @RequiredArgsConstructor
 public class CaseworkerResetConditionalOrderFlags implements CCDConfig<CaseData, State, UserRole> {
     public static final String CASEWORKER_RESET_CONDITIONAL_ORDER = "caseworker-reset-conditional-order-flags";
+
     private static final String RESET_CONDITIONAL_ORDER = "Reset conditional order flags";
 
     private static final String DESCRIPTION_RESET_CONDITIONAL_ORDER_FLAGS = """
-        This event will reset the conditional order drafted and submitted flags on a case, making the draft conditional order event
-        available for the conditional order to be drafted a second time.
+        This event will reset the conditional order drafted and submitted flags, making the draft conditional order event
+        available again for the case to allow the conditional order to be drafted a second time.
         """;
 
     public static final String WARNING_RESET_CONDITIONAL_ORDER_FLAGS = """
-        ### WARNING: Only continue if you are certain the conditional order must be drafted a second time.
+        ### WARNING: Only continue if you are certain that the conditional order must be drafted again on this case.
         """;
 
     private final ResetConditionalOrderFlags resetConditionalOrderFlags;
@@ -54,7 +55,7 @@ public class CaseworkerResetConditionalOrderFlags implements CCDConfig<CaseData,
             .showEventNotes()
             .grant(CREATE_READ_UPDATE, SUPER_USER)
             .grantHistoryOnly(CASE_WORKER, SOLICITOR, LEGAL_ADVISOR, JUDGE))
-            .page("Reset conditional order flags")
+            .page(RESET_CONDITIONAL_ORDER)
             .pageLabel(RESET_CONDITIONAL_ORDER)
             .label("resetDescription", DESCRIPTION_RESET_CONDITIONAL_ORDER_FLAGS)
             .done();
@@ -64,7 +65,7 @@ public class CaseworkerResetConditionalOrderFlags implements CCDConfig<CaseData,
         final CaseDetails<CaseData, State> details,
         final CaseDetails<CaseData, State> beforeDetails) {
 
-        log.info("%s about to submit callback invoked: {}, Case Id: {}", CASEWORKER_RESET_CONDITIONAL_ORDER, details.getId());
+        log.info("{} about to submit callback invoked for case Id: {}", CASEWORKER_RESET_CONDITIONAL_ORDER, details.getId());
 
         final CaseDetails<CaseData, State> updatedCaseDetails = resetConditionalOrderFlags.apply(details);
 

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerResetConditionalOrderFlags.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerResetConditionalOrderFlags.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.divorce.caseworker.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
+import uk.gov.hmcts.divorce.common.service.task.ResetConditionalOrderFlags;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import java.util.Collections;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingConditionalOrder;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.JUDGE;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CaseworkerResetConditionalOrderFlags implements CCDConfig<CaseData, State, UserRole> {
+    public static final String CASEWORKER_RESET_CONDITIONAL_ORDER = "caseworker-reset-conditional-order-flags";
+    private static final String RESET_CONDITIONAL_ORDER = "Reset conditional order flags";
+
+    private static final String DESCRIPTION_RESET_CONDITIONAL_ORDER_FLAGS = """
+        This event will reset the conditional order drafted and submitted flags on a case, making the draft conditional order event
+        available for the conditional order to be drafted a second time.
+        """;
+
+    public static final String WARNING_RESET_CONDITIONAL_ORDER_FLAGS = """
+        ### WARNING: Only continue if you are certain the conditional order must be drafted a second time.
+        """;
+
+    private final ResetConditionalOrderFlags resetConditionalOrderFlags;
+
+    @Override
+    public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
+
+        new PageBuilder(configBuilder
+            .event(CASEWORKER_RESET_CONDITIONAL_ORDER)
+            .forState(AwaitingConditionalOrder)
+            .aboutToSubmitCallback(this::aboutToSubmit)
+            .name(RESET_CONDITIONAL_ORDER)
+            .description(RESET_CONDITIONAL_ORDER)
+            .showSummary()
+            .showEventNotes()
+            .grant(CREATE_READ_UPDATE, SUPER_USER)
+            .grantHistoryOnly(CASE_WORKER, SOLICITOR, LEGAL_ADVISOR, JUDGE))
+            .page("Reset conditional order flags")
+            .pageLabel(RESET_CONDITIONAL_ORDER)
+            .label("resetDescription", DESCRIPTION_RESET_CONDITIONAL_ORDER_FLAGS)
+            .done();
+    }
+
+    public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(
+        final CaseDetails<CaseData, State> details,
+        final CaseDetails<CaseData, State> beforeDetails) {
+
+        log.info("%s about to submit callback invoked: {}, Case Id: {}", CASEWORKER_RESET_CONDITIONAL_ORDER, details.getId());
+
+        final CaseDetails<CaseData, State> updatedCaseDetails = resetConditionalOrderFlags.apply(details);
+
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(updatedCaseDetails.getData())
+            .warnings(Collections.singletonList(WARNING_RESET_CONDITIONAL_ORDER_FLAGS))
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/ResetConditionalOrderFlags.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/ResetConditionalOrderFlags.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.divorce.common.service.task;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
+
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ResetConditionalOrderFlags implements CaseTask {
+    @Override
+    public CaseDetails<CaseData, State> apply(final CaseDetails<CaseData, State> caseDetails) {
+        log.info("Resetting conditional order flags for case id {} ", caseDetails.getId());
+
+        final CaseData data = caseDetails.getData();
+
+        data.getConditionalOrder().getConditionalOrderApplicant1Questions().setIsSubmitted(NO);
+        data.getConditionalOrder().getConditionalOrderApplicant1Questions().setIsDrafted(NO);
+        if (data.getApplicationType() != null && !data.getApplicationType().isSole()) {
+            data.getConditionalOrder().getConditionalOrderApplicant2Questions().setIsSubmitted(NO);
+            data.getConditionalOrder().getConditionalOrderApplicant2Questions().setIsDrafted(NO);
+        }
+
+        return caseDetails;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/divorce/common/service/task/ResetConditionalOrderFlags.java
+++ b/src/main/java/uk/gov/hmcts/divorce/common/service/task/ResetConditionalOrderFlags.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.divorce.common.service.task;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
@@ -11,7 +10,6 @@ import uk.gov.hmcts.divorce.divorcecase.task.CaseTask;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class ResetConditionalOrderFlags implements CaseTask {
     @Override

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerResetConditionalOrderFlagsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerResetConditionalOrderFlagsTest.java
@@ -1,0 +1,82 @@
+package uk.gov.hmcts.divorce.caseworker.event;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.divorce.common.service.task.ResetConditionalOrderFlags;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.divorce.caseworker.event.CaseworkerResetConditionalOrderFlags.CASEWORKER_RESET_CONDITIONAL_ORDER;
+import static uk.gov.hmcts.divorce.caseworker.event.CaseworkerResetConditionalOrderFlags.WARNING_RESET_CONDITIONAL_ORDER_FLAGS;
+import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingConditionalOrder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
+import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
+import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
+
+@ExtendWith(MockitoExtension.class)
+public class CaseworkerResetConditionalOrderFlagsTest {
+    @Mock
+    private ResetConditionalOrderFlags resetConditionalOrderFlags;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @InjectMocks
+    private CaseworkerResetConditionalOrderFlags caseworkerResetConditionalOrderFlags;
+
+    @Test
+    void shouldAddConfigurationToConfigBuilder() throws Exception {
+        final ConfigBuilderImpl<CaseData, State, UserRole> configBuilder = createCaseDataConfigBuilder();
+
+        caseworkerResetConditionalOrderFlags.configure(configBuilder);
+
+        assertThat(getEventsFrom(configBuilder).values())
+            .extracting(Event::getId)
+            .contains(CASEWORKER_RESET_CONDITIONAL_ORDER);
+    }
+
+    @Test
+    void shouldResetConditionalOrderFlagsByDelegatingToCaseTask() {
+        final var caseData = caseData();
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setId(TEST_CASE_ID);
+        caseDetails.setData(caseData);
+        caseDetails.setState(AwaitingConditionalOrder);
+
+        when(resetConditionalOrderFlags.apply(caseDetails)).thenReturn(caseDetails);
+
+        caseworkerResetConditionalOrderFlags.aboutToSubmit(caseDetails, caseDetails);
+
+        verify(resetConditionalOrderFlags).apply(caseDetails);
+    }
+
+    @Test
+    void shouldWarnUserWhenTheyTriggerTheEvent() {
+        final var caseData = caseData();
+        final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
+        caseDetails.setId(TEST_CASE_ID);
+        caseDetails.setData(caseData);
+        caseDetails.setState(AwaitingConditionalOrder);
+
+        when(resetConditionalOrderFlags.apply(caseDetails)).thenReturn(caseDetails);
+
+        var response = caseworkerResetConditionalOrderFlags.aboutToSubmit(caseDetails, caseDetails);
+
+        assertThat(response.getWarnings()).isEqualTo(Collections.singletonList(WARNING_RESET_CONDITIONAL_ORDER_FLAGS));
+        verify(resetConditionalOrderFlags).apply(caseDetails);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerResetConditionalOrderFlagsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerResetConditionalOrderFlagsTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.divorce.caseworker.event;
 
-import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,16 +23,12 @@ import static uk.gov.hmcts.divorce.caseworker.event.CaseworkerResetConditionalOr
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingConditionalOrder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
-import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseData;
 
 @ExtendWith(MockitoExtension.class)
 public class CaseworkerResetConditionalOrderFlagsTest {
     @Mock
     private ResetConditionalOrderFlags resetConditionalOrderFlags;
-
-    @Mock
-    private HttpServletRequest request;
 
     @InjectMocks
     private CaseworkerResetConditionalOrderFlags caseworkerResetConditionalOrderFlags;
@@ -53,7 +48,6 @@ public class CaseworkerResetConditionalOrderFlagsTest {
     void shouldResetConditionalOrderFlagsByDelegatingToCaseTask() {
         final var caseData = caseData();
         final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
-        caseDetails.setId(TEST_CASE_ID);
         caseDetails.setData(caseData);
         caseDetails.setState(AwaitingConditionalOrder);
 
@@ -68,7 +62,6 @@ public class CaseworkerResetConditionalOrderFlagsTest {
     void shouldWarnUserWhenTheyTriggerTheEvent() {
         final var caseData = caseData();
         final CaseDetails<CaseData, State> caseDetails = new CaseDetails<>();
-        caseDetails.setId(TEST_CASE_ID);
         caseDetails.setData(caseData);
         caseDetails.setState(AwaitingConditionalOrder);
 
@@ -77,6 +70,5 @@ public class CaseworkerResetConditionalOrderFlagsTest {
         var response = caseworkerResetConditionalOrderFlags.aboutToSubmit(caseDetails, caseDetails);
 
         assertThat(response.getWarnings()).isEqualTo(Collections.singletonList(WARNING_RESET_CONDITIONAL_ORDER_FLAGS));
-        verify(resetConditionalOrderFlags).apply(caseDetails);
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/common/service/task/ResetConditionalOrderFlagsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/service/task/ResetConditionalOrderFlagsTest.java
@@ -27,10 +27,7 @@ class ResetConditionalOrderFlagsTest {
             .applicationType(ApplicationType.SOLE_APPLICATION)
             .conditionalOrder(ConditionalOrder.builder()
                 .conditionalOrderApplicant1Questions(
-                    ConditionalOrderQuestions.builder()
-                        .isDrafted(YesOrNo.YES)
-                        .isSubmitted(YesOrNo.YES)
-                        .build()
+                    completedConditionalOrderQuestions()
                 ).build()
             ).build();
 
@@ -54,16 +51,10 @@ class ResetConditionalOrderFlagsTest {
             .applicationType(ApplicationType.JOINT_APPLICATION)
             .conditionalOrder(ConditionalOrder.builder()
                 .conditionalOrderApplicant1Questions(
-                    ConditionalOrderQuestions.builder()
-                        .isDrafted(YesOrNo.YES)
-                        .isSubmitted(YesOrNo.YES)
-                        .build()
+                    completedConditionalOrderQuestions()
                 )
                 .conditionalOrderApplicant2Questions(
-                    ConditionalOrderQuestions.builder()
-                        .isDrafted(YesOrNo.YES)
-                        .isSubmitted(YesOrNo.YES)
-                        .build()
+                    completedConditionalOrderQuestions()
                 ).build()
             ).build();
 
@@ -74,7 +65,7 @@ class ResetConditionalOrderFlagsTest {
         resetConditionalOrderFlags.apply(caseDetails);
 
         final ConditionalOrderQuestions app1CoQuestions = caseData.getConditionalOrder().getConditionalOrderApplicant1Questions();
-        final ConditionalOrderQuestions app2CoQuestions = caseData.getConditionalOrder().getConditionalOrderApplicant1Questions();
+        final ConditionalOrderQuestions app2CoQuestions = caseData.getConditionalOrder().getConditionalOrderApplicant2Questions();
 
         assertAll(
             () -> assertEquals(YesOrNo.NO, app1CoQuestions.getIsDrafted()),
@@ -82,5 +73,12 @@ class ResetConditionalOrderFlagsTest {
             () -> assertEquals(YesOrNo.NO, app2CoQuestions.getIsDrafted()),
             () -> assertEquals(YesOrNo.NO, app2CoQuestions.getIsSubmitted())
         );
+    }
+
+    private ConditionalOrderQuestions completedConditionalOrderQuestions() {
+        return ConditionalOrderQuestions.builder()
+            .isDrafted(YesOrNo.YES)
+            .isSubmitted(YesOrNo.YES)
+            .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/divorce/common/service/task/ResetConditionalOrderFlagsTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/common/service/task/ResetConditionalOrderFlagsTest.java
@@ -1,0 +1,86 @@
+package uk.gov.hmcts.divorce.common.service.task;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
+import uk.gov.hmcts.divorce.divorcecase.model.ApplicationType;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrder;
+import uk.gov.hmcts.divorce.divorcecase.model.ConditionalOrderQuestions;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ResetConditionalOrderFlagsTest {
+    private ResetConditionalOrderFlags resetConditionalOrderFlags;
+
+    @BeforeEach
+    void setUp() {
+        resetConditionalOrderFlags = new ResetConditionalOrderFlags();
+    }
+
+    @Test
+    void resetsConditionalOrderFlagsForSoleCases() {
+        final CaseData caseData = CaseData.builder()
+            .applicationType(ApplicationType.SOLE_APPLICATION)
+            .conditionalOrder(ConditionalOrder.builder()
+                .conditionalOrderApplicant1Questions(
+                    ConditionalOrderQuestions.builder()
+                        .isDrafted(YesOrNo.YES)
+                        .isSubmitted(YesOrNo.YES)
+                        .build()
+                ).build()
+            ).build();
+
+        final CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder()
+            .data(caseData)
+            .build();
+
+        resetConditionalOrderFlags.apply(caseDetails);
+
+        final ConditionalOrderQuestions app1CoQuestions = caseData.getConditionalOrder().getConditionalOrderApplicant1Questions();
+
+        assertAll(
+            () -> assertEquals(YesOrNo.NO, app1CoQuestions.getIsDrafted()),
+            () -> assertEquals(YesOrNo.NO, app1CoQuestions.getIsSubmitted())
+        );
+    }
+
+    @Test
+    void resetsConditionalOrderFlagsForJointCases() {
+        final CaseData caseData = CaseData.builder()
+            .applicationType(ApplicationType.JOINT_APPLICATION)
+            .conditionalOrder(ConditionalOrder.builder()
+                .conditionalOrderApplicant1Questions(
+                    ConditionalOrderQuestions.builder()
+                        .isDrafted(YesOrNo.YES)
+                        .isSubmitted(YesOrNo.YES)
+                        .build()
+                )
+                .conditionalOrderApplicant2Questions(
+                    ConditionalOrderQuestions.builder()
+                        .isDrafted(YesOrNo.YES)
+                        .isSubmitted(YesOrNo.YES)
+                        .build()
+                ).build()
+            ).build();
+
+        final CaseDetails<CaseData, State> caseDetails = CaseDetails.<CaseData, State>builder()
+            .data(caseData)
+            .build();
+
+        resetConditionalOrderFlags.apply(caseDetails);
+
+        final ConditionalOrderQuestions app1CoQuestions = caseData.getConditionalOrder().getConditionalOrderApplicant1Questions();
+        final ConditionalOrderQuestions app2CoQuestions = caseData.getConditionalOrder().getConditionalOrderApplicant1Questions();
+
+        assertAll(
+            () -> assertEquals(YesOrNo.NO, app1CoQuestions.getIsDrafted()),
+            () -> assertEquals(YesOrNo.NO, app1CoQuestions.getIsSubmitted()),
+            () -> assertEquals(YesOrNo.NO, app2CoQuestions.getIsDrafted()),
+            () -> assertEquals(YesOrNo.NO, app2CoQuestions.getIsSubmitted())
+        );
+    }
+}


### PR DESCRIPTION
### Change description ###

We've been asked to introduce a new event for caseworkers/superusers to reset conditional order flags. This will allow them to prepare the case data for submission of a second conditional order.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-4255

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
