### PR TITLE
[NFDIV-5069] Make crons resilient to ElasticSearch outages

### DIFF
--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemAlertApplicationNotReviewed.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemAlertApplicationNotReviewed.java
@@ -48,7 +48,7 @@ public class SystemAlertApplicationNotReviewed implements CCDConfig<CaseData, St
                                                                        CaseDetails<CaseData, State> beforeDetails) {
         CaseData data = details.getData();
         Application application = data.getApplication();
-        if (application != null && YesOrNo.YES.equals(application.getOverdueNotificationSent())) {
+        if (YesOrNo.YES.equals(application.getOverdueNotificationSent())) {
             return AboutToStartOrSubmitResponse.<CaseData, State>builder()
                 .errors(List.of(CASE_ALREADY_PROCESSED_ERROR))
                 .build();

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyApplicantCanSwitchToSoleAfterIntentionFO.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyApplicantCanSwitchToSoleAfterIntentionFO.java
@@ -6,11 +6,15 @@ import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.notification.ApplicantSwitchToSoleAfterIntentionFONotification;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
+
+import java.util.List;
 
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.FinalOrder.IntendsToSwitchToSole.I_INTEND_TO_SWITCH_TO_SOLE;
@@ -21,6 +25,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 
 @Component
 @RequiredArgsConstructor
@@ -50,15 +55,23 @@ public class SystemNotifyApplicantCanSwitchToSoleAfterIntentionFO implements CCD
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(CaseDetails<CaseData, State> details,
                                                                        CaseDetails<CaseData, State> beforeDetails) {
         CaseData data = details.getData();
+        FinalOrder finalOrder = data.getFinalOrder();
+        boolean applicant1Notified = YesOrNo.YES.equals(finalOrder.getFinalOrderApplicant1NotifiedCanSwitchToSoleAfterIntention());
+        boolean applicant2Notified = YesOrNo.YES.equals(finalOrder.getFinalOrderApplicant2NotifiedCanSwitchToSoleAfterIntention());
+        if (applicant1Notified || applicant2Notified) {
+            return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .errors(List.of(CASE_ALREADY_PROCESSED_ERROR))
+                .build();
+        }
 
         notificationDispatcher.send(applicantSwitchToSoleAfterIntentionFONotification, data, details.getId());
 
-        if (data.getFinalOrder().getApplicant1IntendsToSwitchToSole() != null
-            && data.getFinalOrder().getApplicant1IntendsToSwitchToSole().contains(I_INTEND_TO_SWITCH_TO_SOLE)) {
-            data.getFinalOrder().setFinalOrderApplicant1NotifiedCanSwitchToSoleAfterIntention(YES);
-        } else if (data.getFinalOrder().getApplicant2IntendsToSwitchToSole() != null
-            && data.getFinalOrder().getApplicant2IntendsToSwitchToSole().contains(I_INTEND_TO_SWITCH_TO_SOLE)) {
-            data.getFinalOrder().setFinalOrderApplicant2NotifiedCanSwitchToSoleAfterIntention(YES);
+        if (finalOrder.getApplicant1IntendsToSwitchToSole() != null
+            && finalOrder.getApplicant1IntendsToSwitchToSole().contains(I_INTEND_TO_SWITCH_TO_SOLE)) {
+            finalOrder.setFinalOrderApplicant1NotifiedCanSwitchToSoleAfterIntention(YES);
+        } else if (finalOrder.getApplicant2IntendsToSwitchToSole() != null
+            && finalOrder.getApplicant2IntendsToSwitchToSole().contains(I_INTEND_TO_SWITCH_TO_SOLE)) {
+            finalOrder.setFinalOrderApplicant2NotifiedCanSwitchToSoleAfterIntention(YES);
         }
 
         return AboutToStartOrSubmitResponse.<CaseData, State>builder()

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyApplicantDisputeFormOverdue.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyApplicantDisputeFormOverdue.java
@@ -8,14 +8,18 @@ import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.citizen.notification.DisputeFormOverdueOverdueNotification;
+import uk.gov.hmcts.divorce.divorcecase.model.AcknowledgementOfService;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 
+import java.util.List;
+
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Holding;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 
 @Component
 @RequiredArgsConstructor
@@ -43,6 +47,12 @@ public class SystemNotifyApplicantDisputeFormOverdue implements CCDConfig<CaseDa
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(CaseDetails<CaseData, State> details,
                                                                        CaseDetails<CaseData, State> beforeDetails) {
         CaseData data = details.getData();
+        AcknowledgementOfService aos = data.getAcknowledgementOfService();
+        if (YesOrNo.YES.equals(aos.getApplicantNotifiedDisputeFormOverdue())) {
+            return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .errors(List.of(CASE_ALREADY_PROCESSED_ERROR))
+                .build();
+        }
 
         notificationDispatcher.send(disputeFormOverdueOverdueNotification, data, details.getId());
 

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyJointApplicantCanSwitchToSole.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyJointApplicantCanSwitchToSole.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.notification.Applicant1CanSwitchToSoleNotification;
 import uk.gov.hmcts.divorce.common.notification.Applicant2CanSwitchToSoleNotification;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
@@ -14,10 +15,13 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 
+import java.util.List;
+
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.ConditionalOrderPending;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 
 @Component
 @RequiredArgsConstructor
@@ -49,9 +53,13 @@ public class SystemNotifyJointApplicantCanSwitchToSole implements CCDConfig<Case
                                                                        CaseDetails<CaseData, State> beforeDetails) {
         CaseData data = details.getData();
         Long caseId = details.getId();
+        if (YesOrNo.YES.equals(data.getApplication().getJointApplicantNotifiedCanSwitchToSole())) {
+            return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .errors(List.of(CASE_ALREADY_PROCESSED_ERROR))
+                .build();
+        }
 
         ConditionalOrder conditionalOrder = data.getConditionalOrder();
-
         if (conditionalOrder.shouldEnableSwitchToSoleCoForApplicant1()) {
             notificationDispatcher.send(applicant1CanSwitchToSoleNotification, data, caseId);
             data.getApplication().setJointApplicantNotifiedCanSwitchToSole(YES);

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyRespondentApplyFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyRespondentApplyFinalOrder.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.OrderSummary;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.notification.RespondentApplyForFinalOrderNotification;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
@@ -15,6 +16,8 @@ import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 import uk.gov.hmcts.divorce.payment.service.PaymentSetupService;
+
+import java.util.List;
 
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingFinalOrder;
@@ -25,6 +28,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 
 @Component
 @Slf4j
@@ -57,6 +61,12 @@ public class SystemNotifyRespondentApplyFinalOrder implements CCDConfig<CaseData
                                                                        CaseDetails<CaseData, State> beforeDetails) {
         final CaseData caseData = details.getData();
         final Long caseId = details.getId();
+        if (YesOrNo.YES.equals(caseData.getFinalOrder().getFinalOrderReminderSentApplicant2())) {
+            return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .errors(List.of(CASE_ALREADY_PROCESSED_ERROR))
+                .build();
+        }
+
         log.info("A period of 3 months has elapsed since applicant became eligible to apply for final order for case {}. "
             + "Triggering notificationDispatcher...", caseId);
 

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicant1ApplicationReviewed.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicant1ApplicationReviewed.java
@@ -8,14 +8,18 @@ import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.citizen.notification.JointApplicationApprovedReminder;
+import uk.gov.hmcts.divorce.divorcecase.model.Application;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 
+import java.util.List;
+
 import static uk.gov.hmcts.divorce.divorcecase.model.State.Applicant2Approved;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 
 @Component
 @RequiredArgsConstructor
@@ -44,6 +48,12 @@ public class SystemRemindApplicant1ApplicationReviewed implements CCDConfig<Case
                                                                        CaseDetails<CaseData, State> beforeDetails) {
 
         CaseData data = details.getData();
+        Application application = data.getApplication();
+        if (YesOrNo.YES.equals(application.getApplicant1ReminderSent())) {
+            return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .errors(List.of(CASE_ALREADY_PROCESSED_ERROR))
+                .build();
+        }
 
         notificationDispatcher.send(jointApplicationApprovedReminder, data, details.getId());
 

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicant2.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicant2.java
@@ -8,14 +8,18 @@ import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.citizen.notification.ApplicationRemindApplicant2Notification;
+import uk.gov.hmcts.divorce.divorcecase.model.Application;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 
+import java.util.List;
+
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingApplicant2Response;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 
 @Component
 @RequiredArgsConstructor
@@ -44,6 +48,12 @@ public class SystemRemindApplicant2 implements CCDConfig<CaseData, State, UserRo
                                                                        CaseDetails<CaseData, State> beforeDetails) {
 
         CaseData data = details.getData();
+        Application application = data.getApplication();
+        if (YesOrNo.YES.equals(application.getApplicant2ReminderSent())) {
+            return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .errors(List.of(CASE_ALREADY_PROCESSED_ERROR))
+                .build();
+        }
 
         notificationDispatcher.send(applicationRemindApplicant2Notification, data, details.getId());
 

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicantsApplyForFinalOrder.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicantsApplyForFinalOrder.java
@@ -6,11 +6,15 @@ import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.notification.AwaitingFinalOrderReminderNotification;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
+
+import java.util.List;
 
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingFinalOrder;
@@ -21,6 +25,7 @@ import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 
 @Component
 @RequiredArgsConstructor
@@ -49,6 +54,12 @@ public class SystemRemindApplicantsApplyForFinalOrder implements CCDConfig<CaseD
     public AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(CaseDetails<CaseData, State> details,
                                                                        CaseDetails<CaseData, State> beforeDetails) {
         CaseData data = details.getData();
+        FinalOrder finalOrder = data.getFinalOrder();
+        if (YesOrNo.YES.equals(finalOrder.getFinalOrderReminderSentApplicant1())) {
+            return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .errors(List.of(CASE_ALREADY_PROCESSED_ERROR))
+                .build();
+        }
 
         notificationDispatcher.send(awaitingFinalOrderReminderNotification, data, details.getId());
 

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindRespondentSolicitor.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindRespondentSolicitor.java
@@ -9,15 +9,19 @@ import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.citizen.notification.RespondentSolicitorReminderNotification;
+import uk.gov.hmcts.divorce.divorcecase.model.Application;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
 import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
 import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 
+import java.util.List;
+
 import static uk.gov.hmcts.divorce.common.ccd.CcdPageConfiguration.NEVER_SHOW;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingAos;
 import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SYSTEMUPDATE;
 import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 
 @Slf4j
 @Component
@@ -48,6 +52,12 @@ public class SystemRemindRespondentSolicitor implements CCDConfig<CaseData, Stat
                                                                        CaseDetails<CaseData, State> beforeDetails) {
 
         CaseData data = details.getData();
+        Application application = data.getApplication();
+        if (YesOrNo.YES.equals(application.getRespondentSolicitorReminderSent())) {
+            return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+                .errors(List.of(CASE_ALREADY_PROCESSED_ERROR))
+                .build();
+        }
 
         notificationDispatcher.send(respondentSolicitorReminderNotification, data, details.getId());
         data.getApplication().setRespondentSolicitorReminderSent(YesOrNo.YES);

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/CcdUpdateService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/CcdUpdateService.java
@@ -44,6 +44,7 @@ public class CcdUpdateService {
     private static final String SUPPLEMENTARY_DATA_UPDATES = "supplementary_data_updates";
     private static final String FORMATTED_SUBMIT_EVENT = "Submit event for Case ID: {}, Event ID: {}";
     private static final String FORMATTED_SUBMIT_EVENT_FAILED = "Submit Event Failed for Case ID: %s, Event ID: %s";
+    public static final String CASE_ALREADY_PROCESSED_ERROR = "The case has already been processed by this cron.";
 
     private final CoreCaseDataApi coreCaseDataApi;
 

--- a/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/CcdUpdateService.java
+++ b/src/main/java/uk/gov/hmcts/divorce/systemupdate/service/CcdUpdateService.java
@@ -44,7 +44,7 @@ public class CcdUpdateService {
     private static final String SUPPLEMENTARY_DATA_UPDATES = "supplementary_data_updates";
     private static final String FORMATTED_SUBMIT_EVENT = "Submit event for Case ID: {}, Event ID: {}";
     private static final String FORMATTED_SUBMIT_EVENT_FAILED = "Submit Event Failed for Case ID: %s, Event ID: %s";
-    public static final String CASE_ALREADY_PROCESSED_ERROR = "The case has already been processed by this cron.";
+    public static final String CASE_ALREADY_PROCESSED_ERROR = "The case has already been processed.";
 
     private final CoreCaseDataApi coreCaseDataApi;
 

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyApplicantCanSwitchToSoleAfterIntentionFOTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyApplicantCanSwitchToSoleAfterIntentionFOTest.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.notification.ApplicantSwitchToSoleAfterIntentionFONotification;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.FinalOrder;
@@ -24,6 +25,7 @@ import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.ApplicationType.JOINT_APPLICATION;
 import static uk.gov.hmcts.divorce.divorcecase.model.FinalOrder.IntendsToSwitchToSole.I_INTEND_TO_SWITCH_TO_SOLE;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemNotifyApplicantCanSwitchToSoleAfterIntentionFO.SYSTEM_APPLICANT_SWITCH_TO_SOLE_AFTER_INTENTION;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 import static uk.gov.hmcts.divorce.testutil.ClockTestUtil.getExpectedLocalDate;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
@@ -52,6 +54,26 @@ class SystemNotifyApplicantCanSwitchToSoleAfterIntentionFOTest {
             .extracting(Event::getId)
             .contains(SYSTEM_APPLICANT_SWITCH_TO_SOLE_AFTER_INTENTION);
     }
+
+    @Test
+    void shouldErrorWhenTheCaseHasAlreadyBeenProcessed() {
+        final CaseData caseData = caseData();
+        caseData.setApplicationType(JOINT_APPLICATION);
+        caseData.setFinalOrder(FinalOrder.builder()
+            .applicant1IntendsToSwitchToSole(Set.of(I_INTEND_TO_SWITCH_TO_SOLE))
+            .finalOrderApplicant1NotifiedCanSwitchToSoleAfterIntention(YesOrNo.YES)
+            .dateApplicant1DeclaredIntentionToSwitchToSoleFo(getExpectedLocalDate().minusDays(15))
+            .build());
+        final CaseDetails<CaseData, State> details = new CaseDetails<>();
+        details.setId(TEST_CASE_ID);
+        details.setData(caseData);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response = systemNotifyApplicantCanSwitchToSoleAfterIntentionFO
+            .aboutToSubmit(details, details);
+
+        assertThat(response.getErrors()).containsExactly(CASE_ALREADY_PROCESSED_ERROR);
+    }
+
 
     @Test
     void shouldSendNotificationToApplicant1SwitchToSoleAfterIntention() {

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyApplicantPartnerNotAppliedForFinalOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemNotifyApplicantPartnerNotAppliedForFinalOrderTest.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.notification.PartnerNotAppliedForFinalOrderNotification;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
 import uk.gov.hmcts.divorce.divorcecase.model.State;
@@ -21,6 +22,7 @@ import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.ApplicationType.JOINT_APPLICATION;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemNotifyApplicantPartnerNotAppliedForFinalOrder.SYSTEM_PARTNER_NOT_APPLIED_FOR_FINAL_ORDER;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
@@ -47,6 +49,22 @@ class SystemNotifyApplicantPartnerNotAppliedForFinalOrderTest {
         assertThat(getEventsFrom(configBuilder).values())
             .extracting(Event::getId)
             .contains(SYSTEM_PARTNER_NOT_APPLIED_FOR_FINAL_ORDER);
+    }
+
+    @Test
+    void shouldErrorWhenTheCaseHasAlreadyBeenProcessed() {
+        final CaseData caseData = caseData();
+        caseData.setApplicationType(JOINT_APPLICATION);
+        caseData.getFinalOrder().setApplicant1AppliedForFinalOrderFirst(YES);
+        caseData.getFinalOrder().setFinalOrderFirstInTimeNotifiedOtherApplicantNotApplied(YesOrNo.YES);
+        final CaseDetails<CaseData, State> details = new CaseDetails<>();
+        details.setId(TEST_CASE_ID);
+        details.setData(caseData);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response =
+            systemNotifyApplicantPartnerNotAppliedForFinalOrder.aboutToSubmit(details, details);
+
+        assertThat(response.getErrors()).containsExactly(CASE_ALREADY_PROCESSED_ERROR);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicant1ApplicationReviewedTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicant1ApplicationReviewedTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemRemindApplicant1ApplicationReviewed.SYSTEM_REMIND_APPLICANT_1_APPLICATION_REVIEWED;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
@@ -51,6 +52,23 @@ class SystemRemindApplicant1ApplicationReviewedTest {
         assertThat(getEventsFrom(configBuilder).values())
             .extracting(Event::getId)
             .contains(SYSTEM_REMIND_APPLICANT_1_APPLICATION_REVIEWED);
+    }
+
+    @Test
+    void shouldErrorWhenTheCaseHasAlreadyBeenProcessed() {
+        final CaseData caseData = caseData();
+        final CaseDetails<CaseData, State> details = new CaseDetails<>();
+        details.setId(TEST_CASE_ID);
+        details.setData(caseData);
+        caseData.getApplication().setApplicant1ReminderSent(YesOrNo.YES);
+
+        when(httpServletRequest.getHeader(AUTHORIZATION))
+            .thenReturn("auth header");
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response =
+            systemRemindApplicant1ApplicationReviewed.aboutToSubmit(details, details);
+
+        assertThat(response.getErrors()).containsExactly(CASE_ALREADY_PROCESSED_ERROR);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicant2Test.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicant2Test.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemRemindApplicant2.SYSTEM_REMIND_APPLICANT2;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
@@ -51,6 +52,23 @@ class SystemRemindApplicant2Test {
         assertThat(getEventsFrom(configBuilder).values())
             .extracting(Event::getId)
             .contains(SYSTEM_REMIND_APPLICANT2);
+    }
+
+    @Test
+    void shouldErrorWhenTheCaseHasAlreadyBeenProcessed() {
+        final CaseData caseData = caseData();
+        final CaseDetails<CaseData, State> details = new CaseDetails<>();
+        details.setId(TEST_CASE_ID);
+        details.setData(caseData);
+        caseData.getApplication().setApplicant2ReminderSent(YesOrNo.YES);
+
+        when(httpServletRequest.getHeader(AUTHORIZATION))
+            .thenReturn("auth header");
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response =
+            systemRemindApplicant2.aboutToSubmit(details, details);
+
+        assertThat(response.getErrors()).containsExactly(CASE_ALREADY_PROCESSED_ERROR);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicantsApplyForCOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicantsApplyForCOrderTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.divorce.common.notification.AwaitingConditionalOrderReminderNotification;
 import uk.gov.hmcts.divorce.common.notification.ConditionalOrderPendingReminderNotification;
 import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
@@ -21,6 +22,7 @@ import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.AwaitingConditionalOrder;
 import static uk.gov.hmcts.divorce.divorcecase.model.State.ConditionalOrderDrafted;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemRemindApplicantsApplyForCOrder.SYSTEM_REMIND_APPLICANTS_CONDITIONAL_ORDER;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
@@ -50,6 +52,19 @@ class SystemRemindApplicantsApplyForCOrderTest {
         assertThat(getEventsFrom(configBuilder).values())
             .extracting(Event::getId)
             .contains(SYSTEM_REMIND_APPLICANTS_CONDITIONAL_ORDER);
+    }
+
+    @Test
+    void shouldErrorWhenTheCaseHasAlreadyBeenProcessed() {
+        final CaseData caseData = caseData();
+        final CaseDetails<CaseData, State> details = CaseDetails.<CaseData, State>builder()
+            .state(AwaitingConditionalOrder).id(TEST_CASE_ID).data(caseData)
+            .build();
+        caseData.getApplication().setApplicantsRemindedCanApplyForConditionalOrder(YesOrNo.YES);
+
+        final var response = systemRemindApplicantsApplyForCOrder.aboutToSubmit(details, details);
+
+        assertThat(response.getErrors()).containsExactly(CASE_ALREADY_PROCESSED_ERROR);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicantsApplyForFinalOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindApplicantsApplyForFinalOrderTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.divorce.notification.NotificationDispatcher;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemRemindApplicantsApplyForFinalOrder.SYSTEM_REMIND_APPLICANTS_APPLY_FOR_FINAL_ORDER;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
@@ -45,6 +46,20 @@ class SystemRemindApplicantsApplyForFinalOrderTest {
         assertThat(getEventsFrom(configBuilder).values())
             .extracting(Event::getId)
             .contains(SYSTEM_REMIND_APPLICANTS_APPLY_FOR_FINAL_ORDER);
+    }
+
+    @Test
+    void shouldErrorWhenTheCaseHasAlreadyBeenProcessed() {
+        final CaseData caseData = caseData();
+        final CaseDetails<CaseData, State> details = new CaseDetails<>();
+        details.setId(TEST_CASE_ID);
+        details.setData(caseData);
+        caseData.getFinalOrder().setFinalOrderReminderSentApplicant1(YesOrNo.YES);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response =
+            systemRemindApplicantsApplyForFinalOrder.aboutToSubmit(details, details);
+
+        assertThat(response.getErrors()).containsExactly(CASE_ALREADY_PROCESSED_ERROR);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindRespondentSolicitorTest.java
+++ b/src/test/java/uk/gov/hmcts/divorce/systemupdate/event/SystemRemindRespondentSolicitorTest.java
@@ -25,10 +25,12 @@ import java.time.LocalDate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.divorce.systemupdate.event.SystemRemindRespondentSolicitor.SYSTEM_REMIND_RESPONDENT_SOLICITOR_TO_RESPOND;
+import static uk.gov.hmcts.divorce.systemupdate.service.CcdUpdateService.CASE_ALREADY_PROCESSED_ERROR;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.createCaseDataConfigBuilder;
 import static uk.gov.hmcts.divorce.testutil.ConfigTestUtil.getEventsFrom;
 import static uk.gov.hmcts.divorce.testutil.TestConstants.TEST_CASE_ID;
 import static uk.gov.hmcts.divorce.testutil.TestDataHelper.caseDataWithOrderSummary;
+import static uk.gov.hmcts.divorce.testutil.TestDataHelper.validJointApplicant1CaseData;
 
 @ExtendWith(SpringExtension.class)
 class SystemRemindRespondentSolicitorTest {
@@ -53,6 +55,20 @@ class SystemRemindRespondentSolicitorTest {
         assertThat(getEventsFrom(configBuilder).values())
             .extracting(Event::getId)
             .contains(SYSTEM_REMIND_RESPONDENT_SOLICITOR_TO_RESPOND);
+    }
+
+    @Test
+    void shouldErrorWhenTheCaseHasAlreadyBeenProcessed() {
+        final CaseData caseData = validJointApplicant1CaseData();
+        final CaseDetails<CaseData, State> details = new CaseDetails<>();
+        details.setId(TEST_CASE_ID);
+        details.setData(caseData);
+        details.setState(State.AwaitingAos);
+        caseData.getApplication().setRespondentSolicitorReminderSent(YesOrNo.YES);
+
+        final AboutToStartOrSubmitResponse<CaseData, State> response = remindRespondentSolicitor.aboutToSubmit(details, details);
+
+        assertThat(response.getErrors()).containsExactly(CASE_ALREADY_PROCESSED_ERROR);
     }
 
     @Test


### PR DESCRIPTION
### Change description ###

We need to check whether notification flags are already set using CCD data rather than relying on queries against Elastic Search data.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/NFDIV-5069

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
