### PR TITLE
[NFDIV-4291] Use correct product and component names in nightly CI

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,11 @@
   "extends": [
     "local>hmcts/.github:renovate-config",
     "local>hmcts/.github//renovate/automerge-all"
+  ],
+  "packageRules": [
+    {
+      "packageNames": ["com.github.hmcts:fortify-client"],
+      "enabled": false
+    }
   ]
 }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -8,8 +8,8 @@ properties([
 @Library("Infrastructure")
 
 def type = "java"
-def product = "rpe"
-def component = "spring-boot-template"
+def product = "nfdiv"
+def component = "case-api"
 
 withNightlyPipeline(type, product, component) {
   enableFortifyScan()

--- a/build.gradle
+++ b/build.gradle
@@ -311,7 +311,7 @@ dependencies {
   testImplementation group: 'io.rest-assured', name: 'rest-assured'
   testImplementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '3.0.3'
   testImplementation group: 'org.simplify4u', name: 'slf4j2-mock', version: '2.3.0'
-  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.4'
+  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.3:all'
 
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -311,7 +311,7 @@ dependencies {
   testImplementation group: 'io.rest-assured', name: 'rest-assured'
   testImplementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '3.0.3'
   testImplementation group: 'org.simplify4u', name: 'slf4j2-mock', version: '2.3.0'
-  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.3:all'
+  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.3'
 
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath


### PR DESCRIPTION
### Change description ###

Corrections to nightly CI config to get Fortify scans to work. Fortify client has also been downgraded to a version that is compatible with Java 17

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-4291

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
