### PR TITLE
[NFDIV-4433] Set missing order summaries for cases in awaiting payment

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenSubmitApplicationIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/divorce/citizen/event/CitizenSubmitApplicationIT.java
@@ -13,7 +13,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.hmcts.ccd.sdk.type.OrderSummary;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.config.WebMvcConfig;
 import uk.gov.hmcts.divorce.common.config.interceptors.RequestInterceptor;
@@ -167,7 +166,6 @@ public class CitizenSubmitApplicationIT {
         stubForFeesNotFound();
 
         CaseData caseData = validApplicant1CaseData();
-        caseData.getApplication().setApplicationFeeOrderSummary(OrderSummary.builder().paymentTotal("55000").build());
 
         mockMvc.perform(post(ABOUT_TO_SUBMIT_URL)
                 .contentType(APPLICATION_JSON)

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenCreateServiceRequest.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenCreateServiceRequest.java
@@ -47,9 +47,9 @@ public class CitizenCreateServiceRequest implements CCDConfig<CaseData, State, U
         final State state = details.getState();
 
         if (AwaitingPayment.equals(state)) {
-            citizenSubmit.setServiceRequestReferenceForApplicationPayment(details.getData(), details.getId());
+            citizenSubmit.setOrderSummaryAndServiceRequestForApplicationPayment(details.getData(), details.getId());
         } else if (AwaitingFinalOrderPayment.equals(state)) {
-            respondentApplyForFinalOrder.setServiceRequestReferenceForFinalOrderPayment(details.getData(), details.getId());
+            respondentApplyForFinalOrder.setOrderSummaryAndServiceRequestForFinalOrderPayment(details.getData(), details.getId());
         }
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenSubmitApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenSubmitApplication.java
@@ -108,7 +108,7 @@ public class CitizenSubmitApplication implements CCDConfig<CaseData, State, User
 
         if (application.getApplicationFeeOrderSummary() == null) {
             OrderSummary orderSummary = paymentService.getOrderSummaryByServiceEvent(SERVICE_DIVORCE,
-            EVENT_ISSUE,KEYWORD_DIVORCE);
+                EVENT_ISSUE,KEYWORD_DIVORCE);
             application.setApplicationFeeOrderSummary(orderSummary);
         }
 

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenSubmitApplication.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/CitizenSubmitApplication.java
@@ -89,11 +89,7 @@ public class CitizenSubmitApplication implements CCDConfig<CaseData, State, User
             data = submittedDetails.getData();
             state = submittedDetails.getState();
         } else {
-            OrderSummary orderSummary = paymentService.getOrderSummaryByServiceEvent(SERVICE_DIVORCE,
-                EVENT_ISSUE,KEYWORD_DIVORCE);
-            application.setApplicationFeeOrderSummary(orderSummary);
-
-            setServiceRequestReferenceForApplicationPayment(data, details.getId());
+            setOrderSummaryAndServiceRequestForApplicationPayment(data, details.getId());
 
             state = AwaitingPayment;
         }
@@ -107,8 +103,14 @@ public class CitizenSubmitApplication implements CCDConfig<CaseData, State, User
             .build();
     }
 
-    public void setServiceRequestReferenceForApplicationPayment(CaseData data, long caseId) {
+    public void setOrderSummaryAndServiceRequestForApplicationPayment(CaseData data, long caseId) {
         final Application application = data.getApplication();
+
+        if (application.getApplicationFeeOrderSummary() == null) {
+            OrderSummary orderSummary = paymentService.getOrderSummaryByServiceEvent(SERVICE_DIVORCE,
+            EVENT_ISSUE,KEYWORD_DIVORCE);
+            application.setApplicationFeeOrderSummary(orderSummary);
+        }
 
         final String serviceRequestReference = paymentService.createServiceRequestReference(
             data.getCitizenPaymentCallbackUrl(),

--- a/src/main/java/uk/gov/hmcts/divorce/citizen/event/RespondentApplyForFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/citizen/event/RespondentApplyForFinalOrder.java
@@ -99,24 +99,26 @@ public class RespondentApplyForFinalOrder implements CCDConfig<CaseData, State, 
     ) {
         log.info("Setting Order Summary for Respondent Final Order for Case Id: {}", details.getId());
 
-        final OrderSummary orderSummary = paymentService.getOrderSummaryByServiceEvent(SERVICE_OTHER, EVENT_GENERAL, KEYWORD_NOTICE);
-        finalOrder.setApplicant2FinalOrderFeeOrderSummary(orderSummary);
-
-        finalOrder.setApplicant2FinalOrderFeeInPounds(
-            NumberFormat.getNumberInstance().format(new BigDecimal(
-                orderSummary.getPaymentTotal()).movePointLeft(2)
-            )
-        );
-
         details.setState(AwaitingFinalOrderPayment);
 
-        setServiceRequestReferenceForFinalOrderPayment(details.getData(), details.getId());
+        setOrderSummaryAndServiceRequestForFinalOrderPayment(details.getData(), details.getId());
 
         return details;
     }
 
-    public void setServiceRequestReferenceForFinalOrderPayment(CaseData data, long caseId) {
+    public void setOrderSummaryAndServiceRequestForFinalOrderPayment(CaseData data, long caseId) {
         final FinalOrder finalOrder = data.getFinalOrder();
+
+        if (finalOrder.getApplicant2FinalOrderFeeOrderSummary() == null) {
+            final OrderSummary orderSummary = paymentService.getOrderSummaryByServiceEvent(SERVICE_OTHER, EVENT_GENERAL, KEYWORD_NOTICE);
+            finalOrder.setApplicant2FinalOrderFeeOrderSummary(orderSummary);
+
+            finalOrder.setApplicant2FinalOrderFeeInPounds(
+                NumberFormat.getNumberInstance().format(new BigDecimal(
+                    orderSummary.getPaymentTotal()).movePointLeft(2)
+                )
+            );
+        }
 
         final String serviceRequestReference = paymentService.createServiceRequestReference(
             data.getCitizenPaymentCallbackUrl(),

--- a/src/test/java/uk/gov/hmcts/divorce/citizen/event/CitizenCreateServiceRequestTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/citizen/event/CitizenCreateServiceRequestTest.java
@@ -55,7 +55,7 @@ class CitizenCreateServiceRequestTest {
 
         citizenCreateServiceRequest.aboutToSubmit(caseDetails, caseDetails);
 
-        verify(citizenSubmitApplication).setServiceRequestReferenceForApplicationPayment(caseData, caseId);
+        verify(citizenSubmitApplication).setOrderSummaryAndServiceRequestForApplicationPayment(caseData, caseId);
     }
 
     @Test
@@ -70,6 +70,6 @@ class CitizenCreateServiceRequestTest {
 
         citizenCreateServiceRequest.aboutToSubmit(caseDetails, caseDetails);
 
-        verify(respondentApplyForFinalOrder).setServiceRequestReferenceForFinalOrderPayment(caseData, caseId);
+        verify(respondentApplyForFinalOrder).setOrderSummaryAndServiceRequestForFinalOrderPayment(caseData, caseId);
     }
 }


### PR DESCRIPTION
### Change description ###

Order summary is required to create a service request and send the request that takes payment in our frontend. The order summary is usually set on application submit (before a case moves to AwaitingPayment), but is missing from some cases due to use of return to previous state. This PR updates citizen-create-service-request, to also set up the order summary if it is missing.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-4433

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
