### PR TITLE
NFDIV-4430 - Introduce workflow to mark PRs and issues as stale or closed

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '0 3 * * *' # Runs at 3AM every day
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          close-issue-message: >
+            This issue has been automatically closed because it has been stalled for 2 days
+            with no activity.
+          close-pr-message: >
+            This issue has been automatically closed because it has been stalled for 2 days
+            with no activity.
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          days-before-close: '2'
+          days-before-stale: '12'
+          exempt-pr-labels: 'pinned,dependencies'
+          debug-only: 'true'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,9 +5,9 @@
 # https://github.com/actions/stale
 name: Mark stale issues and pull requests
 
-on:
-  schedule:
-    - cron: '0 3 * * *' # Runs at 3AM every day
+on: workflow_dispatch
+  #schedule:
+  #  - cron: '0 3 * * *' # Runs at 3AM every day
 
 jobs:
   stale:


### PR DESCRIPTION
### Change description ###

This introduces a new workflow to the repository to mark PRs and issues as stale after 12 days of inactivity and closed after further 2 days (in case of continued inactivity). Currently configured to run in debug mode only.
Certain labels (such as 'dependencies') will exempt PR from inclusion in the workflow.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-4430

