### PR TITLE
[NFDIV-4683] Make renovate ignore cft lib and downgrade to version compatible with Java 17

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
   ],
   "packageRules": [
     {
-      "packageNames": ["com.github.hmcts:fortify-client"],
+      "packageNames": ["com.github.hmcts:fortify-client", "com.github.hmcts.rse-cft-lib"],
       "enabled": false
     }
   ]

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
   id 'org.springframework.boot' version '3.3.5'
   id 'com.github.ben-manes.versions' version '0.52.0'
   id 'hmcts.ccd.sdk' version '5.5.16'
-  id 'com.github.hmcts.rse-cft-lib' version '0.19.1580'
+  id 'com.github.hmcts.rse-cft-lib' version '0.19.1573'
 }
 
 apply plugin: 'cz.habarta.typescript-generator'


### PR DESCRIPTION
### Change description ###
Newer versions of cft lib are only compatible with Java 21. We need to stop renovate auto-upgrading until case-api has been upgraded from Java 17 to 21.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/NFDIV-4683

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
