### PR TITLE
NFDIV-4289 Update to Caseworker Response to service application

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerResponseToServiceApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerResponseToServiceApplication.java
@@ -10,17 +10,19 @@ import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
 import uk.gov.hmcts.divorce.divorcecase.model.AlternativeService;
 import uk.gov.hmcts.divorce.divorcecase.model.AlternativeServiceType;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
-import uk.gov.hmcts.divorce.divorcecase.model.CaseDocuments;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import static java.util.Objects.isNull;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static uk.gov.hmcts.divorce.divorcecase.model.AlternativeServiceType.DEEMED;
 import static uk.gov.hmcts.divorce.divorcecase.model.AlternativeServiceType.DISPENSED;
+import static uk.gov.hmcts.divorce.divorcecase.model.CaseDocuments.addDocumentToTop;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AosOverdue;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingAos;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingBailiffReferral;
@@ -40,6 +42,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_R
 public class CaseworkerResponseToServiceApplication implements CCDConfig<CaseData, State, UserRole> {
     public static final String CASEWORKER_RESPONSE_TO_SERVICE_APPLICATION = "caseworker-response-to-service-application";
     private static final String ALTERNATIVE_SERVICE_TYPE_NULL_ERROR = "Please set the alternative service type before using this event";
+    private static final int MAX_ATTACHMENTS_PER_APP = 5;
 
     @Override
     public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
@@ -54,15 +57,13 @@ public class CaseworkerResponseToServiceApplication implements CCDConfig<CaseDat
             .grant(CREATE_READ_UPDATE, CASE_WORKER)
             .grant(CREATE_READ_UPDATE_DELETE, SUPER_USER)
             .grantHistoryOnly(LEGAL_ADVISOR, SOLICITOR, JUDGE))
-            .page("uploadDocument")
+            .page("uploadDocument", this::midEvent)
             .pageLabel("Upload document")
             .complex(CaseData::getAlternativeService)
             .mandatory(AlternativeService::getAlternativeServiceType)
             .mandatory(AlternativeService::getReceivedServiceApplicationDate)
             .mandatory(AlternativeService::getAlternativeServiceJudgeOrLegalAdvisorDetails)
-            .done()
-            .complex(CaseData::getDocuments)
-                .optional(CaseDocuments::getDocumentsUploaded)
+            .optional(AlternativeService::getServiceApplicationDocuments)
             .done();
     }
 
@@ -90,13 +91,39 @@ public class CaseworkerResponseToServiceApplication implements CCDConfig<CaseDat
         return AboutToStartOrSubmitResponse.<CaseData, State>builder().build();
     }
 
+    public AboutToStartOrSubmitResponse<CaseData, State> midEvent(
+        CaseDetails<CaseData, State> details,
+        CaseDetails<CaseData, State> detailsBefore
+    ) {
+        CaseData caseData = details.getData();
+        List<String> errors = new ArrayList<>();
+
+        AlternativeService altService = caseData.getAlternativeService();
+        if (isNotEmpty(altService.getServiceApplicationDocuments())
+            && altService.getServiceApplicationDocuments().size() > MAX_ATTACHMENTS_PER_APP) {
+            errors.add("Exceeds allowed number of document attachments");
+        }
+
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .errors(errors)
+            .build();
+    }
+
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(final CaseDetails<CaseData, State> details,
                                                                        final CaseDetails<CaseData, State> beforeDetails) {
 
         log.info("Caseworker response to service application about to submit callback invoked for Case Id: {}", details.getId());
 
         CaseData caseData = details.getData();
-        AlternativeServiceType altServiceType = caseData.getAlternativeService().getAlternativeServiceType();
+        AlternativeService altService = caseData.getAlternativeService();
+        AlternativeServiceType altServiceType = altService.getAlternativeServiceType();
+
+        if (isNotEmpty(altService.getServiceApplicationDocuments())) {
+            altService.getServiceApplicationDocuments().forEach(divorceDocumentListValue -> {
+                caseData.getDocuments().setDocumentsUploaded(
+                    addDocumentToTop(caseData.getDocuments().getDocumentsUploaded(), divorceDocumentListValue.getValue()));
+            });
+        }
 
         State state;
         if (DEEMED.equals(altServiceType) || DISPENSED.equals(altServiceType)) {

--- a/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerResponseToServiceApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/caseworker/event/CaseworkerResponseToServiceApplication.java
@@ -95,13 +95,14 @@ public class CaseworkerResponseToServiceApplication implements CCDConfig<CaseDat
         CaseDetails<CaseData, State> details,
         CaseDetails<CaseData, State> detailsBefore
     ) {
+        log.info("Caseworker response to service application midEvent callback invoked for Case Id: {}", details.getId());
         CaseData caseData = details.getData();
         List<String> errors = new ArrayList<>();
 
         AlternativeService altService = caseData.getAlternativeService();
         if (isNotEmpty(altService.getServiceApplicationDocuments())
             && altService.getServiceApplicationDocuments().size() > MAX_ATTACHMENTS_PER_APP) {
-            errors.add("Exceeds allowed number of document attachments");
+            errors.add(String.format("Maximum supported uploads is %s", MAX_ATTACHMENTS_PER_APP));
         }
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/AlternativeService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/model/AlternativeService.java
@@ -8,11 +8,15 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.divorcecase.model.access.CaseworkerAccessOnlyAccess;
+import uk.gov.hmcts.divorce.document.model.DivorceDocument;
 
 import java.time.LocalDate;
+import java.util.List;
 
+import static uk.gov.hmcts.ccd.sdk.type.FieldType.Collection;
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.Date;
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.FixedList;
 import static uk.gov.hmcts.ccd.sdk.type.FieldType.FixedRadioList;
@@ -104,6 +108,13 @@ public class AlternativeService {
     @Builder.Default
     @CCD(access = {CaseworkerAccessOnlyAccess.class})
     private FeeDetails servicePaymentFee = new FeeDetails();
+
+    @CCD(
+        label = "Supporting Documents",
+        typeOverride = Collection,
+        typeParameterOverride = "DivorceDocument"
+    )
+    private List<ListValue<DivorceDocument>> serviceApplicationDocuments;
 
     @SuppressWarnings("PMD")
     @JsonIgnore

--- a/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
+++ b/src/main/java/uk/gov/hmcts/divorce/divorcecase/tab/CaseTypeTab.java
@@ -367,6 +367,7 @@ public class CaseTypeTab implements CCDConfig<CaseData, State, UserRole> {
             .field("receivedServiceAddedDate")
             .field("alternativeServiceType")
             .field("alternativeServiceJudgeOrLegalAdvisorDetails")
+            .field("serviceApplicationDocuments", "serviceApplicationDocuments=\"*\"")
             .field("alternativeServiceFeeRequired")
             .field("servicePaymentFeePaymentMethod", "servicePaymentFeePaymentMethod=\"*\" AND alternativeServiceFeeRequired=\"Yes\"")
             .field("dateOfPayment", "servicePaymentFeePaymentMethod=\"*\" AND alternativeServiceFeeRequired=\"Yes\"")

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/CaseworkerResponseToServiceApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/CaseworkerResponseToServiceApplicationTest.java
@@ -229,7 +229,7 @@ class CaseworkerResponseToServiceApplicationTest {
 
         assertThat(response.getErrors()).isNotEmpty();
         assertThat(response.getErrors()).hasSize(1);
-        assertThat(response.getErrors()).contains("Exceeds allowed number of document attachments");
+        assertThat(response.getErrors()).contains("Maximum supported uploads is 5");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/caseworker/CaseworkerResponseToServiceApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/caseworker/CaseworkerResponseToServiceApplicationTest.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.Document;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.divorce.caseworker.event.CaseworkerResponseToServiceApplication;
 import uk.gov.hmcts.divorce.divorcecase.model.AlternativeService;
@@ -15,9 +16,12 @@ import uk.gov.hmcts.divorce.divorcecase.model.AlternativeServiceOutcome;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.divorce.document.model.DivorceDocument;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.divorce.caseworker.event.CaseworkerResponseToServiceApplication.CASEWORKER_RESPONSE_TO_SERVICE_APPLICATION;
@@ -203,5 +207,88 @@ class CaseworkerResponseToServiceApplicationTest {
 
         assertThat(response.getErrors().size()).isEqualTo(1);
         assertThat(response.getErrors().get(0)).isEqualTo(ALTERNATIVE_SERVICE_TYPE_NULL_ERROR);
+    }
+
+    @Test
+    void shouldReturnErrorIfAttachedDocumentsExceedsMaxNumberAllowed() {
+
+        CaseData caseData = CaseData.builder()
+            .alternativeService(AlternativeService
+                .builder()
+                .alternativeServiceType(DISPENSED)
+                .serviceApplicationDocuments(getListOfDivorceDocument(6))
+                .build())
+            .build();
+
+        final CaseDetails<CaseData, State> details = new CaseDetails<>();
+        details.setData(caseData);
+        details.setId(TEST_CASE_ID);
+        details.setCreatedDate(LOCAL_DATE_TIME);
+
+        AboutToStartOrSubmitResponse<CaseData, State> response = caseworkerResponseToServiceApplication.midEvent(details, details);
+
+        assertThat(response.getErrors()).isNotEmpty();
+        assertThat(response.getErrors()).hasSize(1);
+        assertThat(response.getErrors()).contains("Exceeds allowed number of document attachments");
+    }
+
+    @Test
+    void shouldNotReturnErrorIfAttachedDocumentsIsWithinMaxNumberAllowed() {
+
+        CaseData caseData = CaseData.builder()
+            .alternativeService(AlternativeService
+                .builder()
+                .alternativeServiceType(DISPENSED)
+                .serviceApplicationDocuments(getListOfDivorceDocument(2))
+                .build())
+            .build();
+
+        final CaseDetails<CaseData, State> details = new CaseDetails<>();
+        details.setData(caseData);
+        details.setId(TEST_CASE_ID);
+        details.setCreatedDate(LOCAL_DATE_TIME);
+
+        AboutToStartOrSubmitResponse<CaseData, State> response = caseworkerResponseToServiceApplication.midEvent(details, details);
+
+        assertThat(response.getErrors()).isEmpty();
+    }
+
+    @Test
+    void shouldAddAttachedDocumentsToCaseDocuments() {
+        CaseData caseData = CaseData.builder()
+            .alternativeService(AlternativeService
+                .builder()
+                .alternativeServiceType(DISPENSED)
+                .serviceApplicationDocuments(getListOfDivorceDocument(2))
+                .build())
+            .build();
+
+        final CaseDetails<CaseData, State> details = new CaseDetails<>();
+        details.setData(caseData);
+        details.setId(TEST_CASE_ID);
+        details.setCreatedDate(LOCAL_DATE_TIME);
+
+        AboutToStartOrSubmitResponse<CaseData, State> response = caseworkerResponseToServiceApplication.aboutToSubmit(
+            details,
+            CaseDetails.<CaseData, State>builder().build()
+        );
+
+        assertThat(response.getData().getDocuments().getDocumentsUploaded().size()).isEqualTo(2);
+    }
+
+    private List<ListValue<DivorceDocument>> getListOfDivorceDocument(int size) {
+        List<ListValue<DivorceDocument>> docList = new ArrayList<>();
+        while (size > 0) {
+            ListValue<DivorceDocument> documentListValue = new ListValue<>(
+                UUID.randomUUID().toString(),
+                DivorceDocument
+                    .builder()
+                    .documentLink(Document.builder().filename("dummy.file").build())
+                    .build()
+            );
+            docList.add(documentListValue);
+            size--;
+        }
+        return docList;
     }
 }


### PR DESCRIPTION
### Change description ###

The entire collection of uploaded documents (linked to the case) was displayed in the event, allowing caseworker to add or delete. CTSC has requested to remove this and allow upload of max 5 documents as part of this event.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-4289