### PR TITLE
[NFDIV-4326] Update log4j to 2.24.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,8 +252,9 @@ dependencies {
 // uncomment for local version
 // implementation group: 'com.github.hmcts', name: 'ccd-config-generator', version: 'DEV-SNAPSHOT'
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.0'
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.23.1'
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.23.1'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.24.0'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.24.0'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.24.0'
   implementation group: 'com.google.guava', name: 'guava', version: '33.3.0-jre'
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson


### PR DESCRIPTION
### Change description ###

Dependabot tried to update log4j-api and log4j-to-slf4j to v2.24.0 this morning, which resulted in errors in the logs every time a cron started. I've reproduced the issue locally and it seems to be caused by dependencies which use old versions of log4j-core and specifying a version for log4j-core that's compatible with the other log4j dependencies avoids the errors

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-4326

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
