### PR TITLE
fix: Perftest/master builds should now pull hmctsprod.azurecr.io/ccd/…

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -160,6 +160,9 @@ withPipeline(type, product, component) {
   afterAlways('checkout') {
     builder.setupToolVersion()
     builder.gradle('generateCCDConfig')
+  }
+
+  before('highleveldatasetup') {
     generateDefinitions()
   }
 

--- a/bin/generate-ccd-definition.sh
+++ b/bin/generate-ccd-definition.sh
@@ -18,8 +18,6 @@ echo "Definition input directory: ${definition_input_dir}"
 echo "Definition output file: ${definition_output_file}"
 echo "Additional params: ${additionalParameters}"
 
-env AZURE_CONFIG_DIR=/opt/jenkins/.azure-nonprod az acr login --name hmctsprod --subscription DCD-CNP-PROD
-
 docker run --pull always --rm \
   -v ${definition_input_dir}:/tmp/ccd-definition \
   -v ${definition_output_file}:/tmp/ccd-definition.xlsx \


### PR DESCRIPTION
…definition-processor with credentials already established by the pipeline

### Change description ###

Fixes intermittent CI failures when generating CCD definitions after migrating the definition-processor image to hmctsprod.azurecr.io.

CCD xlsx generation was running during checkout, before the pipeline performs ACR login. That caused flaky authentication required errors when pulling hmctsprod.azurecr.io/ccd/definition-processor. A follow-up attempt to add az acr login in the shell script made failures deterministic, because it ran before Azure login and referenced the prod subscription (DCD-CNP-PROD) from a nonprod Jenkins agent.

This change aligns nfdiv with the pattern used in sptribs-case-api: generate CCD xlsx files immediately before High Level Data Setup, when ACR credentials are already available from the test stage.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-32594

### Pull request checklist ###

**Before raising**
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] README and other documentation has been updated / added (if needed)

**Before merging**
- [ ] this ticket been reviewed by QA
- [ ] the user story been signed off by the PO

**Note:** Bug fixes, dependency updates and technical tasks do not directly impact the user experience and can be merged without QA and PO review.
